### PR TITLE
feat: AI 엔티티 및 레포지토리 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.ai.domain.entity;
 
 
+import com.sparta.delivery.ai.domain.exception.InvalidLlmNameException;
 import com.sparta.delivery.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -55,7 +56,7 @@ public class Llm extends BaseEntity {
     // not null, non-blank and max length 100
     private static void validateLlmName(String llmName) {
         if (llmName == null || llmName.isBlank() || llmName.length() > 100) {
-            throw new IllegalArgumentException("Invalid model name.");
+            throw new InvalidLlmNameException();
         }
     }
 }

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
@@ -1,0 +1,60 @@
+package com.sparta.delivery.ai.domain.entity;
+
+
+import com.sparta.delivery.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_llms")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Llm extends BaseEntity {
+
+    @Id
+    @Column(name = "llm_id")
+    private UUID llmId;
+
+    @Column(name = "llm_name", nullable = false, unique = true, length = 100)
+    private String llmName;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    public static Llm create(UUID llmId, String llmName, boolean isActive) {
+        validateLlmName(llmName);
+
+        Llm llm = new Llm();
+        llm.llmId = llmId;
+        llm.llmName = llmName;
+        llm.isActive = isActive;
+
+        return llm;
+    }
+
+    public void updateName(String llmName) {
+        validateLlmName(llmName);
+        this.llmName = llmName;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    private static void validateLlmName(String llmName) {
+        if (llmName == null || llmName.isBlank() || llmName.length() > 100) {
+            throw new IllegalArgumentException("Invalid model name.");
+        }
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
@@ -52,6 +52,7 @@ public class Llm extends BaseEntity {
         this.isActive = false;
     }
 
+    // not null, non-blank and max length 100
     private static void validateLlmName(String llmName) {
         if (llmName == null || llmName.isBlank() || llmName.length() > 100) {
             throw new IllegalArgumentException("Invalid model name.");

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
@@ -1,5 +1,7 @@
 package com.sparta.delivery.ai.domain.entity;
 
+import com.sparta.delivery.ai.domain.exception.InvalidCreatedByException;
+import com.sparta.delivery.ai.domain.exception.InvalidInputSnapshotException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -74,14 +76,14 @@ public class LlmCall {
     // not null and non-blank
     private static void validateInputSnapshot(String inputSnapshot) {
         if (inputSnapshot == null || inputSnapshot.isBlank()) {
-            throw new IllegalArgumentException("Invalid input snapshot");
+            throw new InvalidInputSnapshotException();
         }
     }
 
     // not null
     private static void validateCreatedBy(Long createdBy) {
         if (createdBy == null) {
-            throw new IllegalArgumentException("Invalid creator id");
+            throw new InvalidCreatedByException();
         }
     }
 }

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
@@ -1,0 +1,87 @@
+package com.sparta.delivery.ai.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_llm_calls")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LlmCall {
+
+    @Id
+    @Column(name = "call_id")
+    private UUID callId;
+
+    @Column(name = "llm_id", nullable = false)
+    private UUID llmId;
+
+    @Column(name = "product_id", nullable = false)
+    private UUID productId;
+
+    @Column(name = "input_snapshot", nullable = false, columnDefinition = "jsonb")
+    private String inputSnapshot;
+
+    @Column(name = "provider_status_code", length = 50)
+    private String providerStatusCode;
+
+    @Column(name = "raw_response", columnDefinition = "TEXT")
+    private String rawResponse;
+
+    @Column(name = "generated_text", columnDefinition = "TEXT")
+    private String generatedText;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", nullable = false)
+    private Long createdBy;
+
+    public static LlmCall create(
+            UUID callId,
+            UUID llmId,
+            UUID productId,
+            String inputSnapshot,
+            String providerStatusCode,
+            String rawResponse,
+            String generatedText,
+            Long createdBy
+    ) {
+        validateInputSnapshot(inputSnapshot);
+        validateCreatedBy(createdBy);
+
+        LlmCall llmCall = new LlmCall();
+        llmCall.callId = callId;
+        llmCall.llmId = llmId;
+        llmCall.productId = productId;
+        llmCall.inputSnapshot = inputSnapshot;
+        llmCall.providerStatusCode = providerStatusCode;
+        llmCall.rawResponse = rawResponse;
+        llmCall.generatedText = generatedText;
+        llmCall.createdAt = LocalDateTime.now();
+        llmCall.createdBy = createdBy;
+        return llmCall;
+    }
+
+    // not null and non-blank
+    private static void validateInputSnapshot(String inputSnapshot) {
+        if (inputSnapshot == null || inputSnapshot.isBlank()) {
+            throw new IllegalArgumentException("Invalid input snapshot");
+        }
+    }
+
+    // not null
+    private static void validateCreatedBy(Long createdBy) {
+        if (createdBy == null) {
+            throw new IllegalArgumentException("Invalid creator id");
+        }
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
@@ -1,0 +1,19 @@
+package com.sparta.delivery.ai.domain.exception;
+
+
+import com.sparta.delivery.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AiErrorCode implements ErrorCode {
+    INVALID_LLM_NAME(HttpStatus.BAD_REQUEST, "AI-001", "유효하지 않은 모델 이름입니다."),
+    INVALID_INPUT_SNAPSHOT(HttpStatus.BAD_REQUEST, "AI-002", "유효하지 않은 입력 스냅샷입니다."),
+    INVALID_CREATED_BY(HttpStatus.BAD_REQUEST, "AI-003", "유효하지 않은 생성자 정보입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidCreatedByException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidCreatedByException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidCreatedByException extends BaseException {
+    public InvalidCreatedByException() {
+        super(AiErrorCode.INVALID_CREATED_BY);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidInputSnapshotException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidInputSnapshotException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidInputSnapshotException extends BaseException {
+    public InvalidInputSnapshotException() {
+        super(AiErrorCode.INVALID_INPUT_SNAPSHOT);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidLlmNameException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidLlmNameException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidLlmNameException extends BaseException {
+    public InvalidLlmNameException() {
+        super(AiErrorCode.INVALID_LLM_NAME);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/repository/LlmCallRepository.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/repository/LlmCallRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.delivery.ai.domain.repository;
+
+import com.sparta.delivery.ai.domain.entity.LlmCall;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LlmCallRepository {
+
+    LlmCall save(LlmCall llmCall);
+
+    Optional<LlmCall> findById(UUID callId);
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/repository/LlmRepository.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/repository/LlmRepository.java
@@ -1,0 +1,17 @@
+package com.sparta.delivery.ai.domain.repository;
+
+import com.sparta.delivery.ai.domain.entity.Llm;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LlmRepository {
+
+    Llm save(Llm llm);
+
+    Optional<Llm> findById(UUID llmId);
+
+    Optional<Llm> findActive();
+
+    boolean existsByLlmName(String llmName);
+}

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/persistence/repository/LlmCallJpaRepository.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/persistence/repository/LlmCallJpaRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.delivery.ai.infrastructure.persistence.repository;
+
+import com.sparta.delivery.ai.domain.entity.LlmCall;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LlmCallJpaRepository extends JpaRepository<LlmCall, UUID> {
+
+    Optional<LlmCall> findByCallId(UUID callId);
+}

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/persistence/repository/LlmCallRepositoryImpl.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/persistence/repository/LlmCallRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.sparta.delivery.ai.infrastructure.persistence.repository;
+
+import com.sparta.delivery.ai.domain.entity.LlmCall;
+import com.sparta.delivery.ai.domain.repository.LlmCallRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class LlmCallRepositoryImpl implements LlmCallRepository {
+
+    private final LlmCallJpaRepository llmCallJpaRepository;
+
+    @Override
+    public LlmCall save(LlmCall llmCall) {
+        return llmCallJpaRepository.save(llmCall);
+    }
+
+    @Override
+    public Optional<LlmCall> findById(UUID callId) {
+        return llmCallJpaRepository.findByCallId(callId);
+    }
+
+}

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/persistence/repository/LlmJpaRepository.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/persistence/repository/LlmJpaRepository.java
@@ -1,0 +1,16 @@
+package com.sparta.delivery.ai.infrastructure.persistence.repository;
+
+import com.sparta.delivery.ai.domain.entity.Llm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LlmJpaRepository extends JpaRepository<Llm, UUID> {
+
+    Optional<Llm> findByLlmIdAndDeletedAtIsNull(UUID llmId);
+
+    Optional<Llm> findByIsActiveTrueAndDeletedAtIsNull();
+
+    boolean existsByLlmNameAndDeletedAtIsNull(String llmName);
+}

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/persistence/repository/LlmRepositoryImpl.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/persistence/repository/LlmRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.sparta.delivery.ai.infrastructure.persistence.repository;
+
+import com.sparta.delivery.ai.domain.entity.Llm;
+import com.sparta.delivery.ai.domain.repository.LlmRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class LlmRepositoryImpl implements LlmRepository {
+
+    private final LlmJpaRepository llmJpaRepository;
+
+    @Override
+    public Llm save(Llm llm) {
+        return llmJpaRepository.save(llm);
+    }
+
+    @Override
+    public Optional<Llm> findById(UUID llmId) {
+        return llmJpaRepository.findByLlmIdAndDeletedAtIsNull(llmId);
+    }
+
+    @Override
+    public Optional<Llm> findActive() {
+        return llmJpaRepository.findByIsActiveTrueAndDeletedAtIsNull();
+    }
+
+    @Override
+    public boolean existsByLlmName(String llmName) {
+        return llmJpaRepository.existsByLlmNameAndDeletedAtIsNull(llmName);
+    }
+}

--- a/src/test/java/com/sparta/delivery/ai/domain/entity/LlmCallTest.java
+++ b/src/test/java/com/sparta/delivery/ai/domain/entity/LlmCallTest.java
@@ -1,0 +1,134 @@
+package com.sparta.delivery.ai.domain.entity;
+
+import com.sparta.delivery.ai.domain.exception.AiErrorCode;
+import com.sparta.delivery.ai.domain.exception.InvalidCreatedByException;
+import com.sparta.delivery.ai.domain.exception.InvalidInputSnapshotException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class LlmCallTest {
+
+    @Test
+    @DisplayName("create should create llmCall successfully")
+    void create_shouldCreateLlmCallSuccessfully() {
+        // given
+        UUID callId = UUID.randomUUID();
+        UUID llmId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        String inputSnapshot = "{\"productName\":\"Americano\",\"price\":4500}";
+        String providerStatusCode = "200";
+        String rawResponse = "{\"result\":\"ok\"}";
+        String generatedText = "깔끔한 커피 설명";
+        Long createdBy = 1L;
+
+        LocalDateTime before = LocalDateTime.now();
+
+        // when
+        LlmCall llmCall = LlmCall.create(
+                callId,
+                llmId,
+                productId,
+                inputSnapshot,
+                providerStatusCode,
+                rawResponse,
+                generatedText,
+                createdBy
+        );
+
+        LocalDateTime after = LocalDateTime.now();
+
+        // then
+        assertThat(llmCall.getCallId()).isEqualTo(callId);
+        assertThat(llmCall.getLlmId()).isEqualTo(llmId);
+        assertThat(llmCall.getProductId()).isEqualTo(productId);
+        assertThat(llmCall.getInputSnapshot()).isEqualTo(inputSnapshot);
+        assertThat(llmCall.getProviderStatusCode()).isEqualTo(providerStatusCode);
+        assertThat(llmCall.getRawResponse()).isEqualTo(rawResponse);
+        assertThat(llmCall.getGeneratedText()).isEqualTo(generatedText);
+        assertThat(llmCall.getCreatedBy()).isEqualTo(createdBy);
+        assertThat(llmCall.getCreatedAt()).isNotNull();
+        assertThat(llmCall.getCreatedAt()).isBetween(before, after);
+    }
+
+    @Test
+    @DisplayName("create should throw when inputSnapshot is null")
+    void create_shouldThrow_whenInputSnapshotIsNull() {
+        // given
+        UUID callId = UUID.randomUUID();
+        UUID llmId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> LlmCall.create(
+                callId,
+                llmId,
+                productId,
+                null,
+                "200",
+                "{\"result\":\"ok\"}",
+                "generated text",
+                1L
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidInputSnapshotException.class);
+        InvalidInputSnapshotException exception = (InvalidInputSnapshotException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_INPUT_SNAPSHOT.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when inputSnapshot is blank")
+    void create_shouldThrow_whenInputSnapshotIsBlank() {
+        // given
+        UUID callId = UUID.randomUUID();
+        UUID llmId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> LlmCall.create(
+                callId,
+                llmId,
+                productId,
+                "   ",
+                "200",
+                "{\"result\":\"ok\"}",
+                "generated text",
+                1L
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidInputSnapshotException.class);
+        InvalidInputSnapshotException exception = (InvalidInputSnapshotException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_INPUT_SNAPSHOT.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when createdBy is null")
+    void create_shouldThrow_whenCreatedByIsNull() {
+        // given
+        UUID callId = UUID.randomUUID();
+        UUID llmId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> LlmCall.create(
+                callId,
+                llmId,
+                productId,
+                "{\"productName\":\"Americano\"}",
+                "200",
+                "{\"result\":\"ok\"}",
+                "generated text",
+                null
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidCreatedByException.class);
+        InvalidCreatedByException exception = (InvalidCreatedByException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_CREATED_BY.getCode());
+    }
+}

--- a/src/test/java/com/sparta/delivery/ai/domain/entity/LlmTest.java
+++ b/src/test/java/com/sparta/delivery/ai/domain/entity/LlmTest.java
@@ -1,0 +1,196 @@
+package com.sparta.delivery.ai.domain.entity;
+
+import com.sparta.delivery.ai.domain.exception.AiErrorCode;
+import com.sparta.delivery.ai.domain.exception.InvalidLlmNameException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class LlmTest {
+
+    @Test
+    @DisplayName("create should create llm successfully")
+    void create_shouldCreateLlmSuccessfully() {
+        // given
+        UUID llmId = UUID.randomUUID();
+        String llmName = "gemini-1.5-flash";
+        boolean isActive = true;
+
+        // when
+        Llm llm = Llm.create(llmId, llmName, isActive);
+
+        // then
+        assertThat(llm.getLlmId()).isEqualTo(llmId);
+        assertThat(llm.getLlmName()).isEqualTo(llmName);
+        assertThat(llm.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("create should throw when llmName is null")
+    void create_shouldThrow_whenLlmNameIsNull() {
+        // given
+        UUID llmId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Llm.create(llmId, null, false));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
+        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when llmName is blank")
+    void create_shouldThrow_whenLlmNameIsBlank() {
+        // given
+        UUID llmId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Llm.create(llmId, "   ", false));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
+        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when llmName length exceeds 100")
+    void create_shouldThrow_whenLlmNameLengthExceeds100() {
+        // given
+        UUID llmId = UUID.randomUUID();
+        String llmName = "a".repeat(101);
+
+        // when
+        Throwable thrown = catchThrowable(() -> Llm.create(llmId, llmName, false));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
+        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("updateName should change llmName successfully")
+    void updateName_shouldChangeLlmNameSuccessfully() {
+        // given
+        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+        String updatedName = "gemini-2.0-flash";
+
+        // when
+        llm.updateName(updatedName);
+
+        // then
+        assertThat(llm.getLlmName()).isEqualTo(updatedName);
+    }
+
+    @Test
+    @DisplayName("updateName should throw when llmName is null")
+    void updateName_shouldThrow_whenLlmNameIsNull() {
+        // given
+        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+
+        // when
+        Throwable thrown = catchThrowable(() -> llm.updateName(null));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
+        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("updateName should throw when llmName is blank")
+    void updateName_shouldThrow_whenLlmNameIsBlank() {
+        // given
+        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+
+        // when
+        Throwable thrown = catchThrowable(() -> llm.updateName("   "));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
+        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("updateName should throw when llmName length exceeds 100")
+    void updateName_shouldThrow_whenLlmNameLengthExceeds100() {
+        // given
+        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+
+        // when
+        Throwable thrown = catchThrowable(() -> llm.updateName("a".repeat(101)));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
+        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("activate should set isActive to true")
+    void activate_shouldSetIsActiveToTrue() {
+        // given
+        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+
+        // when
+        llm.activate();
+
+        // then
+        assertThat(llm.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("deactivate should set isActive to false")
+    void deactivate_shouldSetIsActiveToFalse() {
+        // given
+        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", true);
+
+        // when
+        llm.deactivate();
+
+        // then
+        assertThat(llm.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("softDelete should mark entity as deleted")
+    void softDelete_shouldMarkEntityAsDeleted() {
+        // given
+        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+        Long deletedBy = 1L;
+
+        // when
+        llm.softDelete(deletedBy);
+
+        // then
+        assertThat(llm.isDeleted()).isTrue();
+        assertThat(llm.getDeletedBy()).isEqualTo(deletedBy);
+        assertThat(llm.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("softDelete should keep first deleted state when called twice")
+    void softDelete_shouldKeepFirstDeletedState_whenCalledTwice() {
+        // given
+        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+
+        // when
+        llm.softDelete(1L);
+        LocalDateTime firstDeletedAt = llm.getDeletedAt();
+        Long firstDeletedBy = llm.getDeletedBy();
+
+        llm.softDelete(2L);
+
+        // then
+        assertThat(llm.isDeleted()).isTrue();
+        assertThat(llm.getDeletedAt()).isEqualTo(firstDeletedAt);
+        assertThat(llm.getDeletedBy()).isEqualTo(firstDeletedBy);
+    }
+}


### PR DESCRIPTION
*팀 미팅 이후 repository 구조 방향이 변경되어 해당 PR은 close합니다.*

## 📌 관련 이슈
- Closes #13

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | **AI 도메인 엔티티 및 Repository 구현** |
| 🔍 목적 | AI 설명 생성 기능 지원을 위한 AI 도메인 구조 구성 |
| 🛠️ 변경사항 | `Llm` / `LlmCall` 엔티티, `AiErrorCode` 및 도메인 예외, Repository 계층 구현 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | p_llms 테이블 기준 `Llm` 엔티티 구현 |
| 2️⃣ | p_llm_calls 테이블 기준 `LlmCall` 엔티티 구현 |
| 3️⃣ | `AiErrorCode` 및 `BaseException` 상속 도메인 예외 클래스 작성 |
| 4️⃣ | `LlmRepository` / `LlmJpaRepository` / `LlmRepositoryImpl` 구현 |
| 5️⃣ | `LlmCallRepository` / `LlmCallJpaRepository` / `LlmCallRepositoryImpl` 구현 |
| 6️⃣ | `Llm` / `LlmCall` 엔티티 단위 테스트 추가 및 총 16개 테스트 케이스 통과 확인 |

---

## ✅ 테스트 체크리스트
- [x] 엔티티 생성/상태 변경 기본 동작 확인
- [x] 엔티티 검증 예외 발생 확인
- [x] 테스트 코드 작성 완료
- [x] Llm / LlmCall 엔티티 단위 테스트 16건 통과
- [ ] 레포지토리 통합 테스트는 추후 작성 예정

---

## 🙋‍♀️ 리뷰어 참고사항
- `Llm`은 `BaseEntity`를 상속하여 audit 필드와 soft delete 정책을 따름
- `LlmCall`은 로그성 테이블로 `BaseEntity`를 상속하지 않고 `createdAt`, `createdBy`만 직접 관리
- **활성 LLM은 하나만 유지하며, 관련 정책은 서비스 레벨에서** 제어 예정
- 레포지토리는 인터페이스 / JpaRepository / Impl 구조로 분리
- 현재 PR 범위는 **AI 도메인의 엔티티, 예외, 레포지토리 1차 구현**이며, **엔티티 레벨에서 생성, 수정 시 최소한의 검증**을 수행하도록 설계 및 구현함
