### PR TITLE
Feat: Product 도메인 엔티티 및 레포지토리 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/product/domain/entity/DescriptionSource.java
+++ b/src/main/java/com/sparta/delivery/product/domain/entity/DescriptionSource.java
@@ -1,0 +1,6 @@
+package com.sparta.delivery.product.domain.entity;
+
+public enum DescriptionSource {
+    MANUAL,
+    AI_GENERATED
+}

--- a/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
+++ b/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
@@ -55,7 +55,7 @@ public class Product extends BaseEntity {
     ) {
         validateStoreId(storeId);
         validateProductName(productName);
-        validateDescription(description, descriptionSource);
+        validateDescriptionForCreate(description, descriptionSource);
         validatePrice(price);
         validateDisplayOrder(displayOrder);
 
@@ -76,18 +76,17 @@ public class Product extends BaseEntity {
     public void updateInfo(
             String productName,
             String description,
-            DescriptionSource descriptionSource,
             Integer price,
             Integer displayOrder
     ) {
         validateProductName(productName);
-        validateDescription(description, descriptionSource);
+        validateDescriptionForUpdate(description);
         validatePrice(price);
         validateDisplayOrder(displayOrder);
 
         this.productName = productName;
         this.description = description;
-        this.descriptionSource = descriptionSource;
+        this.descriptionSource = (description == null) ? null : DescriptionSource.MANUAL;
         this.price = price;
         this.displayOrder = displayOrder;
     }
@@ -107,16 +106,16 @@ public class Product extends BaseEntity {
         }
     }
 
-    // not null, non-blank and no whitespaces-only
+    // not null, non-blank, and max length 100
     private static void validateProductName(String productName) {
-        if (productName == null || productName.isBlank()) {
+        if (productName == null || productName.isBlank() || productName.length() > 100) {
             throw new InvalidProductNameException();
         }
 
     }
 
     // relations between description and description source
-    private static void validateDescription(String description, DescriptionSource descriptionSource) {
+    private static void validateDescriptionForCreate(String description, DescriptionSource descriptionSource) {
         if (description == null && descriptionSource != null) {
             throw new InvalidProductDescriptionException();
         }
@@ -126,6 +125,12 @@ public class Product extends BaseEntity {
         }
     }
 
+    // nullable, but blank-only description is not allowed
+    private static void validateDescriptionForUpdate(String description) {
+        if (description != null && description.isBlank()) {
+            throw new InvalidProductDescriptionException();
+        }
+    }
 
     // not null and greater than 0
     private static void validatePrice(Integer price) {

--- a/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
+++ b/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
@@ -1,0 +1,146 @@
+package com.sparta.delivery.product.domain.entity;
+
+import com.sparta.delivery.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_product")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+    @Id
+    @Column(name = "product_id")
+    private UUID productId;
+
+    @Column(name = "store_id", nullable = false)
+    private UUID storeId;
+
+    @Column(name = "product_name", nullable = false)
+    private String productName;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "description_source")
+    @Enumerated(EnumType.STRING)
+    private DescriptionSource descriptionSource;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Column(name = "is_sold_out", nullable = false)
+    private boolean isSoldOut;
+
+    @Column(name = "is_hidden", nullable = false)
+    private boolean isHidden;
+
+    @Column(name = "display_order")
+    private Integer displayOrder;
+
+    public static Product create(
+            UUID productId,
+            UUID storeId,
+            String productName,
+            String description,
+            DescriptionSource descriptionSource,
+            Integer price,
+            Integer displayOrder
+    ) {
+        validateStoreId(storeId);
+        validateProductName(productName);
+        validateDescription(description, descriptionSource);
+        validatePrice(price);
+        validateDisplayOrder(displayOrder);
+
+        Product product = new Product();
+        product.productId = productId;
+        product.storeId = storeId;
+        product.productName = productName;
+        product.description = description;
+        product.descriptionSource = descriptionSource;
+        product.price = price;
+        product.isSoldOut = false;
+        product.isHidden = false;
+        product.displayOrder = displayOrder;
+
+        return product;
+    }
+
+    public void updateInfo(
+            String productName,
+            String description,
+            DescriptionSource descriptionSource,
+            Integer price,
+            Integer displayOrder
+    ) {
+        validateProductName(productName);
+        validateDescription(description, descriptionSource);
+        validatePrice(price);
+        validateDisplayOrder(displayOrder);
+
+        this.productName = productName;
+        this.description = description;
+        this.descriptionSource = descriptionSource;
+        this.price = price;
+        this.displayOrder = displayOrder;
+    }
+
+    public void changeHidden(boolean hidden) {
+        this.isHidden = hidden;
+    }
+
+    public void changeSoldOut(boolean soldOut) {
+        this.isSoldOut = soldOut;
+    }
+
+    /*
+    TODO: 모든 IllegalArgumentException은 상품 도메인 Exception으로 대체할 예정입니다.
+     */
+
+    // not null
+    private static void validateStoreId(UUID storeId) {
+        if (storeId == null) {
+            throw new IllegalArgumentException("StoreId must not be null");
+        }
+    }
+
+    // not null, non-blank and no whitespaces-only
+    private static void validateProductName(String productName) {
+        if (productName == null || productName.isBlank()) {
+            throw new IllegalArgumentException("ProductName must not be blank");
+        }
+
+    }
+
+    // relations between description and description source
+    private static void validateDescription(String description, DescriptionSource descriptionSource) {
+        if (description == null && descriptionSource != null) {
+            throw new IllegalArgumentException("Description and DescriptionSource must match");
+        }
+
+        if (description != null && descriptionSource == null) {
+            throw new IllegalArgumentException("Description and DescriptionSource must match");
+        }
+    }
+
+
+    // not null and greater than 0
+    private static void validatePrice(Integer price) {
+        if (price == null || price <= 0) {
+            throw new IllegalArgumentException("Price must be greater than 0");
+        }
+    }
+
+    // greater than or equal to 0
+    private static void validateDisplayOrder(Integer displayOrder) {
+        if (displayOrder != null && displayOrder < 0) {
+            throw new IllegalArgumentException("DisplayOrder must be greater than or equal to 0");
+        }
+    }
+}

--- a/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
+++ b/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.product.domain.entity;
 
 import com.sparta.delivery.common.model.BaseEntity;
+import com.sparta.delivery.product.domain.exception.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -99,21 +100,17 @@ public class Product extends BaseEntity {
         this.isSoldOut = soldOut;
     }
 
-    /*
-    TODO: 모든 IllegalArgumentException은 상품 도메인 Exception으로 대체할 예정입니다.
-     */
-
     // not null
     private static void validateStoreId(UUID storeId) {
         if (storeId == null) {
-            throw new IllegalArgumentException("StoreId must not be null");
+            throw new InvalidStoreIdException();
         }
     }
 
     // not null, non-blank and no whitespaces-only
     private static void validateProductName(String productName) {
         if (productName == null || productName.isBlank()) {
-            throw new IllegalArgumentException("ProductName must not be blank");
+            throw new InvalidProductNameException();
         }
 
     }
@@ -121,11 +118,11 @@ public class Product extends BaseEntity {
     // relations between description and description source
     private static void validateDescription(String description, DescriptionSource descriptionSource) {
         if (description == null && descriptionSource != null) {
-            throw new IllegalArgumentException("Description and DescriptionSource must match");
+            throw new InvalidProductDescriptionException();
         }
 
         if (description != null && descriptionSource == null) {
-            throw new IllegalArgumentException("Description and DescriptionSource must match");
+            throw new InvalidProductDescriptionException();
         }
     }
 
@@ -133,14 +130,14 @@ public class Product extends BaseEntity {
     // not null and greater than 0
     private static void validatePrice(Integer price) {
         if (price == null || price <= 0) {
-            throw new IllegalArgumentException("Price must be greater than 0");
+            throw new InvalidProductPriceException();
         }
     }
 
     // greater than or equal to 0
     private static void validateDisplayOrder(Integer displayOrder) {
         if (displayOrder != null && displayOrder < 0) {
-            throw new IllegalArgumentException("DisplayOrder must be greater than or equal to 0");
+            throw new InvalidDisplayOrderException();
         }
     }
 }

--- a/src/main/java/com/sparta/delivery/product/domain/exception/InvalidDisplayOrderException.java
+++ b/src/main/java/com/sparta/delivery/product/domain/exception/InvalidDisplayOrderException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.product.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidDisplayOrderException extends BaseException {
+
+    public InvalidDisplayOrderException() {
+        super(ProductErrorCode.INVALID_DISPLAY_ORDER);
+    }
+}

--- a/src/main/java/com/sparta/delivery/product/domain/exception/InvalidProductDescriptionException.java
+++ b/src/main/java/com/sparta/delivery/product/domain/exception/InvalidProductDescriptionException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.product.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidProductDescriptionException extends BaseException {
+
+    public InvalidProductDescriptionException() {
+        super(ProductErrorCode.INVALID_PRODUCT_DESCRIPTION);
+    }
+}

--- a/src/main/java/com/sparta/delivery/product/domain/exception/InvalidProductNameException.java
+++ b/src/main/java/com/sparta/delivery/product/domain/exception/InvalidProductNameException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.product.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidProductNameException extends BaseException {
+
+    public InvalidProductNameException() {
+        super(ProductErrorCode.INVALID_PRODUCT_NAME);
+    }
+}

--- a/src/main/java/com/sparta/delivery/product/domain/exception/InvalidProductPriceException.java
+++ b/src/main/java/com/sparta/delivery/product/domain/exception/InvalidProductPriceException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.product.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidProductPriceException extends BaseException {
+
+    public InvalidProductPriceException() {
+        super(ProductErrorCode.INVALID_PRODUCT_PRICE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/product/domain/exception/InvalidStoreIdException.java
+++ b/src/main/java/com/sparta/delivery/product/domain/exception/InvalidStoreIdException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.product.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidStoreIdException extends BaseException {
+
+    public InvalidStoreIdException() {
+        super(ProductErrorCode.INVALID_STORE_ID);
+    }
+}

--- a/src/main/java/com/sparta/delivery/product/domain/exception/ProductErrorCode.java
+++ b/src/main/java/com/sparta/delivery/product/domain/exception/ProductErrorCode.java
@@ -1,0 +1,20 @@
+package com.sparta.delivery.product.domain.exception;
+
+import com.sparta.delivery.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+    INVALID_STORE_ID(HttpStatus.BAD_REQUEST, "PRODUCT-001", "유효하지 않은 가게 ID입니다."),
+    INVALID_PRODUCT_NAME(HttpStatus.BAD_REQUEST, "PRODUCT-002", "상품명은 비어 있을 수 없습니다."),
+    INVALID_PRODUCT_DESCRIPTION(HttpStatus.BAD_REQUEST, "PRODUCT-003", "상품 설명과 설명 출처의 조합이 올바르지 않습니다."),
+    INVALID_PRODUCT_PRICE(HttpStatus.BAD_REQUEST, "PRODUCT-004", "상품 가격은 0보다 커야 합니다."),
+    INVALID_DISPLAY_ORDER(HttpStatus.BAD_REQUEST, "PRODUCT-005", "노출 순서는 0 이상이어야 합니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/delivery/product/domain/repository/ProductRepository.java
@@ -1,0 +1,23 @@
+package com.sparta.delivery.product.domain.repository;
+
+import com.sparta.delivery.product.domain.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProductRepository extends JpaRepository<Product, UUID> {
+
+    Optional<Product> findByProductIdAndDeletedAtIsNull(UUID productId);
+
+    /* 기본 목록 조회와 노출 순서(displayOrder) 기준 목록 조회를 분리한다.
+    서비스/유스케이스에 따라 정렬 없는 원본 목록이 필요할 수 있고,
+    사용자 노출용 목록은 displayOrder 기준 정렬이 필요하다. */
+
+    List<Product> findAllByStoreIdAndDeletedAtIsNull(UUID storeId);
+
+    List<Product> findAllByStoreIdAndDeletedAtIsNullOrderByDisplayOrderAsc(UUID storeId);
+
+    boolean existsByStoreIdAndProductNameAndDeletedAtIsNull(UUID storeId, String productName);
+}

--- a/src/test/java/com/sparta/delivery/product/domain/entity/ProductTest.java
+++ b/src/test/java/com/sparta/delivery/product/domain/entity/ProductTest.java
@@ -1,0 +1,532 @@
+package com.sparta.delivery.product.domain.entity;
+
+import com.sparta.delivery.product.domain.exception.InvalidDisplayOrderException;
+import com.sparta.delivery.product.domain.exception.InvalidProductDescriptionException;
+import com.sparta.delivery.product.domain.exception.InvalidProductNameException;
+import com.sparta.delivery.product.domain.exception.InvalidProductPriceException;
+import com.sparta.delivery.product.domain.exception.InvalidStoreIdException;
+import com.sparta.delivery.product.domain.exception.ProductErrorCode;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ProductTest {
+
+    @Test
+    @DisplayName("create should create product successfully with default states")
+    void create_shouldCreateProductSuccessfully_withDefaultStates() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        String productName = "Americano";
+        String description = "극강의 산미, 에티오피아 싱글 아메리카노";
+        DescriptionSource descriptionSource = DescriptionSource.AI_GENERATED;
+        Integer price = 4500;
+        Integer displayOrder = 1;
+
+        // when
+        Product product = Product.create(
+                productId,
+                storeId,
+                productName,
+                description,
+                descriptionSource,
+                price,
+                displayOrder
+        );
+
+        // then
+        assertThat(product.getProductId()).isEqualTo(productId);
+        assertThat(product.getStoreId()).isEqualTo(storeId);
+        assertThat(product.getProductName()).isEqualTo(productName);
+        assertThat(product.getDescription()).isEqualTo(description);
+        assertThat(product.getDescriptionSource()).isEqualTo(descriptionSource);
+        assertThat(product.getPrice()).isEqualTo(price);
+        assertThat(product.getDisplayOrder()).isEqualTo(displayOrder);
+        assertThat(product.isSoldOut()).isFalse();
+        assertThat(product.isHidden()).isFalse();
+    }
+
+    @Test
+    @DisplayName("create should allow null description and null descriptionSource")
+    void create_shouldAllowNullDescriptionAndNullDescriptionSource() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Product product = Product.create(
+                productId,
+                storeId,
+                "Americano",
+                null,
+                null,
+                4500,
+                1
+        );
+
+        // then
+        assertThat(product.getDescription()).isNull();
+        assertThat(product.getDescriptionSource()).isNull();
+    }
+
+    @Test
+    @DisplayName("create should throw when storeId is null")
+    void create_shouldThrow_whenStoreIdIsNull() {
+        // given
+        UUID productId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                null,
+                "Americano",
+                null,
+                null,
+                4500,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidStoreIdException.class);
+        InvalidStoreIdException exception = (InvalidStoreIdException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_STORE_ID.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when productName is null")
+    void create_shouldThrow_whenProductNameIsNull() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                null,
+                null,
+                null,
+                4500,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductNameException.class);
+        InvalidProductNameException exception = (InvalidProductNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when productName is blank")
+    void create_shouldThrow_whenProductNameIsBlank() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                "   ",
+                null,
+                null,
+                4500,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductNameException.class);
+        InvalidProductNameException exception = (InvalidProductNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when productName length exceeds 100")
+    void create_shouldThrow_whenProductNameLengthExceeds100() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        String longName = "a".repeat(101);
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                longName,
+                null,
+                null,
+                4500,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductNameException.class);
+        InvalidProductNameException exception = (InvalidProductNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when description is null and descriptionSource exists")
+    void create_shouldThrow_whenDescriptionIsNullAndDescriptionSourceExists() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                "Americano",
+                null,
+                DescriptionSource.MANUAL,
+                4500,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductDescriptionException.class);
+        InvalidProductDescriptionException exception = (InvalidProductDescriptionException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_DESCRIPTION.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when description exists and descriptionSource is null")
+    void create_shouldThrow_whenDescriptionExistsAndDescriptionSourceIsNull() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                "Americano",
+                "깔끔한 아메리카노",
+                null,
+                4500,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductDescriptionException.class);
+        InvalidProductDescriptionException exception = (InvalidProductDescriptionException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_DESCRIPTION.getCode());
+    }
+
+    @Test
+    @DisplayName("create should allow description and descriptionSource together")
+    void create_shouldAllowDescriptionAndDescriptionSourceTogether() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Product product = Product.create(
+                productId,
+                storeId,
+                "Americano",
+                "깔끔한 아메리카노",
+                DescriptionSource.AI_GENERATED,
+                4500,
+                1
+        );
+
+        // then
+        assertThat(product.getDescription()).isEqualTo("깔끔한 아메리카노");
+        assertThat(product.getDescriptionSource()).isEqualTo(DescriptionSource.AI_GENERATED);
+    }
+
+    @Test
+    @DisplayName("create should throw when price is null")
+    void create_shouldThrow_whenPriceIsNull() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                "Americano",
+                null,
+                null,
+                null,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductPriceException.class);
+        InvalidProductPriceException exception = (InvalidProductPriceException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_PRICE.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when price is zero")
+    void create_shouldThrow_whenPriceIsZero() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                "Americano",
+                null,
+                null,
+                0,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductPriceException.class);
+        InvalidProductPriceException exception = (InvalidProductPriceException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_PRICE.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when price is negative")
+    void create_shouldThrow_whenPriceIsNegative() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                "Americano",
+                null,
+                null,
+                -100,
+                1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductPriceException.class);
+        InvalidProductPriceException exception = (InvalidProductPriceException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_PRICE.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when displayOrder is negative")
+    void create_shouldThrow_whenDisplayOrderIsNegative() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+
+        // when
+        Throwable thrown = catchThrowable(() -> Product.create(
+                productId,
+                storeId,
+                "Americano",
+                null,
+                null,
+                4500,
+                -1
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidDisplayOrderException.class);
+        InvalidDisplayOrderException exception = (InvalidDisplayOrderException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_DISPLAY_ORDER.getCode());
+    }
+
+    @Test
+    @DisplayName("updateInfo should update fields and set descriptionSource to manual when description exists")
+    void updateInfo_shouldUpdateFieldsAndSetDescriptionSourceToManual_whenDescriptionExists() {
+        // given
+        Product product = Product.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Americano",
+                "AI description",
+                DescriptionSource.AI_GENERATED,
+                4500,
+                1
+        );
+
+        // when
+        product.updateInfo(
+                "Cafe Latte",
+                "수기 설명",
+                5500,
+                2
+        );
+
+        // then
+        assertThat(product.getProductName()).isEqualTo("Cafe Latte");
+        assertThat(product.getDescription()).isEqualTo("수기 설명");
+        assertThat(product.getDescriptionSource()).isEqualTo(DescriptionSource.MANUAL);
+        assertThat(product.getPrice()).isEqualTo(5500);
+        assertThat(product.getDisplayOrder()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("updateInfo should set descriptionSource to null when description is null")
+    void updateInfo_shouldSetDescriptionSourceToNull_whenDescriptionIsNull() {
+        // given
+        Product product = Product.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Americano",
+                "AI description",
+                DescriptionSource.AI_GENERATED,
+                4500,
+                1
+        );
+
+        // when
+        product.updateInfo(
+                "Cafe Latte",
+                null,
+                5500,
+                2
+        );
+
+        // then
+        assertThat(product.getDescription()).isNull();
+        assertThat(product.getDescriptionSource()).isNull();
+    }
+
+    @Test
+    @DisplayName("updateInfo should throw when description is blank")
+    void updateInfo_shouldThrow_whenDescriptionIsBlank() {
+        // given
+        Product product = Product.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Americano",
+                null,
+                null,
+                4500,
+                1
+        );
+
+        // when
+        Throwable thrown = catchThrowable(() -> product.updateInfo(
+                "Cafe Latte",
+                "   ",
+                5500,
+                2
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProductDescriptionException.class);
+        InvalidProductDescriptionException exception = (InvalidProductDescriptionException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ProductErrorCode.INVALID_PRODUCT_DESCRIPTION.getCode());
+    }
+
+    @Test
+    @DisplayName("changeHidden should change hidden state")
+    void changeHidden_shouldChangeHiddenState() {
+        // given
+        Product product = Product.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Americano",
+                null,
+                null,
+                4500,
+                1
+        );
+
+        // when
+        product.changeHidden(true);
+
+        // then
+        assertThat(product.isHidden()).isTrue();
+
+        // when
+        product.changeHidden(false);
+
+        // then
+        assertThat(product.isHidden()).isFalse();
+    }
+
+    @Test
+    @DisplayName("changeSoldOut should change soldOut state")
+    void changeSoldOut_shouldChangeSoldOutState() {
+        // given
+        Product product = Product.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Americano",
+                null,
+                null,
+                4500,
+                1
+        );
+
+        // when
+        product.changeSoldOut(true);
+
+        // then
+        assertThat(product.isSoldOut()).isTrue();
+
+        // when
+        product.changeSoldOut(false);
+
+        // then
+        assertThat(product.isSoldOut()).isFalse();
+    }
+
+    @Test
+    @DisplayName("softDelete should mark product as deleted")
+    void softDelete_shouldMarkProductAsDeleted() {
+        // given
+        Product product = Product.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Americano",
+                null,
+                null,
+                4500,
+                1
+        );
+        Long deletedBy = 1L;
+        LocalDateTime before = LocalDateTime.now();
+
+        // when
+        product.softDelete(deletedBy);
+
+        LocalDateTime after = LocalDateTime.now();
+
+        // then
+        assertThat(product.isDeleted()).isTrue();
+        assertThat(product.getDeletedBy()).isEqualTo(deletedBy);
+        assertThat(product.getDeletedAt()).isNotNull();
+        assertThat(product.getDeletedAt()).isBetween(before, after);
+    }
+
+    @Test
+    @DisplayName("softDelete should keep first deleted state when called twice")
+    void softDelete_shouldKeepFirstDeletedState_whenCalledTwice() {
+        // given
+        Product product = Product.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Americano",
+                null,
+                null,
+                4500,
+                1
+        );
+
+        // when
+        product.softDelete(1L);
+        LocalDateTime firstDeletedAt = product.getDeletedAt();
+        Long firstDeletedBy = product.getDeletedBy();
+
+        product.softDelete(2L);
+
+        // then
+        assertThat(product.isDeleted()).isTrue();
+        assertThat(product.getDeletedAt()).isEqualTo(firstDeletedAt);
+        assertThat(product.getDeletedBy()).isEqualTo(firstDeletedBy);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #14

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Product 도메인 엔티티 및 Repository 구현 |
| 🔍 목적 | 상품 관리 기능 지원을 위한 Product 도메인 구조 구성 |
| 🛠️ 변경사항 | `Product` 엔티티, `DescriptionSource`, `ProductErrorCode` 및 도메인 예외, `ProductRepository` 구현 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `p_product` 테이블 기준 `Product` 엔티티 구현 |
| 2️⃣ | `DescriptionSource` enum 작성 |
| 3️⃣ | `ProductErrorCode` 및 `BaseException` 상속 도메인 예외 클래스 작성 |
| 4️⃣ | `ProductRepository` 구현 및 기본 조회 메서드 정의 |
| 5️⃣ | `Product` 엔티티 단위 테스트 추가 및 총 20개 테스트 케이스 통과 확인 |

---

## ✅ 테스트 체크리스트
- [x] 엔티티 생성/상태 변경 기본 동작 확인
- [x] 엔티티 검증 예외 발생 확인
- [x] 테스트 코드 작성 완료
- [x] `Product` 엔티티 단위 테스트 20건 통과
- [ ] 레포지토리 통합 테스트는 추후 작성 예정

---

## 🙋‍♀️ 리뷰어 참고사항
- `Product`는 `BaseEntity`를 상속하여 audit 필드와 soft delete 정책을 따름
- 상품 설명은 `description`과 `descriptionSource` 조합으로 관리
- 생성 시 `AI_GENERATED`, `MANUAL` 모두 가능하며, 수정 시 설명이 존재하면 `descriptionSource`는 `MANUAL`로 처리되도록 구현
- 숨김/품절 상태 변경은 엔티티 메서드에서 단순 상태 변경으로 처리
- 레포지토리는 `domain/repository` 단일 인터페이스에서 `JpaRepository`를 직접 상속하는 방식으로 통일
- 현재 PR 범위는 Product 도메인의 엔티티, 예외, 레포지토리 1차 구현이며, 엔티티 레벨에서 생성/수정 시 최소한의 검증을 수행하도록 설계함