### PR TITLE
feat: User 도메인 1차 작업 (래빗 테스트용

### DIFF
--- a/src/main/java/com/sparta/delivery/user/domain/entity/User.java
+++ b/src/main/java/com/sparta/delivery/user/domain/entity/User.java
@@ -1,0 +1,90 @@
+package com.sparta.delivery.user.domain.entity;
+
+import com.sparta.delivery.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 엔티티.
+ * PK는 BIGINT (user_id) — 과제 원문은 username이 PK였으나 튜터가 별 지적 안함.
+ * 로그인 식별자는 email 사용.
+ *
+ * BaseEntity 상속으로 감사 필드(createdAt/By, updatedAt/By, deletedAt/By) 자동 관리.
+ * 다른 도메인은 User를 @ManyToOne이 아니라 Long userId FK로만 참조할 것.
+ */
+@Entity
+@Table(name = "p_user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+
+    @Column(length = 20)
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @Column(nullable = false)
+    private boolean isPublic = true;
+
+    @Column(nullable = false)
+    private int tokenVersion = 0;
+
+    private LocalDateTime lastLoginAt;
+
+    // AI 상품 설명 기능에서 사용할 사용자 선호 텍스트
+    @Column(columnDefinition = "TEXT")
+    private String useAiDescription;
+
+    @Builder
+    public User(String email, String password, String name, String phone, UserRole role) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.role = role;
+    }
+
+    public void updateInfo(String name, String phone, boolean isPublic, String useAiDescription) {
+        this.name = name;
+        this.phone = phone;
+        this.isPublic = isPublic;
+        this.useAiDescription = useAiDescription;
+    }
+
+    public void changeRole(UserRole role) {
+        this.role = role;
+    }
+
+    public void updateLastLoginAt() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
+
+    /**
+     * 권한 변경/탈퇴/로그아웃 시 호출. 기존 JWT를 무효화한다.
+     * Filter가 토큰의 tokenVersion과 DB값이 다르면 인증을 거부.
+     */
+    public void incrementTokenVersion() {
+        this.tokenVersion++;
+    }
+
+}

--- a/src/main/java/com/sparta/delivery/user/domain/entity/UserRole.java
+++ b/src/main/java/com/sparta/delivery/user/domain/entity/UserRole.java
@@ -1,0 +1,8 @@
+package com.sparta.delivery.user.domain.entity;
+
+public enum UserRole {
+    CUSTOMER,
+    OWNER,
+    MANAGER,
+    MASTER
+}

--- a/src/main/java/com/sparta/delivery/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/sparta/delivery/user/domain/repository/UserRepository.java
@@ -1,0 +1,29 @@
+package com.sparta.delivery.user.domain.repository;
+
+import com.sparta.delivery.user.domain.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    User save(User user);
+
+    Optional<User> findById(Long id);
+
+    /**
+     * 로그인 시 사용. Soft Delete된 계정은 제외하고 조회.
+     */
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+
+    /**
+     * 회원가입 시 중복 체크용.
+     */
+    boolean existsByEmail(String email);
+
+    /**
+     * 관리자용 사용자 목록 조회. 삭제되지 않은 계정만.
+     */
+    Page<User> findAllByDeletedAtIsNull(Pageable pageable);
+}

--- a/src/main/java/com/sparta/delivery/user/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/com/sparta/delivery/user/infrastructure/persistence/repository/UserJpaRepository.java
@@ -1,0 +1,18 @@
+package com.sparta.delivery.user.infrastructure.persistence.repository;
+
+import com.sparta.delivery.user.domain.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+
+    boolean existsByEmail(String email);
+
+    Page<User> findAllByDeletedAtIsNull(Pageable pageable);
+
+}

--- a/src/main/java/com/sparta/delivery/user/infrastructure/persistence/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/sparta/delivery/user/infrastructure/persistence/repository/UserRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.sparta.delivery.user.infrastructure.persistence.repository;
+
+import com.sparta.delivery.user.domain.entity.User;
+import com.sparta.delivery.user.domain.repository.UserRepository;
+import com.sparta.delivery.user.infrastructure.persistence.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public User save(User user) {
+        return userJpaRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return userJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<User> findByEmailAndDeletedAtIsNull(String email) {
+        return userJpaRepository.findByEmailAndDeletedAtIsNull(email);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userJpaRepository.existsByEmail(email);
+    }
+
+    @Override
+    public Page<User> findAllByDeletedAtIsNull(Pageable pageable) {
+        return userJpaRepository.findAllByDeletedAtIsNull(pageable);
+    }
+
+}

