### PR TITLE
feat: 주소 엔티티 및 Repo 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/address/domain/entity/Address.java
+++ b/src/main/java/com/sparta/delivery/address/domain/entity/Address.java
@@ -1,0 +1,87 @@
+package com.sparta.delivery.address.domain.entity;
+
+import com.sparta.delivery.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "p_address")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID addressId;
+
+    @Column(nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(length = 50)
+    private String alias;
+
+    @Column(nullable = false, length = 255)
+    private String address;
+
+    @Column(length = 255)
+    private String detail;
+
+    @Column(length = 10)
+    private String zipCode;
+
+    @Column(nullable = false)
+    private boolean isDefault;
+
+    @Builder
+    private Address(
+            Long userId,
+            String alias,
+            String address,
+            String detail,
+            String zipCode,
+            boolean isDefault
+    ) {
+        this.userId = userId;
+        this.alias = alias;
+        this.address = address;
+        this.detail = detail;
+        this.zipCode = zipCode;
+        this.isDefault = isDefault;
+    }
+
+    public static Address create(
+            Long userId,
+            String alias,
+            String address,
+            String detail,
+            String zipCode,
+            boolean isDefault
+    ) {
+        return Address.builder()
+                .userId(userId)
+                .alias(alias)
+                .address(address)
+                .detail(detail)
+                .zipCode(zipCode)
+                .isDefault(isDefault)
+                .build();
+    }
+
+    public void update(String alias, String address, String detail, String zipCode) {
+        this.alias = alias;
+        this.address = address;
+        this.detail = detail;
+        this.zipCode = zipCode;
+    }
+}

--- a/src/main/java/com/sparta/delivery/address/domain/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/delivery/address/domain/repository/AddressRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.address.domain.repository;
+
+import com.sparta.delivery.address.domain.entity.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AddressRepository extends JpaRepository<Address, UUID> {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #6 

## ✨ 기능 요약

| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Address 엔티티 및 Repository 구현 |
| 🔍 목적 | ERD 기준에 맞춰 주소 도메인의 구조를 구성하기 위함 |
| 🛠️ 변경사항 | `Address` 엔티티 추가 / `AddressRepository` 추가 / `p_address` 컬럼 기준 필드 및 매핑 반영 |


## 📝 상세 내역

| 번호 | 내용 |
|------|------|
| 1️⃣ | `p_address` 기반 `Address` 엔티티 추가 (`BaseEntity` 상속, UUID PK, `userId(Long)` FK-only 적용) |
| 2️⃣ | 주소 정보 필드(`alias`, `address`, `detail`, `zipCode`, `isDefault`) 반영 및 생성/수정용 도메인 메서드 작성 |
| 3️⃣ | `AddressRepository` 추가 및 주소 도메인 기본 영속성 구조 구성 |

---

## 🙋‍♀️ 리뷰어 참고사항
* BaseEntity를 상속하고 soft delete .
* User 엔티티 직접 참조 없이 userId(Long)만 저장하도록 구성
