### PR TITLE
feat: Region 도메인 서비스 로직 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/region/application/RegionService.java
+++ b/src/main/java/com/sparta/delivery/region/application/RegionService.java
@@ -1,0 +1,126 @@
+package com.sparta.delivery.region.application;
+
+import com.sparta.delivery.region.domain.entity.Region;
+import com.sparta.delivery.region.domain.exception.DuplicateRegionCodeException;
+import com.sparta.delivery.region.domain.exception.InvalidParentRegionException;
+import com.sparta.delivery.region.domain.exception.InvalidRegionDepthException;
+import com.sparta.delivery.region.domain.exception.RegionHasChildrenException;
+import com.sparta.delivery.region.domain.exception.RegionNotFoundException;
+import com.sparta.delivery.region.domain.repository.RegionRepository;
+import com.sparta.delivery.region.presentation.dto.RegionCreateRequest;
+import com.sparta.delivery.region.presentation.dto.RegionResponse;
+import com.sparta.delivery.region.presentation.dto.RegionUpdateRequest;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RegionService {
+
+    private final RegionRepository regionRepository;
+
+    /** 지역 생성 */
+    @Transactional
+    public RegionResponse createRegion(RegionCreateRequest request) {
+        validateDuplicateRegionCode(request.regionCode());
+        validateParentAndDepth(request.parentId(), request.depth());
+
+        Region region = Region.create(
+                request.regionCode(),
+                request.regionName(),
+                request.parentId(),
+                request.depth(),
+                request.isActive()
+        );
+
+        return RegionResponse.from(regionRepository.save(region));
+    }
+
+    /** 지역 단건 조회 */
+    public RegionResponse getRegion(UUID regionId) {
+        Region region = getRegionOrThrow(regionId);
+        return RegionResponse.from(region);
+    }
+
+    /** 최상위 지역 목록 조회 */
+    public List<RegionResponse> getRootRegions() {
+        return regionRepository.findByParentIdIsNull().stream()
+                .map(RegionResponse::from)
+                .toList();
+    }
+
+    /** 특정 지역의 하위 지역 목록 조회 */
+    public List<RegionResponse> getChildRegions(UUID parentId) {
+        return regionRepository.findByParentId(parentId).stream()
+                .map(RegionResponse::from)
+                .toList();
+    }
+
+    /** 지역 정보 수정 */
+    @Transactional
+    public RegionResponse updateRegion(UUID regionId, RegionUpdateRequest request) {
+        Region region = getRegionOrThrow(regionId);
+
+        // 자기 자신을 부모로 지정할 수 없음
+        if (request.parentId() != null && request.parentId().equals(regionId)) {
+            throw new InvalidParentRegionException();
+        }
+
+        validateParentAndDepth(request.parentId(), request.depth());
+
+        region.update(
+                request.regionName(),
+                request.parentId(),
+                request.depth(),
+                request.isActive()
+        );
+
+        return RegionResponse.from(region);
+    }
+
+    /** 하위 지역이 없을 때만 삭제 */
+    @Transactional
+    public void deleteRegion(UUID regionId, Long currentUserId) {
+        Region region = getRegionOrThrow(regionId);
+
+        if (!regionRepository.findByParentId(regionId).isEmpty()) {
+            throw new RegionHasChildrenException();
+        }
+
+        region.softDelete(currentUserId);
+    }
+
+    /** 지역 조회, 없으면 예외 */
+    private Region getRegionOrThrow(UUID regionId) {
+        return regionRepository.findByRegionId(regionId)
+                .orElseThrow(RegionNotFoundException::new);
+    }
+
+    /** 지역 코드 중복 검사 */
+    private void validateDuplicateRegionCode(String regionCode) {
+        if (regionRepository.existsByRegionCode(regionCode)) {
+            throw new DuplicateRegionCodeException();
+        }
+    }
+
+    /** 부모 지역과 depth 규칙 검사 */
+    private void validateParentAndDepth(UUID parentId, Integer depth) {
+        if (parentId == null) {
+            if (depth != 1) {
+                throw new InvalidRegionDepthException();
+            }
+            return;
+        }
+
+        Region parent = regionRepository.findByRegionId(parentId)
+                .orElseThrow(InvalidParentRegionException::new);
+
+        if (depth != parent.getDepth() + 1) {
+            throw new InvalidRegionDepthException();
+        }
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/entity/Region.java
+++ b/src/main/java/com/sparta/delivery/region/domain/entity/Region.java
@@ -2,22 +2,28 @@ package com.sparta.delivery.region.domain.entity;
 
 
 import com.sparta.delivery.common.model.BaseEntity;
+import com.sparta.delivery.region.domain.exception.InvalidRegionActiveStatusException;
+import com.sparta.delivery.region.domain.exception.InvalidRegionCodeException;
+import com.sparta.delivery.region.domain.exception.InvalidRegionDepthException;
+import com.sparta.delivery.region.domain.exception.InvalidRegionNameException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "p_region")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Region extends BaseEntity {
+    private static final String REGION_CODE_PATTERN = "^\\d{10}$";
+
     @Id
-    @GeneratedValue
-    @UuidGenerator
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "region_id", updatable = false, nullable = false)
     private UUID regionId;
 
@@ -37,6 +43,11 @@ public class Region extends BaseEntity {
     private Boolean isActive;
 
     private Region(String regionCode, String regionName, UUID parentId, Integer depth, Boolean isActive) {
+        validateRegionCode(regionCode);
+        validateRegionName(regionName);
+        validateDepth(depth);
+        validateIsActive(isActive);
+
         this.regionCode = regionCode;
         this.regionName = regionName;
         this.parentId = parentId;
@@ -54,6 +65,10 @@ public class Region extends BaseEntity {
             Integer depth,
             Boolean isActive
     ) {
+        validateRegionName(regionName);
+        validateDepth(depth);
+        validateIsActive(isActive);
+
         this.regionName = regionName;
         this.parentId = parentId;
         this.depth = depth;
@@ -66,5 +81,29 @@ public class Region extends BaseEntity {
 
     public void activate() {
         this.isActive = true;
+    }
+
+    private static void validateRegionCode(String regionCode) {
+        if (regionCode == null || !regionCode.matches(REGION_CODE_PATTERN)) {
+            throw new InvalidRegionCodeException();
+        }
+    }
+
+    private static void validateRegionName(String regionName) {
+        if (regionName == null || regionName.isBlank()) {
+            throw new InvalidRegionNameException();
+        }
+    }
+
+    private static void validateDepth(Integer depth) {
+        if (depth == null || depth < 1) {
+            throw new InvalidRegionDepthException();
+        }
+    }
+
+    private static void validateIsActive(Boolean isActive) {
+        if (isActive == null) {
+            throw new InvalidRegionActiveStatusException();
+        }
     }
 }

--- a/src/main/java/com/sparta/delivery/region/domain/exception/DuplicateRegionCodeException.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/DuplicateRegionCodeException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.region.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class DuplicateRegionCodeException extends BaseException {
+
+    public DuplicateRegionCodeException() {
+        super(RegionErrorCode.DUPLICATE_REGION_CODE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/exception/InvalidParentRegionException.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/InvalidParentRegionException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.region.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidParentRegionException extends BaseException {
+
+    public InvalidParentRegionException() {
+        super(RegionErrorCode.INVALID_PARENT_REGION);
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/exception/InvalidRegionActiveStatusException.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/InvalidRegionActiveStatusException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.region.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidRegionActiveStatusException extends BaseException {
+
+    public InvalidRegionActiveStatusException() {
+        super(RegionErrorCode.INVALID_REGION_ACTIVE_STATUS);
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/exception/InvalidRegionCodeException.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/InvalidRegionCodeException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.region.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidRegionCodeException extends BaseException {
+
+    public InvalidRegionCodeException() {
+        super(RegionErrorCode.INVALID_REGION_CODE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/exception/InvalidRegionDepthException.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/InvalidRegionDepthException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.region.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidRegionDepthException extends BaseException {
+
+    public InvalidRegionDepthException() {
+        super(RegionErrorCode.INVALID_REGION_DEPTH);
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/exception/InvalidRegionNameException.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/InvalidRegionNameException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.region.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidRegionNameException extends BaseException {
+
+    public InvalidRegionNameException() {
+        super(RegionErrorCode.INVALID_REGION_NAME);
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/exception/RegionErrorCode.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/RegionErrorCode.java
@@ -1,0 +1,24 @@
+package com.sparta.delivery.region.domain.exception;
+
+
+import com.sparta.delivery.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RegionErrorCode implements ErrorCode {
+    REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION-001", "지역을 찾을 수 없습니다."),
+    DUPLICATE_REGION_CODE(HttpStatus.CONFLICT, "REGION-002", "이미 사용 중인 지역 코드입니다."),
+    INVALID_PARENT_REGION(HttpStatus.BAD_REQUEST, "REGION-003", "유효하지 않은 상위 지역입니다."),
+    INVALID_REGION_DEPTH(HttpStatus.BAD_REQUEST, "REGION-004", "지역 depth 값이 올바르지 않습니다."),
+    REGION_HAS_CHILDREN(HttpStatus.BAD_REQUEST, "REGION-005", "하위 지역이 존재하여 삭제할 수 없습니다."),
+    INVALID_REGION_CODE(HttpStatus.BAD_REQUEST, "REGION-006", "지역 코드는 10자리 숫자여야 합니다."),
+    INVALID_REGION_NAME(HttpStatus.BAD_REQUEST, "REGION-007", "지역명은 비어 있을 수 없습니다."),
+    INVALID_REGION_ACTIVE_STATUS(HttpStatus.BAD_REQUEST, "REGION-008", "지역 활성 여부는 필수입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/region/domain/exception/RegionHasChildrenException.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/RegionHasChildrenException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.region.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class RegionHasChildrenException extends BaseException {
+
+    public RegionHasChildrenException() {
+        super(RegionErrorCode.REGION_HAS_CHILDREN);
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/exception/RegionNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/region/domain/exception/RegionNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.region.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class RegionNotFoundException extends BaseException {
+
+    public RegionNotFoundException() {
+        super(RegionErrorCode.REGION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/domain/repository/RegionRepository.java
+++ b/src/main/java/com/sparta/delivery/region/domain/repository/RegionRepository.java
@@ -8,13 +8,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RegionRepository extends JpaRepository<Region, UUID> {
 
-    boolean existsByRegionCodeAndDeletedAtIsNull(String regionCode);
+    boolean existsByRegionCode(String regionCode);
 
-    Optional<Region> findByRegionIdAndDeletedAtIsNull(UUID regionId);
+    Optional<Region> findByRegionId(UUID regionId);
 
-    Optional<Region> findByRegionCodeAndDeletedAtIsNull(String regionCode);
+    Optional<Region> findByRegionCode(String regionCode);
 
-    List<Region> findByParentIdAndDeletedAtIsNull(UUID parentId);
+    List<Region> findByParentId(UUID parentId);
 
-    List<Region> findByParentIdIsNullAndDeletedAtIsNull();
+    List<Region> findByParentIdIsNull();
 }

--- a/src/main/java/com/sparta/delivery/region/presentation/dto/RegionCreateRequest.java
+++ b/src/main/java/com/sparta/delivery/region/presentation/dto/RegionCreateRequest.java
@@ -1,0 +1,27 @@
+package com.sparta.delivery.region.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record RegionCreateRequest(
+
+        @NotBlank(message = "지역 코드는 필수입니다.")
+        @Pattern(regexp = "^\\d{10}$", message = "지역 코드는 10자리 숫자여야 합니다.")
+        String regionCode,
+
+        @NotBlank(message = "지역명은 필수입니다.")
+        @Size(max = 100, message = "지역명은 100자 이하여야 합니다.")
+        String regionName,
+
+        UUID parentId,
+
+        @NotNull(message = "depth는 필수입니다.")
+        Integer depth,
+
+        @NotNull(message = "활성 여부는 필수입니다.")
+        Boolean isActive
+) {
+}

--- a/src/main/java/com/sparta/delivery/region/presentation/dto/RegionResponse.java
+++ b/src/main/java/com/sparta/delivery/region/presentation/dto/RegionResponse.java
@@ -1,0 +1,25 @@
+package com.sparta.delivery.region.presentation.dto;
+
+import com.sparta.delivery.region.domain.entity.Region;
+import java.util.UUID;
+
+public record RegionResponse(
+        UUID regionId,
+        String regionCode,
+        String regionName,
+        UUID parentId,
+        Integer depth,
+        Boolean isActive
+) {
+
+    public static RegionResponse from(Region region) {
+        return new RegionResponse(
+                region.getRegionId(),
+                region.getRegionCode(),
+                region.getRegionName(),
+                region.getParentId(),
+                region.getDepth(),
+                region.getIsActive()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/region/presentation/dto/RegionUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/region/presentation/dto/RegionUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.sparta.delivery.region.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record RegionUpdateRequest(
+
+        @NotBlank(message = "지역명은 필수입니다.")
+        @Size(max = 100, message = "지역명은 100자 이하여야 합니다.")
+        String regionName,
+
+        UUID parentId,
+
+        @NotNull(message = "depth는 필수입니다.")
+        Integer depth,
+
+        @NotNull(message = "활성 여부는 필수입니다.")
+        Boolean isActive
+) {
+}

--- a/src/test/java/com/sparta/delivery/region/application/RegionServiceTest.java
+++ b/src/test/java/com/sparta/delivery/region/application/RegionServiceTest.java
@@ -1,0 +1,521 @@
+package com.sparta.delivery.region.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+
+import com.sparta.delivery.region.domain.entity.Region;
+import com.sparta.delivery.region.domain.exception.DuplicateRegionCodeException;
+import com.sparta.delivery.region.domain.exception.InvalidParentRegionException;
+import com.sparta.delivery.region.domain.exception.InvalidRegionDepthException;
+import com.sparta.delivery.region.domain.exception.RegionHasChildrenException;
+import com.sparta.delivery.region.domain.exception.RegionNotFoundException;
+import com.sparta.delivery.region.domain.repository.RegionRepository;
+import com.sparta.delivery.region.presentation.dto.RegionCreateRequest;
+import com.sparta.delivery.region.presentation.dto.RegionUpdateRequest;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegionServiceTest {
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @InjectMocks
+    private RegionService regionService;
+
+    @Nested
+    @DisplayName("지역 생성")
+    class CreateRegionTest {
+
+        @Test
+        @DisplayName("정상적으로 루트 지역을 생성한다")
+        void createRegion_success_root() {
+            // given
+            RegionCreateRequest request = new RegionCreateRequest(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            given(regionRepository.existsByRegionCode("1100000000")).willReturn(false);
+            given(regionRepository.save(any(Region.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            var response = regionService.createRegion(request);
+
+            // then
+            assertThat(response.regionCode()).isEqualTo("1100000000");
+            assertThat(response.regionName()).isEqualTo("서울특별시");
+            assertThat(response.parentId()).isNull();
+            assertThat(response.depth()).isEqualTo(1);
+            assertThat(response.isActive()).isTrue();
+
+            then(regionRepository).should().existsByRegionCode("1100000000");
+            then(regionRepository).should().save(any(Region.class));
+        }
+
+        @Test
+        @DisplayName("정상적으로 하위 지역을 생성한다")
+        void createRegion_success_child() {
+            // given
+            UUID parentId = UUID.randomUUID();
+
+            Region parent = Region.create(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            RegionCreateRequest request = new RegionCreateRequest(
+                    "1111000000",
+                    "종로구",
+                    parentId,
+                    2,
+                    true
+            );
+
+            given(regionRepository.existsByRegionCode("1111000000")).willReturn(false);
+            given(regionRepository.findByRegionId(parentId)).willReturn(Optional.of(parent));
+            given(regionRepository.save(any(Region.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            var response = regionService.createRegion(request);
+
+            // then
+            assertThat(response.regionCode()).isEqualTo("1111000000");
+            assertThat(response.regionName()).isEqualTo("종로구");
+            assertThat(response.parentId()).isEqualTo(parentId);
+            assertThat(response.depth()).isEqualTo(2);
+            assertThat(response.isActive()).isTrue();
+
+            then(regionRepository).should().existsByRegionCode("1111000000");
+            then(regionRepository).should().findByRegionId(parentId);
+            then(regionRepository).should().save(any(Region.class));
+        }
+
+        @Test
+        @DisplayName("지역 코드가 중복되면 DuplicateRegionCodeException이 발생한다")
+        void createRegion_fail_whenDuplicateCode() {
+            // given
+            RegionCreateRequest request = new RegionCreateRequest(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            given(regionRepository.existsByRegionCode("1100000000")).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> regionService.createRegion(request))
+                    .isInstanceOf(DuplicateRegionCodeException.class)
+                    .hasMessageContaining("지역 코드");
+
+            then(regionRepository).should().existsByRegionCode("1100000000");
+            then(regionRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("루트 지역의 depth가 1이 아니면 InvalidRegionDepthException이 발생한다")
+        void createRegion_fail_whenRootDepthIsInvalid() {
+            // given
+            RegionCreateRequest request = new RegionCreateRequest(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    2,
+                    true
+            );
+
+            given(regionRepository.existsByRegionCode("1100000000")).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> regionService.createRegion(request))
+                    .isInstanceOf(InvalidRegionDepthException.class)
+                    .hasMessageContaining("depth");
+
+            then(regionRepository).should().existsByRegionCode("1100000000");
+            then(regionRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("부모 지역이 없으면 InvalidParentRegionException이 발생한다")
+        void createRegion_fail_whenParentNotFound() {
+            // given
+            UUID parentId = UUID.randomUUID();
+
+            RegionCreateRequest request = new RegionCreateRequest(
+                    "1111000000",
+                    "종로구",
+                    parentId,
+                    2,
+                    true
+            );
+
+            given(regionRepository.existsByRegionCode("1111000000")).willReturn(false);
+            given(regionRepository.findByRegionId(parentId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> regionService.createRegion(request))
+                    .isInstanceOf(InvalidParentRegionException.class)
+                    .hasMessageContaining("상위");
+
+            then(regionRepository).should().existsByRegionCode("1111000000");
+            then(regionRepository).should().findByRegionId(parentId);
+            then(regionRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("하위 지역의 depth가 부모 depth보다 1 크지 않으면 InvalidRegionDepthException이 발생한다")
+        void createRegion_fail_whenChildDepthIsInvalid() {
+            // given
+            UUID parentId = UUID.randomUUID();
+
+            Region parent = Region.create(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            RegionCreateRequest request = new RegionCreateRequest(
+                    "1111000000",
+                    "종로구",
+                    parentId,
+                    3,
+                    true
+            );
+
+            given(regionRepository.existsByRegionCode("1111000000")).willReturn(false);
+            given(regionRepository.findByRegionId(parentId)).willReturn(Optional.of(parent));
+
+            // when & then
+            assertThatThrownBy(() -> regionService.createRegion(request))
+                    .isInstanceOf(InvalidRegionDepthException.class)
+                    .hasMessageContaining("depth");
+
+            then(regionRepository).should().existsByRegionCode("1111000000");
+            then(regionRepository).should().findByRegionId(parentId);
+            then(regionRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("지역 조회")
+    class GetRegionTest {
+
+        @Test
+        @DisplayName("지역 ID로 단건 조회한다")
+        void getRegion_success() {
+            // given
+            UUID regionId = UUID.randomUUID();
+
+            Region region = Region.create(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+
+            // when
+            var response = regionService.getRegion(regionId);
+
+            // then
+            assertThat(response.regionCode()).isEqualTo("1100000000");
+            assertThat(response.regionName()).isEqualTo("서울특별시");
+
+            then(regionRepository).should().findByRegionId(regionId);
+        }
+
+        @Test
+        @DisplayName("지역이 없으면 RegionNotFoundException이 발생한다")
+        void getRegion_fail_whenNotFound() {
+            // given
+            UUID regionId = UUID.randomUUID();
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> regionService.getRegion(regionId))
+                    .isInstanceOf(RegionNotFoundException.class)
+                    .hasMessageContaining("지역");
+
+            then(regionRepository).should().findByRegionId(regionId);
+        }
+
+        @Test
+        @DisplayName("최상위 지역 목록을 조회한다")
+        void getRootRegions_success() {
+            // given
+            Region seoul = Region.create(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            Region busan = Region.create(
+                    "2600000000",
+                    "부산광역시",
+                    null,
+                    1,
+                    true
+            );
+
+            given(regionRepository.findByParentIdIsNull()).willReturn(List.of(seoul, busan));
+
+            // when
+            var responses = regionService.getRootRegions();
+
+            // then
+            assertThat(responses).hasSize(2);
+            assertThat(responses)
+                    .extracting("regionName")
+                    .containsExactly("서울특별시", "부산광역시");
+
+            then(regionRepository).should().findByParentIdIsNull();
+        }
+
+        @Test
+        @DisplayName("하위 지역 목록을 조회한다")
+        void getChildRegions_success() {
+            // given
+            UUID parentId = UUID.randomUUID();
+
+            Region jongno = Region.create(
+                    "1111000000",
+                    "종로구",
+                    parentId,
+                    2,
+                    true
+            );
+
+            given(regionRepository.findByParentId(parentId)).willReturn(List.of(jongno));
+
+            // when
+            var responses = regionService.getChildRegions(parentId);
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).regionName()).isEqualTo("종로구");
+            assertThat(responses.get(0).parentId()).isEqualTo(parentId);
+
+            then(regionRepository).should().findByParentId(parentId);
+        }
+    }
+
+    @Nested
+    @DisplayName("지역 수정")
+    class UpdateRegionTest {
+
+        @Test
+        @DisplayName("정상적으로 지역 정보를 수정한다")
+        void updateRegion_success() {
+            // given
+            UUID regionId = UUID.randomUUID();
+            UUID parentId = UUID.randomUUID();
+
+            Region parent = Region.create(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            Region region = Region.create(
+                    "1111000000",
+                    "종로구",
+                    parentId,
+                    2,
+                    true
+            );
+
+            RegionUpdateRequest request = new RegionUpdateRequest(
+                    "종로구 수정",
+                    parentId,
+                    2,
+                    false
+            );
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+            given(regionRepository.findByRegionId(parentId)).willReturn(Optional.of(parent));
+
+            // when
+            var response = regionService.updateRegion(regionId, request);
+
+            // then
+            assertThat(response.regionName()).isEqualTo("종로구 수정");
+            assertThat(response.parentId()).isEqualTo(parentId);
+            assertThat(response.depth()).isEqualTo(2);
+            assertThat(response.isActive()).isFalse();
+
+            then(regionRepository).should().findByRegionId(regionId);
+            then(regionRepository).should().findByRegionId(parentId);
+        }
+
+        @Test
+        @DisplayName("자기 자신을 부모로 지정하면 InvalidParentRegionException이 발생한다")
+        void updateRegion_fail_whenParentIsSelf() {
+            // given
+            UUID regionId = UUID.randomUUID();
+
+            Region region = Region.create(
+                    "1111000000",
+                    "종로구",
+                    null,
+                    1,
+                    true
+            );
+
+            RegionUpdateRequest request = new RegionUpdateRequest(
+                    "종로구 수정",
+                    regionId,
+                    2,
+                    true
+            );
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+
+            // when & then
+            assertThatThrownBy(() -> regionService.updateRegion(regionId, request))
+                    .isInstanceOf(InvalidParentRegionException.class)
+                    .hasMessageContaining("상위");
+
+            then(regionRepository).should().findByRegionId(regionId);
+        }
+
+        @Test
+        @DisplayName("수정 대상 지역이 없으면 RegionNotFoundException이 발생한다")
+        void updateRegion_fail_whenRegionNotFound() {
+            // given
+            UUID regionId = UUID.randomUUID();
+
+            RegionUpdateRequest request = new RegionUpdateRequest(
+                    "종로구 수정",
+                    null,
+                    1,
+                    true
+            );
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> regionService.updateRegion(regionId, request))
+                    .isInstanceOf(RegionNotFoundException.class)
+                    .hasMessageContaining("지역");
+
+            then(regionRepository).should().findByRegionId(regionId);
+        }
+    }
+
+    @Nested
+    @DisplayName("지역 삭제")
+    class DeleteRegionTest {
+
+        @Test
+        @DisplayName("하위 지역이 없으면 soft delete 처리한다")
+        void deleteRegion_success() {
+            // given
+            UUID regionId = UUID.randomUUID();
+            Long currentUserId = 1L;
+
+            Region region = Region.create(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+            given(regionRepository.findByParentId(regionId)).willReturn(List.of());
+
+            // when
+            regionService.deleteRegion(regionId, currentUserId);
+
+            // then
+            assertThat(region.isDeleted()).isTrue();
+            assertThat(region.getDeletedBy()).isEqualTo(currentUserId);
+
+            then(regionRepository).should().findByRegionId(regionId);
+            then(regionRepository).should().findByParentId(regionId);
+        }
+
+        @Test
+        @DisplayName("하위 지역이 있으면 RegionHasChildrenException이 발생한다")
+        void deleteRegion_fail_whenHasChildren() {
+            // given
+            UUID regionId = UUID.randomUUID();
+            Long currentUserId = 1L;
+
+            Region region = Region.create(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    true
+            );
+
+            Region child = Region.create(
+                    "1111000000",
+                    "종로구",
+                    regionId,
+                    2,
+                    true
+            );
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+            given(regionRepository.findByParentId(regionId)).willReturn(List.of(child));
+
+            // when & then
+            assertThatThrownBy(() -> regionService.deleteRegion(regionId, currentUserId))
+                    .isInstanceOf(RegionHasChildrenException.class)
+                    .hasMessageContaining("하위 지역");
+
+            then(regionRepository).should().findByRegionId(regionId);
+            then(regionRepository).should().findByParentId(regionId);
+        }
+
+        @Test
+        @DisplayName("삭제 대상 지역이 없으면 RegionNotFoundException이 발생한다")
+        void deleteRegion_fail_whenRegionNotFound() {
+            // given
+            UUID regionId = UUID.randomUUID();
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> regionService.deleteRegion(regionId, 1L))
+                    .isInstanceOf(RegionNotFoundException.class)
+                    .hasMessageContaining("지역");
+
+            then(regionRepository).should().findByRegionId(regionId);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #33

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Region 서비스 로직 구현 |
| 🔍 목적 | Region 도메인의 생성/조회/수정/삭제 유스케이스를 처리한다. |
| 🛠️ 변경사항 | RegionService 추가 및 RegionService 단위 테스트 작성 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | Region 생성, 단건 조회, 최상위 지역 조회, 하위 지역 조회 로직을 구현했습니다. |
| 2️⃣ | Region 수정 및 soft delete 기반 삭제 로직을 구현했습니다. |
| 3️⃣ | regionCode 중복, parentId/depth 계층 규칙, 하위 지역 존재 여부 검증을 추가했습니다. |
| 4️⃣ | RegionService 단위 테스트를 작성해 주요 성공/예외 케이스를 검증했습니다. |

---

## ✅ 테스트 체크리스트
- [x] RegionService 단위 테스트 작성 완료
- [x] Region 생성/조회/수정/삭제 성공 케이스 확인
- [x] 중복 코드, 잘못된 부모 지역, 잘못된 depth, 하위 지역 존재 예외 케이스 확인
- [x] `./gradlew test --tests com.sparta.delivery.region.application.RegionServiceTest` 성공

---

## 📸 포스트맨 캡처 사진
- 해당 없음

---

## 🙋‍♀️ 리뷰어 참고사항
- 현재 PR은 Region 서비스 계층과 단위 테스트 구현 범위입니다.
- 컨트롤러/API 연동은 후속 작업에서 진행 예정입니다.
- 삭제는 `BaseEntity.softDelete(currentUserId)`를 사용하며, 하위 지역이 존재하면 삭제를 제한합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 지역 생성, 조회, 수정, 삭제 기능 추가
  * 지역 계층 구조 및 깊이 유효성 검증
  * 중복 지역 코드 방지 및 자식 지역 존재 여부 확인
  * 소프트 삭제 지원으로 지역 데이터 복구 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->