### PR TITLE
feat: 주문 엔티티 및 Repo 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
@@ -48,7 +48,7 @@ public class Order extends BaseEntity {
     @Column(nullable = false, length = 20)
     private OrderStatus status;
 
-    @Column(length = 500)
+    @Column(nullable = false, updatable = false, length = 500)
     private String deliveryAddressSnapshot;
 
     private LocalDateTime rejectedAt;

--- a/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.order.domain.entity;
 
 import com.sparta.delivery.common.model.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,8 +9,11 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -51,6 +55,9 @@ public class Order extends BaseEntity {
     private LocalDateTime cancelDeadlineAt;
     private LocalDateTime completedAt;
     private LocalDateTime canceledAt;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<OrderItem> items = new ArrayList<>();
 
     @Builder
     private Order(
@@ -94,5 +101,10 @@ public class Order extends BaseEntity {
                 .deliveryAddressSnapshot(deliveryAddressSnapshot)
                 .cancelDeadlineAt(cancelDeadlineAt)
                 .build();
+    }
+
+    public void addOrderItem(OrderItem item) {
+        this.items.add(item);
+        item.setOrder(this);
     }
 }

--- a/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
@@ -1,0 +1,98 @@
+package com.sparta.delivery.order.domain.entity;
+
+import com.sparta.delivery.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "p_order")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID orderId;
+
+    @Column(nullable = false, updatable = false)
+    private UUID storeId;
+
+    @Column(nullable = false, updatable = false)
+    private UUID addressId;
+
+    @Column(nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Integer totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OrderStatus status;
+
+    @Column(length = 500)
+    private String deliveryAddressSnapshot;
+
+    private LocalDateTime rejectedAt;
+    private LocalDateTime cancelDeadlineAt;
+    private LocalDateTime completedAt;
+    private LocalDateTime canceledAt;
+
+    @Builder
+    private Order(
+            UUID storeId,
+            UUID addressId,
+            Long userId,
+            Integer totalPrice,
+            OrderStatus status,
+            String deliveryAddressSnapshot,
+            LocalDateTime rejectedAt,
+            LocalDateTime cancelDeadlineAt,
+            LocalDateTime completedAt,
+            LocalDateTime canceledAt
+    ) {
+        this.storeId = storeId;
+        this.addressId = addressId;
+        this.userId = userId;
+        this.totalPrice = totalPrice;
+        this.status = status;
+        this.deliveryAddressSnapshot = deliveryAddressSnapshot;
+        this.rejectedAt = rejectedAt;
+        this.cancelDeadlineAt = cancelDeadlineAt;
+        this.completedAt = completedAt;
+        this.canceledAt = canceledAt;
+    }
+
+    public static Order create(
+            UUID storeId,
+            UUID addressId,
+            Long userId,
+            Integer totalPrice,
+            String deliveryAddressSnapshot,
+            LocalDateTime cancelDeadlineAt
+    ) {
+        return Order.builder()
+                .storeId(storeId)
+                .addressId(addressId)
+                .userId(userId)
+                .totalPrice(totalPrice)
+                .status(OrderStatus.PENDING)
+                .deliveryAddressSnapshot(deliveryAddressSnapshot)
+                .cancelDeadlineAt(cancelDeadlineAt)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
@@ -1,0 +1,99 @@
+package com.sparta.delivery.order.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "p_order_items")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID orderItemId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false, updatable = false)
+    private Order order;
+
+    @Column(nullable = false, updatable = false)
+    private UUID productId;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(nullable = false)
+    private Integer unitPrice;
+
+    @Column(nullable = false)
+    private Integer lineTotalPrice;
+
+    @Column(nullable = false, length = 255)
+    private String productNameSnapshot;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private Long createdBy;
+
+    @Builder
+    private OrderItem(
+            Order order,
+            UUID productId,
+            Integer quantity,
+            Integer unitPrice,
+            Integer lineTotalPrice,
+            String productNameSnapshot
+    ) {
+        this.order = order;
+        this.productId = productId;
+        this.quantity = quantity;
+        this.unitPrice = unitPrice;
+        this.lineTotalPrice = lineTotalPrice;
+        this.productNameSnapshot = productNameSnapshot;
+    }
+
+    public static OrderItem create(
+            Order order,
+            UUID productId,
+            Integer quantity,
+            Integer unitPrice,
+            Integer lineTotalPrice,
+            String productNameSnapshot
+    ) {
+        return OrderItem.builder()
+                .order(order)
+                .productId(productId)
+                .quantity(quantity)
+                .unitPrice(unitPrice)
+                .lineTotalPrice(lineTotalPrice)
+                .productNameSnapshot(productNameSnapshot)
+                .build();
+    }
+
+    void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
@@ -60,13 +60,11 @@ public class OrderItem {
 
     @Builder
     private OrderItem(
-            Order order,
             UUID productId,
             Integer quantity,
             Integer unitPrice,
             String productNameSnapshot
     ) {
-        this.order = order;
         this.productId = productId;
         this.quantity = quantity;
         this.unitPrice = unitPrice;
@@ -75,14 +73,12 @@ public class OrderItem {
     }
 
     public static OrderItem create(
-            Order order,
             UUID productId,
             Integer quantity,
             Integer unitPrice,
             String productNameSnapshot
     ) {
         return OrderItem.builder()
-                .order(order)
                 .productId(productId)
                 .quantity(quantity)
                 .unitPrice(unitPrice)

--- a/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
@@ -64,14 +64,13 @@ public class OrderItem {
             UUID productId,
             Integer quantity,
             Integer unitPrice,
-            Integer lineTotalPrice,
             String productNameSnapshot
     ) {
         this.order = order;
         this.productId = productId;
         this.quantity = quantity;
         this.unitPrice = unitPrice;
-        this.lineTotalPrice = lineTotalPrice;
+        this.lineTotalPrice = quantity * unitPrice;
         this.productNameSnapshot = productNameSnapshot;
     }
 
@@ -80,7 +79,6 @@ public class OrderItem {
             UUID productId,
             Integer quantity,
             Integer unitPrice,
-            Integer lineTotalPrice,
             String productNameSnapshot
     ) {
         return OrderItem.builder()
@@ -88,7 +86,6 @@ public class OrderItem {
                 .productId(productId)
                 .quantity(quantity)
                 .unitPrice(unitPrice)
-                .lineTotalPrice(lineTotalPrice)
                 .productNameSnapshot(productNameSnapshot)
                 .build();
     }

--- a/src/main/java/com/sparta/delivery/order/domain/entity/OrderStatus.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/OrderStatus.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.order.domain.entity;
+
+public enum OrderStatus {
+    PENDING,
+    ACCEPTED,
+    COOKING,
+    DELIVERING,
+    DELIVERED,
+    COMPLETED,
+    CANCELED
+}

--- a/src/main/java/com/sparta/delivery/order/domain/entity/OrderStatus.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/OrderStatus.java
@@ -7,5 +7,6 @@ public enum OrderStatus {
     DELIVERING,
     DELIVERED,
     COMPLETED,
+    REJECTED,
     CANCELED
 }

--- a/src/main/java/com/sparta/delivery/order/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/sparta/delivery/order/domain/repository/OrderItemRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.order.domain.repository;
+
+import com.sparta.delivery.order.domain.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, UUID> {
+}

--- a/src/main/java/com/sparta/delivery/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/delivery/order/domain/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.order.domain.repository;
+
+import com.sparta.delivery.order.domain.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #7  

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Order / OrderItem 도메인 엔티티 및 Repository 구현 |
| 🔍 목적 | ERD 기준에 맞춰 주문 도메인의 구조를 구성하기 위함 |
| 🛠️ 변경사항 | `Order`, `OrderItem`, `OrderStatus` 추가 / `OrderRepository`, `OrderItemRepository` 추가 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `p_order` 기반 `Order` 엔티티 추가 (`BaseEntity` 상속, UUID PK, 주문 상태/배송지 스냅샷/취소 관련 필드 반영) |
| 2️⃣ | `p_order_items` 기반 `OrderItem` 엔티티 추가 (`createdAt`, `createdBy` 별도 관리, 상품명/가격 스냅샷 필드 반영) |
| 3️⃣ | `OrderStatus` enum, `OrderRepository`, `OrderItemRepository` 추가 및 `Order` - `OrderItem` 연관관계 설정 |

---

## 🙋‍♀️ 리뷰어 참고사항
* 주문 생성 시 기본 상태는 `PENDING`으로 설정.
* `OrderItem`은 `BaseEntity`를 상속하지 않고 `createdAt`, `createdBy`만 별도 관리.
* 주문-주문항목 aggregate 관계 매핑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 주문 생성 및 관리 기능의 기반이 추가되었습니다.
  * 주문 상태 추적(대기 중, 수락, 조리 중, 배송 중, 완료, 거절, 취소)이 지원됩니다.
  * 주문 항목 저장 및 관리 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->