### PR TITLE
feat: Swagger OpenAPI 설정 및 Security 경로 허용 추가

### DIFF
--- a/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // --- 공개 엔드포인트 ---
                         .requestMatchers(
+                                "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/actuator/health",

--- a/src/main/java/com/sparta/delivery/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/sparta/delivery/common/config/swagger/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.sparta.delivery.common.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String securitySchemeName = "Bearer Token";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Delivery API")
+                        .description("광화문 지역 배달 주문 관리 플랫폼 API")
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
 
 jwt:
   secret: ${JWT_SECRET:local-dev-secret-key-at-least-256-bits-long-for-hs256-algorithm}


### PR DESCRIPTION
## Summary
설정 빼먹은거라 간단하게 작성했습니다

- SwaggerConfig 클래스 추가 (API 문서 제목, JWT Bearer 인증 스키마)
- application.yml Swagger 설정 보강 (정렬, 미디어 타입)
- SecurityConfig에 /swagger-ui.html 경로 permitAll 추가

## Test
- [X] /swagger-ui.html 접속 확인
- [x] JWT 자물쇠 아이콘 표시 확인