### PR TITLE
feat: 리뷰 엔티티 및 Repo 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/review/domain/entity/Review.java
+++ b/src/main/java/com/sparta/delivery/review/domain/entity/Review.java
@@ -1,0 +1,62 @@
+package com.sparta.delivery.review.domain.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sparta.delivery.common.model.BaseEntity;
+
+@Entity
+@Table(name = "p_review", uniqueConstraints = {@UniqueConstraint(name = "uk_review_order_id", columnNames = "order_id")}, indexes = {@Index(name = "idx_review_store_id", columnList = "store_id")})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseEntity {
+
+    @Builder
+    private Review(UUID orderId, UUID storeId, Long userId, Integer rating, String content) {
+        this.orderId = orderId;
+        this.storeId = storeId;
+        this.userId = userId;
+        this.rating = rating;
+        this.content = content;
+    }
+
+    @Id
+    @Column(name = "review_id", nullable = false, updatable = false)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID reviewId;
+
+    @Column(name = "order_id", nullable = false, updatable = false)
+    private UUID orderId;
+
+    @Column(name = "store_id", nullable = false, updatable = false)
+    private UUID storeId;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(name = "rating", nullable = false)
+    private Integer rating;
+
+    @Column(name = "content")
+    private String content;
+
+    public void update(Integer rating, String content) {
+        this.rating = rating;
+        this.content = content;
+    }
+
+
+}

--- a/src/main/java/com/sparta/delivery/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/delivery/review/domain/repository/ReviewRepository.java
@@ -1,0 +1,20 @@
+package com.sparta.delivery.review.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sparta.delivery.review.domain.entity.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+
+    boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId);
+
+    Page<Review> findByStoreIdAndDeletedAtIsNull(UUID storeId, Pageable pageable);
+
+    Optional<Review> findByReviewIdAndDeletedAtIsNull(UUID reviewId);
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #3 

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Review 도메인 Entity/Repository 1차 구현 |
| 🔍 목적 | 리뷰 도메인 기본 데이터 모델 및 조회/중복 체크용 Repository 메서드 기반 마련 |
| 🛠️ 변경사항 | `Review` 엔티티 추가, `ReviewRepository` 인터페이스 및 메서드 선언 추가 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `Review` 엔티티 생성 (`BaseEntity` 상속, UUID PK, `order_id` UNIQUE, `store_id` 인덱스 반영) |
| 2️⃣ | 리뷰 식별/참조 필드 매핑 (`orderId`, `storeId`, `userId`, `rating`, `content`) 및 수정 메서드(`update`) 추가 |
| 3️⃣ | `ReviewRepository` 추가: `existsByOrderIdAndDeletedAtIsNull`, `findByStoreIdAndDeletedAtIsNull`, `findByReviewIdAndDeletedAtIsNull` |

---

## ✅ 테스트 체크리스트
- [x] 엔티티/리포지토리 컴파일 에러 없이 작성 완료
- [x] Soft Delete 고려한 Repository 메서드 네이밍 반영
- [ ] 서비스/컨트롤러 연동 테스트 (미구현)
- [ ] API(Postman) 테스트 (미구현)
- [ ] 테스트 코드 작성 (미구현)

---

## 🙋‍♀️ 리뷰어 참고사항
- 이번 PR 범위는 **Review Entity + Repository**로 제한했습니다.
- `order_id` 단일 UNIQUE를 우선 반영했습니다.  
  Soft Delete 후 재작성 허용 여부(Partial Unique Index 적용)는 후속 범위에서 검토 예정입니다.
