### PR TITLE
refactor: AI 도메인 UUID 및 검증 책임 정리

### DIFF
--- a/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
@@ -3,23 +3,23 @@ package com.sparta.delivery.ai.domain.entity;
 
 import com.sparta.delivery.ai.domain.exception.InvalidLlmNameException;
 import com.sparta.delivery.common.model.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "p_llms")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Llm extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "llm_id")
     private UUID llmId;
 
@@ -29,11 +29,10 @@ public class Llm extends BaseEntity {
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
 
-    public static Llm create(UUID llmId, String llmName, boolean isActive) {
+    public static Llm create(String llmName, boolean isActive) {
         validateLlmName(llmName);
 
         Llm llm = new Llm();
-        llm.llmId = llmId;
         llm.llmName = llmName;
         llm.isActive = isActive;
 
@@ -55,7 +54,7 @@ public class Llm extends BaseEntity {
 
     // not null, non-blank and max length 100
     private static void validateLlmName(String llmName) {
-        if (llmName == null || llmName.isBlank() || llmName.length() > 100) {
+        if (llmName.length() > 100) {
             throw new InvalidLlmNameException();
         }
     }

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
@@ -1,11 +1,6 @@
 package com.sparta.delivery.ai.domain.entity;
 
-import com.sparta.delivery.ai.domain.exception.InvalidCreatedByException;
-import com.sparta.delivery.ai.domain.exception.InvalidInputSnapshotException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +15,7 @@ import java.util.UUID;
 public class LlmCall {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "call_id")
     private UUID callId;
 
@@ -48,7 +44,6 @@ public class LlmCall {
     private Long createdBy;
 
     public static LlmCall create(
-            UUID callId,
             UUID llmId,
             UUID productId,
             String inputSnapshot,
@@ -57,11 +52,7 @@ public class LlmCall {
             String generatedText,
             Long createdBy
     ) {
-        validateInputSnapshot(inputSnapshot);
-        validateCreatedBy(createdBy);
-
         LlmCall llmCall = new LlmCall();
-        llmCall.callId = callId;
         llmCall.llmId = llmId;
         llmCall.productId = productId;
         llmCall.inputSnapshot = inputSnapshot;
@@ -73,17 +64,4 @@ public class LlmCall {
         return llmCall;
     }
 
-    // not null and non-blank
-    private static void validateInputSnapshot(String inputSnapshot) {
-        if (inputSnapshot == null || inputSnapshot.isBlank()) {
-            throw new InvalidInputSnapshotException();
-        }
-    }
-
-    // not null
-    private static void validateCreatedBy(Long createdBy) {
-        if (createdBy == null) {
-            throw new InvalidCreatedByException();
-        }
-    }
 }

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
@@ -9,9 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AiErrorCode implements ErrorCode {
-    INVALID_LLM_NAME(HttpStatus.BAD_REQUEST, "AI-001", "모델 이름은 100자를 넘을 수 없습니다."),
-    INVALID_INPUT_SNAPSHOT(HttpStatus.BAD_REQUEST, "AI-002", "유효하지 않은 입력 스냅샷입니다."),
-    INVALID_CREATED_BY(HttpStatus.BAD_REQUEST, "AI-003", "유효하지 않은 생성자 정보입니다.");
+    INVALID_LLM_NAME(HttpStatus.BAD_REQUEST, "AI-001", "모델 이름은 100자를 넘을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AiErrorCode implements ErrorCode {
-    INVALID_LLM_NAME(HttpStatus.BAD_REQUEST, "AI-001", "유효하지 않은 모델 이름입니다."),
+    INVALID_LLM_NAME(HttpStatus.BAD_REQUEST, "AI-001", "모델 이름은 100자를 넘을 수 없습니다."),
     INVALID_INPUT_SNAPSHOT(HttpStatus.BAD_REQUEST, "AI-002", "유효하지 않은 입력 스냅샷입니다."),
     INVALID_CREATED_BY(HttpStatus.BAD_REQUEST, "AI-003", "유효하지 않은 생성자 정보입니다.");
 

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidCreatedByException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidCreatedByException.java
@@ -1,9 +1,0 @@
-package com.sparta.delivery.ai.domain.exception;
-
-import com.sparta.delivery.common.exception.BaseException;
-
-public class InvalidCreatedByException extends BaseException {
-    public InvalidCreatedByException() {
-        super(AiErrorCode.INVALID_CREATED_BY);
-    }
-}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidInputSnapshotException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidInputSnapshotException.java
@@ -1,9 +1,0 @@
-package com.sparta.delivery.ai.domain.exception;
-
-import com.sparta.delivery.common.exception.BaseException;
-
-public class InvalidInputSnapshotException extends BaseException {
-    public InvalidInputSnapshotException() {
-        super(AiErrorCode.INVALID_INPUT_SNAPSHOT);
-    }
-}

--- a/src/main/java/com/sparta/delivery/ai/domain/repository/LlmRepository.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/repository/LlmRepository.java
@@ -7,9 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LlmRepository extends JpaRepository<Llm, UUID> {
 
-    Optional<Llm> findByLlmIdAndDeletedAtIsNull(UUID llmId);
+    Optional<Llm> findByLlmId(UUID llmId);
 
-    Optional<Llm> findByIsActiveTrueAndDeletedAtIsNull();
+    Optional<Llm> findByIsActiveTrue();
 
-    boolean existsByLlmNameAndDeletedAtIsNull(String llmName);
+    boolean existsByLlmName(String llmName);
 }

--- a/src/test/java/com/sparta/delivery/ai/domain/entity/LlmCallTest.java
+++ b/src/test/java/com/sparta/delivery/ai/domain/entity/LlmCallTest.java
@@ -1,14 +1,12 @@
 package com.sparta.delivery.ai.domain.entity;
 
-import com.sparta.delivery.ai.domain.exception.AiErrorCode;
-import com.sparta.delivery.ai.domain.exception.InvalidCreatedByException;
-import com.sparta.delivery.ai.domain.exception.InvalidInputSnapshotException;
-import java.time.LocalDateTime;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LlmCallTest {
 
@@ -16,7 +14,6 @@ class LlmCallTest {
     @DisplayName("create should create llmCall successfully")
     void create_shouldCreateLlmCallSuccessfully() {
         // given
-        UUID callId = UUID.randomUUID();
         UUID llmId = UUID.randomUUID();
         UUID productId = UUID.randomUUID();
         String inputSnapshot = "{\"productName\":\"Americano\",\"price\":4500}";
@@ -29,7 +26,6 @@ class LlmCallTest {
 
         // when
         LlmCall llmCall = LlmCall.create(
-                callId,
                 llmId,
                 productId,
                 inputSnapshot,
@@ -42,7 +38,6 @@ class LlmCallTest {
         LocalDateTime after = LocalDateTime.now();
 
         // then
-        assertThat(llmCall.getCallId()).isEqualTo(callId);
         assertThat(llmCall.getLlmId()).isEqualTo(llmId);
         assertThat(llmCall.getProductId()).isEqualTo(productId);
         assertThat(llmCall.getInputSnapshot()).isEqualTo(inputSnapshot);
@@ -52,83 +47,5 @@ class LlmCallTest {
         assertThat(llmCall.getCreatedBy()).isEqualTo(createdBy);
         assertThat(llmCall.getCreatedAt()).isNotNull();
         assertThat(llmCall.getCreatedAt()).isBetween(before, after);
-    }
-
-    @Test
-    @DisplayName("create should throw when inputSnapshot is null")
-    void create_shouldThrow_whenInputSnapshotIsNull() {
-        // given
-        UUID callId = UUID.randomUUID();
-        UUID llmId = UUID.randomUUID();
-        UUID productId = UUID.randomUUID();
-
-        // when
-        Throwable thrown = catchThrowable(() -> LlmCall.create(
-                callId,
-                llmId,
-                productId,
-                null,
-                "200",
-                "{\"result\":\"ok\"}",
-                "generated text",
-                1L
-        ));
-
-        // then
-        assertThat(thrown).isInstanceOf(InvalidInputSnapshotException.class);
-        InvalidInputSnapshotException exception = (InvalidInputSnapshotException) thrown;
-        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_INPUT_SNAPSHOT.getCode());
-    }
-
-    @Test
-    @DisplayName("create should throw when inputSnapshot is blank")
-    void create_shouldThrow_whenInputSnapshotIsBlank() {
-        // given
-        UUID callId = UUID.randomUUID();
-        UUID llmId = UUID.randomUUID();
-        UUID productId = UUID.randomUUID();
-
-        // when
-        Throwable thrown = catchThrowable(() -> LlmCall.create(
-                callId,
-                llmId,
-                productId,
-                "   ",
-                "200",
-                "{\"result\":\"ok\"}",
-                "generated text",
-                1L
-        ));
-
-        // then
-        assertThat(thrown).isInstanceOf(InvalidInputSnapshotException.class);
-        InvalidInputSnapshotException exception = (InvalidInputSnapshotException) thrown;
-        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_INPUT_SNAPSHOT.getCode());
-    }
-
-    @Test
-    @DisplayName("create should throw when createdBy is null")
-    void create_shouldThrow_whenCreatedByIsNull() {
-        // given
-        UUID callId = UUID.randomUUID();
-        UUID llmId = UUID.randomUUID();
-        UUID productId = UUID.randomUUID();
-
-        // when
-        Throwable thrown = catchThrowable(() -> LlmCall.create(
-                callId,
-                llmId,
-                productId,
-                "{\"productName\":\"Americano\"}",
-                "200",
-                "{\"result\":\"ok\"}",
-                "generated text",
-                null
-        ));
-
-        // then
-        assertThat(thrown).isInstanceOf(InvalidCreatedByException.class);
-        InvalidCreatedByException exception = (InvalidCreatedByException) thrown;
-        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_CREATED_BY.getCode());
     }
 }

--- a/src/test/java/com/sparta/delivery/ai/domain/entity/LlmTest.java
+++ b/src/test/java/com/sparta/delivery/ai/domain/entity/LlmTest.java
@@ -2,12 +2,13 @@ package com.sparta.delivery.ai.domain.entity;
 
 import com.sparta.delivery.ai.domain.exception.AiErrorCode;
 import com.sparta.delivery.ai.domain.exception.InvalidLlmNameException;
-import java.time.LocalDateTime;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class LlmTest {
 
@@ -15,58 +16,25 @@ class LlmTest {
     @DisplayName("create should create llm successfully")
     void create_shouldCreateLlmSuccessfully() {
         // given
-        UUID llmId = UUID.randomUUID();
         String llmName = "gemini-1.5-flash";
         boolean isActive = true;
 
         // when
-        Llm llm = Llm.create(llmId, llmName, isActive);
+        Llm llm = Llm.create(llmName, isActive);
 
         // then
-        assertThat(llm.getLlmId()).isEqualTo(llmId);
         assertThat(llm.getLlmName()).isEqualTo(llmName);
         assertThat(llm.isActive()).isTrue();
-    }
-
-    @Test
-    @DisplayName("create should throw when llmName is null")
-    void create_shouldThrow_whenLlmNameIsNull() {
-        // given
-        UUID llmId = UUID.randomUUID();
-
-        // when
-        Throwable thrown = catchThrowable(() -> Llm.create(llmId, null, false));
-
-        // then
-        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
-        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
-        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
-    }
-
-    @Test
-    @DisplayName("create should throw when llmName is blank")
-    void create_shouldThrow_whenLlmNameIsBlank() {
-        // given
-        UUID llmId = UUID.randomUUID();
-
-        // when
-        Throwable thrown = catchThrowable(() -> Llm.create(llmId, "   ", false));
-
-        // then
-        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
-        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
-        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
     }
 
     @Test
     @DisplayName("create should throw when llmName length exceeds 100")
     void create_shouldThrow_whenLlmNameLengthExceeds100() {
         // given
-        UUID llmId = UUID.randomUUID();
         String llmName = "a".repeat(101);
 
         // when
-        Throwable thrown = catchThrowable(() -> Llm.create(llmId, llmName, false));
+        Throwable thrown = catchThrowable(() -> Llm.create(llmName, false));
 
         // then
         assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
@@ -78,7 +46,7 @@ class LlmTest {
     @DisplayName("updateName should change llmName successfully")
     void updateName_shouldChangeLlmNameSuccessfully() {
         // given
-        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", false);
         String updatedName = "gemini-2.0-flash";
 
         // when
@@ -89,40 +57,10 @@ class LlmTest {
     }
 
     @Test
-    @DisplayName("updateName should throw when llmName is null")
-    void updateName_shouldThrow_whenLlmNameIsNull() {
-        // given
-        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
-
-        // when
-        Throwable thrown = catchThrowable(() -> llm.updateName(null));
-
-        // then
-        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
-        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
-        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
-    }
-
-    @Test
-    @DisplayName("updateName should throw when llmName is blank")
-    void updateName_shouldThrow_whenLlmNameIsBlank() {
-        // given
-        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
-
-        // when
-        Throwable thrown = catchThrowable(() -> llm.updateName("   "));
-
-        // then
-        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
-        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
-        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
-    }
-
-    @Test
     @DisplayName("updateName should throw when llmName length exceeds 100")
     void updateName_shouldThrow_whenLlmNameLengthExceeds100() {
         // given
-        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", false);
 
         // when
         Throwable thrown = catchThrowable(() -> llm.updateName("a".repeat(101)));
@@ -137,7 +75,7 @@ class LlmTest {
     @DisplayName("activate should set isActive to true")
     void activate_shouldSetIsActiveToTrue() {
         // given
-        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", false);
 
         // when
         llm.activate();
@@ -150,7 +88,7 @@ class LlmTest {
     @DisplayName("deactivate should set isActive to false")
     void deactivate_shouldSetIsActiveToFalse() {
         // given
-        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", true);
+        Llm llm = Llm.create("gemini-1.5-flash", true);
 
         // when
         llm.deactivate();
@@ -163,7 +101,7 @@ class LlmTest {
     @DisplayName("softDelete should mark entity as deleted")
     void softDelete_shouldMarkEntityAsDeleted() {
         // given
-        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", false);
         Long deletedBy = 1L;
 
         // when
@@ -179,7 +117,7 @@ class LlmTest {
     @DisplayName("softDelete should keep first deleted state when called twice")
     void softDelete_shouldKeepFirstDeletedState_whenCalledTwice() {
         // given
-        Llm llm = Llm.create(UUID.randomUUID(), "gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", false);
 
         // when
         llm.softDelete(1L);


### PR DESCRIPTION
## 📌 관련 이슈
- Relates to #29 

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | AI 도메인 엔티티 리팩터링 |
| 🔍 목적 | AI 도메인 엔티티를 팀 컨벤션에 맞춰 UUID 생성 전략과 검증 책임을 정리하기 위함 |
| 🛠️ 변경사항 | `Llm`, `LlmCall`의 생성 정책을 정리하고, 입력 검증 책임을 DTO 레이어 기준으로 맞추며, 관련 테스트/예외 코드를 정리 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `Llm` 엔티티의 UUID 생성 전략을 `@GeneratedValue(strategy = GenerationType.UUID)`로 정리 |
| 2️⃣ | `Llm` 엔티티에 `@SQLRestriction("deleted_at IS NULL")`를 적용하고 레포지토리 조회 메서드를 이에 맞게 정리 |
| 3️⃣ | `Llm`, `LlmCall` 엔티티에서 null/blank 등 입력 형식 검증 책임을 DTO 레이어로 분리하고(추후 실제 구현 예정), 엔티티에는 도메인 불변식만 남기도록 정리 |
| 4️⃣ | `LlmCall`의 생성 경로에서 `callId` 직접 주입을 제거하고 UUID 자동 생성 방식으로 정리 |
| 5️⃣ | 변경된 정책에 맞춰 관련 예외 코드와 엔티티 테스트를 정리 |

---

## ✅ 테스트 체크리스트
- [x] `LlmTest` 기준 생성/수정/soft delete 관련 단위 테스트 정리 및 영향 여부 확인
- [x] `LlmCallTest` 기준 생성 성공 시나리오 단위 테스트 정리 및 영향 여부 확인
- [ ] `@SQLRestriction("deleted_at IS NULL")` 동작에 대한 리포지토리/통합 테스트는 추후 보완 예정

---

## 🙋‍♀️ 리뷰어 참고사항
- 팀 컨벤션에 따라 null/blank 등 입력 형식 검증은 DTO validation 레이어에서 처리하고, 엔티티는 DTO validation을 통과한 값을 전제로 도메인 불변식만 검증하도록 정리
- 호출 이력 보존 목적의 `LlmCall`은 soft delete 대상에서 제외

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * AI 모델 생성 프로세스를 간소화했습니다.
  * 모델 이름 길이 검증 메시지를 명확하게 개선했습니다.
  * 데이터 접근 계층의 쿼리 처리 로직을 최적화했습니다.

* **테스트**
  * 업데이트된 엔티티 생성 로직에 맞춰 테스트를 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->