### PR TITLE
feat: 공통 기반(Common Foundation) 모듈 구축

### DIFF
--- a/docs/007-common-foundation-guide.md
+++ b/docs/007-common-foundation-guide.md
@@ -180,7 +180,10 @@ public class UserService {
 
 ## 5. 컨트롤러 응답 작성
 
-모든 컨트롤러 메서드는 `ApiResponse<T>` 로 감싸서 반환.
+모든 컨트롤러 메서드는 **`ResponseEntity<ApiResponse<T>>`** 로 반환합니다.
+
+> HTTP 상태 코드와 `ApiResponse.status` 를 일치시키기 위해 `ResponseEntity` 로 감싸는 게 팀 컨벤션.
+> `GlobalExceptionHandler` 도 같은 시그니처라 예외 응답과 정상 응답의 구조가 동일합니다.
 
 ```java
 @RestController
@@ -190,38 +193,44 @@ public class UserController {
 
     private final UserService userService;
 
-    // 단건 조회
+    // 단건 조회 (200)
     @GetMapping("/{id}")
-    public ApiResponse<UserResponse> get(@PathVariable Long id) {
-        return ApiResponse.success(userService.getUser(id));
+    public ResponseEntity<ApiResponse<UserResponse>> get(@PathVariable Long id) {
+        return ResponseEntity.ok(ApiResponse.success(userService.getUser(id)));
     }
 
     // 생성 (201)
     @PostMapping
-    public ApiResponse<UserResponse> create(@RequestBody @Valid UserCreateRequest req) {
-        return ApiResponse.created(userService.create(req));
+    public ResponseEntity<ApiResponse<UserResponse>> create(
+            @RequestBody @Valid UserCreateRequest req) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(userService.create(req)));
     }
 
-    // 데이터 없는 성공 응답
+    // 데이터 없는 성공 (200)
     @DeleteMapping("/{id}")
-    public ApiResponse<Void> delete(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
         userService.delete(id);
-        return ApiResponse.ok();
+        return ResponseEntity.ok(ApiResponse.ok());
     }
 
     // 페이지네이션
     @GetMapping
-    public ApiResponse<PageResponse<UserResponse>> list(Pageable pageable) {
-        return ApiResponse.success(PageResponse.from(userService.list(pageable)));
+    public ResponseEntity<ApiResponse<PageResponse<UserResponse>>> list(Pageable pageable) {
+        return ResponseEntity.ok(
+                ApiResponse.success(PageResponse.from(userService.list(pageable)))
+        );
     }
 }
 ```
 
 **지키면 되는 것**
 
-- ⚠️ **엔티티를 그대로 반환하지 말 것.** 반드시 Response DTO로 변환 (`UserResponse.from(user)` 같은 static factory 권장)
-- ⚠️ 성공 응답은 `success(data)` / `ok()` / `created(data)` 중 선택
-- ⚠️ 페이지는 항상 `PageResponse.from(page)` 로 변환 후 반환 (Spring `Page` 직노출 금지)
+- ⚠️ **엔티티를 그대로 반환하지 말 것.** 반드시 Response DTO 로 변환 (`UserResponse.from(user)` 같은 static factory 권장)
+- ⚠️ 정적 팩토리는 목적에 맞게: `ApiResponse.success(data)` / `ApiResponse.ok()` / `ApiResponse.created(data)`
+- ⚠️ 생성(POST) 응답은 `ResponseEntity.status(HttpStatus.CREATED).body(...)` 로 HTTP 201 명시
+- ⚠️ 페이지는 항상 `PageResponse.from(page)` 로 변환 (Spring `Page` 직노출 금지)
 
 ### 성공 응답 예시
 

--- a/docs/007-common-foundation-guide.md
+++ b/docs/007-common-foundation-guide.md
@@ -1,0 +1,300 @@
+# 007. 공통 기반(Common Foundation) 사용 가이드
+
+> **이 문서를 보면**: 공통 모듈에서 제공하는 응답 포맷 / 예외 처리 / 감사 필드 / 보안 뼈대를 내 도메인에서 어떻게 써야 하는지 파악 가능.
+>
+> **언제 다시 보나요**: 새 도메인 착수 시, 예외 던지는 코드 처음 작성할 때, 컨트롤러 응답 감 안 잡힐 때.
+
+---
+
+## 한 줄 요약
+
+모든 엔티티는 `BaseEntity` 상속 / 모든 예외는 `BaseException` 상속 / 모든 컨트롤러 응답은 `ApiResponse` 포맷 / 페이지 응답은 `PageResponse.from(page)`.
+
+---
+
+## 목차
+
+- [1. 패키지 구조 복습](#1-패키지-구조-복습)
+- [2. 의존성 방향](#2-의존성-방향)
+- [3. 엔티티 만들 때](#3-엔티티-만들-때)
+- [4. 예외 던지는 방법](#4-예외-던지는-방법)
+- [5. 컨트롤러 응답 작성](#5-컨트롤러-응답-작성)
+- [6. common 패키지 활용법](#6-common-패키지-활용법)
+
+---
+
+## 1. 패키지 구조 복습
+
+구조는 2단계로 나뉩니다.
+
+1. **도메인별 폴더** (user, order, store 등)
+2. 각 도메인 안에서 **4계층** (presentation / application / domain / infrastructure)
+
+"새 코드 어디에 둘까?" 생각할 때 순서:
+
+- Q1. 어느 **도메인**? (user? order? store?)
+- Q2. 어느 **계층**? (컨트롤러? 서비스? 엔티티?)
+
+| 만들 것 | 위치 |
+|---|---|
+| REST API 메서드 | `{domain}/presentation/` |
+| Request/Response DTO | `{domain}/presentation/dto/` |
+| `@Service` | `{domain}/application/` |
+| `@Entity` | `{domain}/domain/entity/` |
+| Repository 인터페이스 | `{domain}/domain/repository/` |
+| 도메인 전용 예외 | `{domain}/domain/exception/` |
+| 커스텀 쿼리 구현체 | `{domain}/infrastructure/persistence/repository/` |
+
+> 더 자세한 위치 가이드는 [`docs/004-architecture.md`](./004-architecture.md) 참고.
+
+---
+
+## 2. 의존성 방향
+
+```
+presentation → application → domain ← infrastructure
+```
+
+- 컨트롤러는 **서비스만** 호출
+- 서비스는 엔티티·Repository를 조합
+- Repository 구현체(infrastructure)는 `domain/repository/`의 인터페이스를 **구현**하고 엔티티를 반환 — **의존성 역전**
+- `domain`은 다른 계층을 **절대 모름**
+
+---
+
+## 3. 엔티티 만들 때
+
+```java
+@Entity
+@Table(name = "p_store")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Store extends BaseEntity {   // 🔴 무조건 BaseEntity 상속
+
+    @Id @GeneratedValue
+    private UUID storeId;
+
+    private Long userId;        // 🔴 @ManyToOne User 금지, Long FK 만
+    private UUID regionId;      // 🔴 @ManyToOne Region 금지
+    // ...
+}
+```
+
+**지키면 되는 것**
+
+- `createdAt / updatedAt / deletedAt / createdBy / updatedBy / deletedBy`는 **작성하지 않음** — `BaseEntity`가 자동 관리
+- 삭제 시 `store.softDelete(currentUserId)` 호출 (물리 삭제 금지)
+- 다른 도메인 엔티티는 **Long/UUID FK 로만** 참조
+- 모든 연관관계는 `LAZY`
+
+> 세부 규칙은 [`docs/005-jpa-guidelines.md`](./005-jpa-guidelines.md) 참고.
+
+---
+
+## 4. 예외 던지는 방법
+
+**제일 자주 하게 되는 작업.** 4단계로 정리.
+
+### Step 1. 도메인 ErrorCode enum 작성
+
+위치: `{domain}/domain/exception/{Domain}ErrorCode.java`
+
+```java
+// 예: user/domain/exception/UserErrorCode.java
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "사용자를 찾을 수 없습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "USER-002", "이미 사용 중인 아이디입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}
+```
+
+> 코드 네이밍 규칙: `{DOMAIN}-{001부터}` (예: `USER-001`, `ORDER-001`, `STORE-001`)
+
+### Step 2. 도메인 예외 클래스 작성
+
+위치: `{domain}/domain/exception/{Domain}Exception.java`
+
+```java
+// 예: user/domain/exception/UserException.java
+public class UserException extends BaseException {
+
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UserException(UserErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+}
+```
+
+### Step 3. 서비스에서 throw
+
+```java
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserResponse getUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        return UserResponse.from(user);
+    }
+}
+```
+
+> 💡 `GlobalExceptionHandler`가 `BaseException`을 다형 처리하므로 **컨트롤러에 try-catch 필요 없음**.
+
+### Step 4. 응답 확인
+
+아래 포맷으로 자동 내려감:
+
+```json
+{
+  "success": false,
+  "status": 404,
+  "errorCode": "USER-001",
+  "message": "사용자를 찾을 수 없습니다.",
+  "data": null
+}
+```
+
+### 자주 묻는 것
+
+- **Q. `@Valid` 검증 실패도 따로 처리해야 하나요?**
+  → 아니요. `GlobalExceptionHandler`가 자동으로 `COMMON-001` + 필드 에러 목록으로 내려줍니다.
+- **Q. 공통 예외(인증/인가/404 등)도 따로 만들어야 하나요?**
+  → 아니요. `CommonErrorCode` + `CommonException`이 이미 준비돼 있습니다. 꼭 도메인 고유 의미가 있을 때만 새 enum 추가.
+
+---
+
+## 5. 컨트롤러 응답 작성
+
+모든 컨트롤러 메서드는 `ApiResponse<T>` 로 감싸서 반환.
+
+```java
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    // 단건 조회
+    @GetMapping("/{id}")
+    public ApiResponse<UserResponse> get(@PathVariable Long id) {
+        return ApiResponse.success(userService.getUser(id));
+    }
+
+    // 생성 (201)
+    @PostMapping
+    public ApiResponse<UserResponse> create(@RequestBody @Valid UserCreateRequest req) {
+        return ApiResponse.created(userService.create(req));
+    }
+
+    // 데이터 없는 성공 응답
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@PathVariable Long id) {
+        userService.delete(id);
+        return ApiResponse.ok();
+    }
+
+    // 페이지네이션
+    @GetMapping
+    public ApiResponse<PageResponse<UserResponse>> list(Pageable pageable) {
+        return ApiResponse.success(PageResponse.from(userService.list(pageable)));
+    }
+}
+```
+
+**지키면 되는 것**
+
+- ⚠️ **엔티티를 그대로 반환하지 말 것.** 반드시 Response DTO로 변환 (`UserResponse.from(user)` 같은 static factory 권장)
+- ⚠️ 성공 응답은 `success(data)` / `ok()` / `created(data)` 중 선택
+- ⚠️ 페이지는 항상 `PageResponse.from(page)` 로 변환 후 반환 (Spring `Page` 직노출 금지)
+
+### 성공 응답 예시
+
+```json
+{
+  "success": true,
+  "status": 200,
+  "errorCode": null,
+  "message": "OK",
+  "data": { "userId": 1, "username": "alice" }
+}
+```
+
+### 페이지 응답 예시
+
+```json
+{
+  "success": true,
+  "status": 200,
+  "errorCode": null,
+  "message": "OK",
+  "data": {
+    "content": [ { "..." }, { "..." } ],
+    "page": 0,
+    "size": 10,
+    "totalElements": 42,
+    "totalPages": 5,
+    "last": false
+  }
+}
+```
+
+---
+
+## 6. common 패키지 활용법
+
+공통으로 쓰는 것들은 전부 `common/` 아래에 있습니다.
+
+| 클래스 | 위치 | 용도 |
+|---|---|---|
+| `BaseEntity` | `common/model/` | 모든 엔티티가 상속 (감사 필드 + soft delete) |
+| `ApiResponse` | `common/response/` | 모든 컨트롤러 응답 포맷 |
+| `PageResponse` | `common/response/` | 페이지네이션 응답 변환 |
+| `ErrorCode` | `common/exception/` | 도메인별 ErrorCode enum이 구현할 인터페이스 |
+| `BaseException` | `common/exception/` | 모든 도메인 예외의 부모 |
+| `CommonErrorCode` / `CommonException` | `common/exception/` | 공통 예외(입력값 오류, 인증 실패 등) |
+| `GlobalExceptionHandler` | `common/exception/` | 전역 예외 처리 (건드릴 일 없음) |
+| `JpaAuditingConfig` | `common/config/jpa/` | `@CreatedBy` / `@LastModifiedBy` 자동 채움 |
+| `SecurityConfig` | `common/config/security/` | 전역 보안 설정 (JWT 필터는 auth 담당자) |
+| `UserPrincipal` | `common/config/security/` | auth 쪽에서 구현할 인증 주체 인터페이스 |
+
+### 꼭 기억할 것
+
+- `common/` 은 **모든 도메인이 의존** — 여기서 뭘 바꾸면 전 도메인 영향. 건드릴 때 팀에 공유
+- 내 도메인 전용 Util/Enum/Validator 는 `common/` 이 아니라 `{domain}/` 안에 두기
+- 여러 도메인에서 **실제로 쓰게 된 시점**에 `common/` 으로 승격
+
+---
+
+## 체크리스트 (새 도메인 착수 시)
+
+- [ ] 엔티티가 `BaseEntity` 를 상속했는가
+- [ ] 연관관계는 Long/UUID FK 만 사용했는가 (`@ManyToOne {다른도메인엔티티}` 금지)
+- [ ] `{Domain}ErrorCode` enum 과 `{Domain}Exception` 클래스를 작성했는가
+- [ ] 서비스에서 예외를 throw 할 때 `BaseException` 계열만 사용하는가
+- [ ] 컨트롤러는 `ApiResponse` 로 감싸서 반환하는가
+- [ ] 엔티티를 컨트롤러까지 올리지 않고 Response DTO 로 변환했는가
+- [ ] 페이지 조회는 `PageResponse.from(page)` 로 변환했는가
+
+---
+
+## 관련 문서
+
+- [004. 아키텍처 가이드](./004-architecture.md)
+- [005. JPA 가이드](./005-jpa-guidelines.md)
+- [006. 팀 협업 컨벤션](./006-conventions.md)

--- a/src/main/java/com/sparta/delivery/common/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/com/sparta/delivery/common/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,46 @@
+package com.sparta.delivery.common.config.jpa;
+
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+    @Bean
+    public AuditorAware<Long> auditorAware() {
+        return () -> {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+            // SecurityContext 자체가 비어있는 경우 (필터 체인 밖, 일부 비동기/스케줄러 컨텍스트 등).
+            // 익명 사용자는 여기 걸리지 않고 — AnonymousAuthenticationToken 은 isAuthenticated()=true 반환 —
+            // 아래 principal 문자열 체크에서 걸러진다.
+            if (auth == null || !auth.isAuthenticated()) {
+                return Optional.empty();
+            }
+
+            // 회원가입/Swagger/헬스체크처럼 permitAll() 인 요청은 익명 토큰으로 들어오며
+            // 이때 principal 은 "anonymousUser" 문자열이다. createdBy 기록 대상 아님.
+            Object principal = auth.getPrincipal();
+            if (principal instanceof String) {
+                return Optional.empty();
+            }
+
+            // 인증된 사용자 — UserPrincipal 구현체에서 user_id 추출
+            if (principal instanceof UserPrincipal userPrincipal) {
+                return Optional.of(userPrincipal.getId());
+            }
+            log.warn("Unknown principal type: {}", auth.getPrincipal().getClass());
+            return Optional.empty();
+        };
+    }
+}

--- a/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.sparta.delivery.common.config.security;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity  // @PreAuthorize("hasRole('MASTER')") 등 메서드 레벨 권한 활성화
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // --- 공개 엔드포인트 ---
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/actuator/health",
+                                "/actuator/info"
+                        ).permitAll()
+                        // 인증/회원가입 (auth 도메인이 실제 경로 확정 시 갱신)
+                        .requestMatchers(
+                                "/api/v1/auth/**",
+                                "/api/v1/users/signup"
+                        ).permitAll()
+                        // --- 그 외 전부 인증 필요 ---
+                        .anyRequest().authenticated()
+                )
+                // TODO(auth 담당): JwtAuthenticationFilter 삽입 위치
+                // .addFilterBefore(jwtAuthenticationFilter,
+                //                  UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sparta/delivery/common/config/security/UserPrincipal.java
+++ b/src/main/java/com/sparta/delivery/common/config/security/UserPrincipal.java
@@ -1,0 +1,13 @@
+package com.sparta.delivery.common.config.security;
+
+public interface UserPrincipal {
+
+    /** 사용자 PK (p_user.user_id) */
+    Long getId();
+
+    /** 로그인 아이디 */
+    String getUsername();
+
+    /** 권한: CUSTOMER | OWNER | MANAGER | MASTER */
+    String getRole();
+}

--- a/src/main/java/com/sparta/delivery/common/exception/BaseException.java
+++ b/src/main/java/com/sparta/delivery/common/exception/BaseException.java
@@ -1,0 +1,29 @@
+package com.sparta.delivery.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    /** 메시지 동적 치환이 필요할 때 (예: "상품 {id} 를 찾을 수 없습니다") */
+    protected BaseException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return errorCode.getStatus();
+    }
+
+    public String getCode() {
+        return errorCode.getCode();
+    }
+}

--- a/src/main/java/com/sparta/delivery/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/sparta/delivery/common/exception/CommonErrorCode.java
@@ -1,0 +1,28 @@
+package com.sparta.delivery.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    // ========== 입력/요청 ==========
+
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON-001", "잘못된 입력값입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-002", "허용되지 않는 메서드입니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-003", "요청한 리소스를 찾을 수 없습니다."),
+
+    // ========== 인증/인가 ==========
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON-101", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON-102", "권한이 없습니다."),
+
+    // ========== 서버 ==========
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-999", "서버 내부 오류가 발생했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/common/exception/CommonException.java
+++ b/src/main/java/com/sparta/delivery/common/exception/CommonException.java
@@ -1,0 +1,12 @@
+package com.sparta.delivery.common.exception;
+
+public class CommonException extends BaseException {
+
+    public CommonException(CommonErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public CommonException(CommonErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+}

--- a/src/main/java/com/sparta/delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/delivery/common/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.sparta.delivery.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    /** HTTP 응답 상태 */
+    HttpStatus getStatus();
+
+    /** 클라이언트 식별용 코드 (예: "USER-001") */
+    String getCode();
+
+    /** 사용자 메시지 */
+    String getMessage();
+}

--- a/src/main/java/com/sparta/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,86 @@
+package com.sparta.delivery.common.exception;
+
+import com.sparta.delivery.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /** 모든 도메인 예외 — BaseException 다형성 */
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBase(BaseException e, HttpServletRequest req) {
+        ErrorCode ec = e.getErrorCode();
+        log.warn("[{}] {} - {}", ec.getCode(), req.getRequestURI(), e.getMessage());
+        return ResponseEntity.status(ec.getStatus()).body(ApiResponse.error(ec));
+    }
+
+    /** @Valid 검증 실패 — 필드 에러 상세를 data에 담는다 */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<List<FieldErrorDetail>>> handleValidation(
+            MethodArgumentNotValidException e, HttpServletRequest req) {
+        List<FieldErrorDetail> details = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldErrorDetail::from)
+                .toList();
+        log.warn("[Validation] {} - {} fields failed", req.getRequestURI(), details.size());
+        return ResponseEntity
+                .status(CommonErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT_VALUE, details));
+    }
+
+    /** HTTP 메서드 미지원 */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(
+            HttpRequestMethodNotSupportedException e) {
+        return ResponseEntity.status(CommonErrorCode.METHOD_NOT_ALLOWED.getStatus())
+                .body(ApiResponse.error(CommonErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    /** Spring Security 인증 실패 */
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuth(
+            AuthenticationException e, HttpServletRequest req) {
+        log.warn("[Auth] {} - {}", req.getRequestURI(), e.getMessage());
+        return ResponseEntity.status(CommonErrorCode.UNAUTHORIZED.getStatus())
+                .body(ApiResponse.error(CommonErrorCode.UNAUTHORIZED));
+    }
+
+    /** Spring Security 권한 부족 */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(
+            AccessDeniedException e, HttpServletRequest req) {
+        log.warn("[Forbidden] {} - {}", req.getRequestURI(), e.getMessage());
+        return ResponseEntity.status(CommonErrorCode.FORBIDDEN.getStatus())
+                .body(ApiResponse.error(CommonErrorCode.FORBIDDEN));
+    }
+
+    /** 최종 fallback — 스택트레이스는 로그에만 */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleFallback(Exception e, HttpServletRequest req) {
+        log.error("[Unhandled] {} - {}", req.getRequestURI(), e.getMessage(), e);
+        return ResponseEntity.status(CommonErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+
+    /** Validation 필드 에러 상세 (응답 data에 담김) */
+    public record FieldErrorDetail(String field, String value, String reason) {
+        public static FieldErrorDetail from(FieldError fe) {
+            return new FieldErrorDetail(
+                    fe.getField(),
+                    fe.getRejectedValue() == null ? "" : fe.getRejectedValue().toString(),
+                    fe.getDefaultMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/sparta/delivery/common/model/BaseEntity.java
+++ b/src/main/java/com/sparta/delivery/common/model/BaseEntity.java
@@ -1,0 +1,53 @@
+package com.sparta.delivery.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // abstract 라 어차피 직접 생성 불가지만 명시적으로
+public abstract class BaseEntity {
+    // ID 는 자식 엔티티에서 정의 (User: Long, 나머지: UUID)
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // nullable=false 의도적으로 제외:
+    // 회원가입처럼 SecurityContext 가 비어있는 시점에 생성되는 엔티티(첫 유저/시드 데이터 등)는
+    // AuditorAware 가 Optional.empty() 를 돌려주어 createdBy 가 null 로 들어갈 수 있음.
+    @CreatedBy
+    @Column(updatable = false)
+    private Long createdBy;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    private Long updatedBy;
+
+    private LocalDateTime deletedAt;
+    private Long deletedBy;
+
+    public void softDelete(Long userId) {
+        if (isDeleted()) return; // 이미 삭제된 엔티티 재삭제 방지
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = userId;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+}

--- a/src/main/java/com/sparta/delivery/common/response/ApiResponse.java
+++ b/src/main/java/com/sparta/delivery/common/response/ApiResponse.java
@@ -1,0 +1,50 @@
+package com.sparta.delivery.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sparta.delivery.common.exception.ErrorCode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(
+        boolean success,
+        int status,
+        String errorCode,
+        String message,
+        T data
+) {
+
+    // ========== 성공 ==========
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, 200, null, "OK", data);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, 200, null, message, data);
+    }
+
+    /** 데이터 없는 200 응답 (record 접근자와 충돌 피하려고 ok() 로 명명) */
+    public static ApiResponse<Void> ok() {
+        return new ApiResponse<>(true, 200, null, "OK", null);
+    }
+
+    public static <T> ApiResponse<T> created(T data) {
+        return new ApiResponse<>(true, 201, null, "Created", data);
+    }
+
+    // ========== 실패 ==========
+
+    /** ErrorCode 인터페이스 기반 — 어느 도메인 enum이든 받을 수 있음 */
+    public static <T> ApiResponse<T> error(ErrorCode ec) {
+        return new ApiResponse<>(false, ec.getStatus().value(), ec.getCode(), ec.getMessage(), null);
+    }
+
+    /** ErrorCode + 추가 데이터 (Validation 필드 에러 등) */
+    public static <T> ApiResponse<T> error(ErrorCode ec, T data) {
+        return new ApiResponse<>(false, ec.getStatus().value(), ec.getCode(), ec.getMessage(), data);
+    }
+
+    /** 직접 구성 (fallback용) */
+    public static <T> ApiResponse<T> error(int status, String errorCode, String message) {
+        return new ApiResponse<>(false, status, errorCode, message, null);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #

## ✨ 기능 요약

| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 공통 기반(Common Foundation) 모듈 구축 |
| 🔍 목적 | 전 도메인이 공유할 응답 포맷·예외 체계·감사 필드·보안 뼈대 확정 |
| 🛠️ 변경사항 | `BaseEntity`, `ApiResponse`, `PageResponse`, `ErrorCode`/`BaseException` 계층, `GlobalExceptionHandler`, `JpaAuditingConfig`, `SecurityConfig` 추가 |

## 📝 상세 내역

| 번호 | 내용 |
|------|------|
| 1️⃣ | `ApiResponse<T>` record — 성공/실패/페이지네이션 단일 포맷 |
| 2️⃣ | `ErrorCode`(interface) + `BaseException`(abstract) + `CommonErrorCode`(enum) 3단 구조. 도메인별 enum으로 확장 |
| 3️⃣ | `GlobalExceptionHandler` — `BaseException` 다형 처리 + `@Valid` 검증 실패 + Security 예외 + fallback |
| 4️⃣ | `BaseEntity` 순수 상속 + `JpaAuditingConfig`에서 `UserPrincipal.getId()` 추출 |
| 5️⃣ | `SecurityConfig` — Stateless / CSRF·Form·Basic off / `@EnableMethodSecurity`. JWT 필터 삽입 지점 TODO 표시 |

---

## ✅ 테스트 체크리스트

- [x] 애플리케이션 부팅 성공


---

## 📸 포스트맨 캡처 사진

공통 모듈만 포함돼 별도 엔드포인트 없음. user 도메인 PR부터 첨부 예정.

---

## 🙋‍♀️ 리뷰어 참고사항

- 📘 공통 모듈 사용법은 [`docs/007-common-foundation-guide.md`](../docs/007-common-foundation-guide.md) 참고
- **설계 문서와 의도적으로 다른 부분**
    - `BaseEntity.createdBy`에 `nullable=false` 미적용 — 회원가입 시점엔 `SecurityContext`가 비어있어 `AuditorAware`가 `Optional.empty()` 반환. 코드 주석으로 명시
 