--- a/src/test/java/com/sparta/delivery/user/domain/entity/UserTest.java
+++ b/src/test/java/com/sparta/delivery/user/domain/entity/UserTest.java
@@ -1,0 +1,127 @@
+package com.sparta.delivery.user.domain.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * User 엔티티의 도메인 메서드 단위 테스트.
+ * DB/Spring 없이 순수 POJO로 검증 → 빠름.
+ */
+class UserTest {
+
+    /** 테스트용 기본 User 생성 헬퍼 */
+    private User buildUser() {
+        return User.builder()
+                .email("test@test.com")
+                .password("encoded-password")
+                .name("tester")
+                .phone("010-1234-5678")
+                .role(UserRole.CUSTOMER)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("빌더로 User를 생성하믄.")
+    class CreateUser {
+
+        @Test
+        @DisplayName("전달한 값이 그대로 들어간다.")
+        void build_setsFields() {
+            // given
+            User user = buildUser();
+
+            assertThat(user.getEmail()).isEqualTo("test@test.com");
+            assertThat(user.getName()).isEqualTo("tester");
+            assertThat(user.getRole()).isEqualTo(UserRole.CUSTOMER);
+        }
+
+        @Test
+        @DisplayName("isPublic 기본값은 true, tokenVersion 기본값은 0")
+        void build_defaults() {
+            User user = buildUser();
+
+            assertThat(user.isPublic()).isTrue();
+            assertThat(user.getTokenVersion()).isZero();
+            assertThat(user.getLastLoginAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("changeRole 호출 시")
+    class ChangeRole {
+
+        @Test
+        @DisplayName("role이 변경된다")
+        void changesRole() {
+            User user = buildUser();
+
+            user.changeRole(UserRole.OWNER);
+
+            assertThat(user.getRole()).isEqualTo(UserRole.OWNER);
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementTokenVersion 호출 시")
+    class IncrementTokenVersion {
+
+        @Test
+        @DisplayName("tokenVersion이 1 증가한다")
+        void increments() {
+            User user = buildUser();
+            int before = user.getTokenVersion();
+
+            user.incrementTokenVersion();
+
+            assertThat(user.getTokenVersion()).isEqualTo(before + 1);
+        }
+
+        @Test
+        @DisplayName("여러 번 호출하면 그 횟수만큼 증가한다")
+        void multipleIncrements() {
+            User user = buildUser();
+
+            user.incrementTokenVersion();
+            user.incrementTokenVersion();
+            user.incrementTokenVersion();
+
+            assertThat(user.getTokenVersion()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("softDelete 호출 시 (BaseEntity 로직)")
+    class SoftDelete {
+
+        @Test
+        @DisplayName("deletedAt, deletedBy가 세팅된다")
+        void setsDeletedFields() {
+            User user = buildUser();
+
+            user.softDelete(999L);
+
+            assertThat(user.isDeleted()).isTrue();
+            assertThat(user.getDeletedAt()).isNotNull();
+            assertThat(user.getDeletedBy()).isEqualTo(999L);
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 엔티티를 다시 삭제해도 값이 덮어쓰이지 않는다")
+        void doesNotOverwriteIfAlreadyDeleted() {
+            User user = buildUser();
+            user.softDelete(1L);
+            var firstDeletedAt = user.getDeletedAt();
+
+            user.softDelete(2L);
+
+            // deletedBy는 처음 삭제한 1L 유지
+            assertThat(user.getDeletedBy()).isEqualTo(1L);
+            assertThat(user.getDeletedAt()).isEqualTo(firstDeletedAt);
+        }
+    }
+
+}

--- a/src/test/java/com/sparta/delivery/user/infrastructure/persistence/repository/UserRepositoryImplTest.java
+++ b/src/test/java/com/sparta/delivery/user/infrastructure/persistence/repository/UserRepositoryImplTest.java
@@ -1,0 +1,132 @@
+package com.sparta.delivery.user.infrastructure.persistence.repository;
+
+import com.sparta.delivery.common.config.jpa.JpaAuditingConfig;
+import com.sparta.delivery.user.domain.entity.User;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * UserRepository 통합 테스트.
+ *
+ * @DataJpaTest: JPA 관련 빈만 로드 → Spring Boot 전체 컨텍스트보다 빠름
+ * @AutoConfigureTestDatabase(replace = NONE): H2가 아니라 실제 DB 설정 사용
+ * @Import(JpaAuditingConfig.class): BaseEntity의 @CreatedDate/By 자동화 활성화
+ *
+ * UserRepositoryImpl + UserJpaRepository를 함께 Bean으로 잡기 위해
+ * @Import로 구현체를 추가한다.
+ */
+@DataJpaTest
+@Import({UserRepositoryImpl.class, JpaAuditingConfig.class})
+class UserRepositoryImplTest {
+    @Autowired
+    private UserRepositoryImpl userRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @BeforeEach
+    void setUp() {
+        userJpaRepository.deleteAll();
+    }
+
+    private User newUser(String email, String name) {
+        return User.builder()
+                .email(email)
+                .password("encoded")
+                .name(name)
+                .phone("010-0000-0000")
+                .role(UserRole.CUSTOMER)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("save / findById")
+    class SaveAndFind {
+
+        @Test
+        @DisplayName("저장 후 ID로 조회할 수 있다")
+        void save_findById() {
+            User saved = userRepository.save(newUser("a@a.com", "userA"));
+
+            Optional<User> found = userRepository.findById(saved.getUserId());
+
+            assertThat(found).isPresent();
+            assertThat(found.get().getEmail()).isEqualTo("a@a.com");
+        }
+
+        @Test
+        @DisplayName("없는 ID로 조회하면 Optional.empty")
+        void findById_notFound() {
+            Optional<User> found = userRepository.findById(999L);
+
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByEmailAndDeletedAtIsNull")
+    class FindByEmail {
+
+        @Test
+        @DisplayName("삭제되지 않은 사용자는 이메일로 조회된다")
+        void returnsActiveUser() {
+            userRepository.save(newUser("a@a.com", "userA"));
+
+            Optional<User> found = userRepository.findByEmailAndDeletedAtIsNull("a@a.com");
+
+            assertThat(found).isPresent();
+        }
+
+        @Test
+        @DisplayName("Soft Delete된 사용자는 조회되지 않는다")
+        void excludesDeletedUser() {
+            User user = userRepository.save(newUser("a@a.com", "userA"));
+            user.softDelete(user.getUserId());
+            userJpaRepository.flush();  // deletedAt을 실제 DB에 반영
+
+            Optional<User> found = userRepository.findByEmailAndDeletedAtIsNull("a@a.com");
+
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("없는 이메일로 조회하면 Optional.empty")
+        void notFound() {
+            Optional<User> found = userRepository.findByEmailAndDeletedAtIsNull("none@none.com");
+
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByEmail")
+    class ExistsByEmail {
+
+        @Test
+        @DisplayName("저장된 이메일은 true")
+        void exists() {
+            userRepository.save(newUser("a@a.com", "userA"));
+
+            assertThat(userRepository.existsByEmail("a@a.com")).isTrue();
+        }
+
+        @Test
+        @DisplayName("저장되지 않은 이메일은 false")
+        void notExists() {
+            assertThat(userRepository.existsByEmail("none@none.com")).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 기능 요약

User 도메인 1차 작업. 

회원가입/로그인 등 서비스 로직은 2차 작업에서 진행.

---

## 📌 작업 내용

### 엔티티
- `user/domain/entity/User.java` — User 엔티티 구현
  - PK: `BIGINT` (user_id)
  - BaseEntity 상속 → 감사 필드(createdAt/By, updatedAt/By, deletedAt/By) 자동 관리
  - 필드: email, password, name, phone, role, isPublic, tokenVersion, lastLoginAt, useAiDescription
  - 도메인 메서드: `updateInfo()`, `changeRole()`, `updateLastLoginAt()`, `incrementTokenVersion()`
- `user/domain/entity/UserRole.java` — 권한 enum (CUSTOMER / OWNER / MANAGER / MASTER)

### Repository (3-layer 분리)
- `user/domain/repository/UserRepository.java` — **인터페이스** (domain 계층)
- `user/infrastructure/persistence/repository/UserJpaRepository.java` — **Spring Data JPA 전용**
- `user/infrastructure/persistence/repository/UserRepositoryImpl.java` — **구현체** (infrastructure 계층)

### 테스트
- `UserTest` — 엔티티 도메인 메서드 단위 테스트 (빌더, updateInfo, changeRole, incrementTokenVersion, softDelete)
- `UserRepositoryImplTest` — `@DataJpaTest` 기반 Repository 통합 테스트
- `src/test/resources/application.yml` — H2 기반 테스트 설정

---

## 🏗️ Repository 왜 3개로 나눴나

### 파일 위치와 역할
```
├── domain/
│ └── repository/
│ └── UserRepository.java ← ① 인터페이스 (domain이 "필요한 기능"만 선언)
│
└── infrastructure/
└── persistence/
└── repository/
├── UserJpaRepository.java ← ② Spring Data JPA 전용 인터페이스
└── UserRepositoryImpl.java ← ③ UserRepository 구현체
```

### 각 파일의 역할
**① `UserRepository` (domain 계층의 인터페이스)**
- 도메인이 필요로 하는 영속성 기능을 **"우리 언어"로** 선언
- JPA, QueryDSL 같은 기술 용어가 전혀 없음
- Service는 이 인터페이스에만 의존

② UserJpaRepository (infrastructure 계층의 JPA 인터페이스)
- Spring Data JPA가 런타임에 구현체를 자동 생성해주는 인터페이스
- JpaRepository<User, Long> 상속으로 save, findById 등 자동 제공
- 외부(Service)에서 직접 쓰지 않고 UserRepositoryImpl만 의존

③ UserRepositoryImpl (구현체 = 어댑터)
- UserRepository 인터페이스를 구현하면서 내부적으로 UserJpaRepository를 사용
- domain 인터페이스와 JPA 세부 구현 사이의 다리 역할
 
### 왜 이렇게까지 쪼개나
1. 의존성 방향을 한 방향으로 유지 (의존성 역전)
```
Service (application)
   ↓ 의존
UserRepository (domain) ← "이런 기능이 필요해"
   ↑ 구현
UserRepositoryImpl (infrastructure) → JPA
```
- domain 계층은 JPA를 몰라도 됨
- JPA 구현을 다른 기술로 바꿔도 domain/application은 영향 없음