### PR TITLE
feat: 결제 엔티티 및 repo 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/payment/domain/entity/Payment.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/entity/Payment.java
@@ -1,0 +1,112 @@
+package com.sparta.delivery.payment.domain.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sparta.delivery.common.model.BaseEntity;
+
+@Entity
+@Table(name = "p_payment", uniqueConstraints = {@UniqueConstraint(name = "uk_payment_order_id", columnNames = "order_id")})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
+
+    @Id
+    @Column(name = "payment_id", nullable = false, updatable = false)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID paymentId;
+
+    @Column(name = "order_id", nullable = false, updatable = false)
+    private UUID orderId;
+
+    @Column(name = "payment_method", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
+
+    @Column(name = "payment_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus paymentStatus;
+
+    @Column(name = "total_price", nullable = false)
+    private Integer totalPrice;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+
+    @Column(name = "failed_at")
+    private LocalDateTime failedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Column(name = "failure_reason", length = 255)
+    private String failureReason;
+
+    @Column(name = "pg_provider", length = 50)
+    private String pgProvider;
+
+    @Column(name = "pg_transaction_id", length = 100)
+    private String pgTransactionId;
+
+    @Builder
+    private Payment(UUID orderId, PaymentMethod paymentMethod, Integer totalPrice, LocalDateTime approvedAt, LocalDateTime failedAt, LocalDateTime cancelledAt, String failureReason, String pgProvider, String pgTransactionId) {
+        this.orderId = orderId;
+        this.paymentMethod = paymentMethod;
+        this.paymentStatus = PaymentStatus.PENDING;
+        this.totalPrice = totalPrice;
+        this.approvedAt = approvedAt;
+        this.failedAt = failedAt;
+        this.cancelledAt = cancelledAt;
+        this.failureReason = failureReason;
+        this.pgProvider = pgProvider;
+        this.pgTransactionId = pgTransactionId;
+    }
+
+    public void approve(String pgProvider, String pgTransactionId) {
+        if(this.paymentStatus != PaymentStatus.PENDING) {
+            throw new IllegalStateException();
+        }
+
+        this.paymentStatus = PaymentStatus.APPROVED;
+        this.approvedAt = LocalDateTime.now();
+        this.pgProvider = pgProvider;
+        this.pgTransactionId = pgTransactionId;
+    }
+
+    public void fail(String failureReason) {
+
+        if(this.paymentStatus != PaymentStatus.PENDING) {
+            throw new IllegalStateException();
+        }
+
+        this.paymentStatus = PaymentStatus.FAILED;
+        this.failedAt = LocalDateTime.now();
+        this.failureReason = failureReason;
+    }
+
+    public void cancel() {
+
+        if(this.paymentStatus != PaymentStatus.APPROVED) {
+            throw new IllegalStateException();
+        }
+
+        this.cancelledAt = LocalDateTime.now();
+        this.paymentStatus = PaymentStatus.CANCELLED;
+    }
+
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/entity/PaymentMethod.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/entity/PaymentMethod.java
@@ -1,0 +1,5 @@
+package com.sparta.delivery.payment.domain.entity;
+
+public enum PaymentMethod {
+    CARD
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/entity/PaymentStatus.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/entity/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.sparta.delivery.payment.domain.entity;
+
+public enum PaymentStatus {
+    PENDING,
+    APPROVED,
+    FAILED,
+    CANCELLED
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/repository/PaymentRepository.java
@@ -1,0 +1,18 @@
+package com.sparta.delivery.payment.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sparta.delivery.payment.domain.entity.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+
+    boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId);
+
+    Optional<Payment> findByOrderIdAndDeletedAtIsNull(UUID orderId);
+
+    Optional<Payment> findByPaymentIdAndDeletedAtIsNull(UUID paymentId);
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #4

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Payment 도메인 Entity/Repository 1차 구현 |
| 🔍 목적 | 결제 도메인의 기본 데이터 모델과 중복 결제 방지/조회 기반 마련 |
| 🛠️ 변경사항 | `Payment` 엔티티 + 상태 전이 메서드, `PaymentMethod/PaymentStatus` enum, `PaymentRepository` 메서드 추가 |


## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `Payment` 엔티티 생성: `BaseEntity` 상속, `p_payment` 매핑, `order_id` UNIQUE 제약, UUID PK, 컬럼 길이 제약(`failure_reason`, `pg_provider`, `pg_transaction_id`) 반영 |
| 2️⃣ | 결제 상태 전이 메서드 추가: `approve`, `fail`, `cancel` (가드 조건 + 상태별 timestamp 세팅) |
| 3️⃣ | `PaymentMethod(CARD)`, `PaymentStatus(PENDING/APPROVED/FAILED/CANCELLED)` enum 추가 및 `PaymentRepository` 조회/중복확인 메서드 추가 |


---

## ✅ 테스트 체크리스트
- [x] `./gradlew compileJava` 빌드 성공
- [x] Repository 메서드 선언 확인 (`existsByOrderIdAndDeletedAtIsNull`, `findByOrderIdAndDeletedAtIsNull`, `findByPaymentIdAndDeletedAtIsNull`)
- [ ] 서비스/컨트롤러 연동 테스트 (미구현)
- [ ] API(Postman) 테스트 (미구현)
- [ ] 테스트 코드 작성 (미구현)

---

## 📸 포스트맨 캡처 사진

---

## 🙋‍♀️ 리뷰어 참고사항
- 이번 PR 범위는 **Payment Entity + Repository**로 제한했습니다.
- 현재 정책상 `order_id` UNIQUE로 주문당 결제 row 1건을 유지합니다.
- 상태 전이 예외는 우선 `IllegalStateException`으로 처리했으며, 도메인 예외는 후속 작업에서 정리 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 결제 기능 추가: 대기, 승인, 실패, 취소 상태 관리
  * 카드 결제 방식 지원
  * 주문별 결제 조회 및 처리 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->