### PR TITLE
feat: 배송지 CRUD API

### DIFF
--- a/src/main/java/com/sparta/delivery/address/application/AddressService.java
+++ b/src/main/java/com/sparta/delivery/address/application/AddressService.java
@@ -66,7 +66,7 @@ public class AddressService {
     }
 
     @Transactional
-    public void delete(Long actorId, String actorRole, UUID addressId) {
+    public void delete(Long actorId, UserRole actorRole, UUID addressId) {
         Address address = getDeletableAddress(actorId, actorRole, addressId);
         Long ownerId = address.getUserId();
         boolean wasDefault = address.isDefault();
@@ -78,8 +78,8 @@ public class AddressService {
         setLatestAddressAsDefault(ownerId, wasDefault);
     }
 
-    private Address getDeletableAddress(Long actorId, String actorRole, UUID addressId) {
-        if (isMaster(actorRole)) {
+    private Address getDeletableAddress(Long actorId, UserRole actorRole, UUID addressId) {
+        if (actorRole == UserRole.MASTER) {
             return addressRepository.findById(addressId)
                     .orElseThrow(AddressNotFoundException::new);
         }
@@ -140,9 +140,5 @@ public class AddressService {
             throw new AddressForbiddenException();
         }
         return address;
-    }
-
-    private static boolean isMaster(String role) {
-        return UserRole.valueOf(role) == UserRole.MASTER;
     }
 }

--- a/src/main/java/com/sparta/delivery/address/application/AddressService.java
+++ b/src/main/java/com/sparta/delivery/address/application/AddressService.java
@@ -1,0 +1,135 @@
+package com.sparta.delivery.address.application;
+
+import com.sparta.delivery.address.domain.entity.Address;
+import com.sparta.delivery.address.domain.exception.AddressForbiddenException;
+import com.sparta.delivery.address.domain.exception.AddressNotFoundException;
+import com.sparta.delivery.address.domain.repository.AddressRepository;
+import com.sparta.delivery.address.presentation.dto.AddressCreateRequest;
+import com.sparta.delivery.address.presentation.dto.AddressResponse;
+import com.sparta.delivery.address.presentation.dto.AddressUpdateRequest;
+import java.util.List;
+import java.util.UUID;
+
+import com.sparta.delivery.user.domain.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AddressService {
+
+    private final AddressRepository addressRepository;
+
+    @Transactional
+    public AddressResponse create(Long userId, AddressCreateRequest request) {
+        boolean shouldBeDefault = shouldSetAsDefault(userId, request.isDefault());
+        if (shouldBeDefault) {
+            clearDefaultAddress(userId);
+        }
+
+        Address address = createAddress(userId, request, shouldBeDefault);
+        return AddressResponse.from(addressRepository.save(address));
+    }
+
+    public List<AddressResponse> getAddresses(Long userId) {
+        return addressRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(AddressResponse::from)
+                .toList();
+    }
+
+    public AddressResponse getAddress(Long userId, UUID addressId) {
+        return AddressResponse.from(getOwnedAddress(userId, addressId));
+    }
+
+    @Transactional
+    public AddressResponse update(Long userId, UUID addressId, AddressUpdateRequest request) {
+        Address address = getOwnedAddress(userId, addressId);
+        updateAddress(address, request);
+        return AddressResponse.from(address);
+    }
+
+    @Transactional
+    public AddressResponse setDefaultAddress(Long userId, UUID addressId) {
+        Address target = getOwnedAddress(userId, addressId);
+        changeDefaultAddress(userId, target.getAddressId());
+        target.markAsDefault();
+        return AddressResponse.from(target);
+    }
+
+    @Transactional
+    public void delete(Long actorId, String actorRole, UUID addressId) {
+        Address address = getDeletableAddress(actorId, actorRole, addressId);
+        Long ownerId = address.getUserId();
+        boolean wasDefault = address.isDefault();
+
+        address.softDelete(actorId);
+
+        setLatestAddressAsDefault(ownerId, wasDefault);
+    }
+
+    private Address getDeletableAddress(Long actorId, String actorRole, UUID addressId) {
+        if (isMaster(actorRole)) {
+            return addressRepository.findById(addressId)
+                    .orElseThrow(AddressNotFoundException::new);
+        }
+        return getOwnedAddress(actorId, addressId);
+    }
+
+    private boolean shouldSetAsDefault(Long userId, boolean requestedDefault) {
+        // 첫 배송지는 기본 배송지 1개를 보장하기 위해 자동으로 기본 처리한다.
+        return requestedDefault || !addressRepository.existsByUserId(userId);
+    }
+
+    private Address createAddress(Long userId, AddressCreateRequest request, boolean isDefault) {
+        return Address.create(
+                userId,
+                request.alias(),
+                request.address(),
+                request.detail(),
+                request.zipCode(),
+                isDefault
+        );
+    }
+
+    private void updateAddress(Address address, AddressUpdateRequest request) {
+        address.update(request.alias(), request.address(), request.detail(), request.zipCode());
+    }
+
+    private void clearDefaultAddress(Long userId) {
+        addressRepository.findByUserIdAndIsDefaultTrue(userId)
+                .ifPresent(Address::unmarkAsDefault);
+    }
+
+    private void changeDefaultAddress(Long userId, UUID targetAddressId) {
+        addressRepository.findByUserIdAndIsDefaultTrue(userId).ifPresent(current -> {
+            if (!current.getAddressId().equals(targetAddressId)) {
+                current.unmarkAsDefault();
+            }
+        });
+    }
+
+    private void setLatestAddressAsDefault(Long ownerId, boolean deletedDefault) {
+        if (!deletedDefault) {
+            return;
+        }
+
+        addressRepository.findAllByUserIdOrderByCreatedAtDesc(ownerId).stream()
+                .findFirst()
+                .ifPresent(Address::markAsDefault);
+    }
+
+    private Address getOwnedAddress(Long userId, UUID addressId) {
+        Address address = addressRepository.findById(addressId)
+                .orElseThrow(AddressNotFoundException::new);
+        if (!address.getUserId().equals(userId)) {
+            throw new AddressForbiddenException();
+        }
+        return address;
+    }
+
+    private static boolean isMaster(String role) {
+        return UserRole.valueOf(role) == UserRole.MASTER;
+    }
+}

--- a/src/main/java/com/sparta/delivery/address/application/AddressService.java
+++ b/src/main/java/com/sparta/delivery/address/application/AddressService.java
@@ -12,10 +12,12 @@ import java.util.UUID;
 
 import com.sparta.delivery.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AddressService {
@@ -30,7 +32,10 @@ public class AddressService {
         }
 
         Address address = createAddress(userId, request, shouldBeDefault);
-        return AddressResponse.from(addressRepository.save(address));
+        Address savedAddress = addressRepository.save(address);
+        log.info("배송지 등록 완료 - userId={}, addressId={}, 기본배송지={}",
+                userId, savedAddress.getAddressId(), savedAddress.isDefault());
+        return AddressResponse.from(savedAddress);
     }
 
     public List<AddressResponse> getAddresses(Long userId) {
@@ -47,6 +52,7 @@ public class AddressService {
     public AddressResponse update(Long userId, UUID addressId, AddressUpdateRequest request) {
         Address address = getOwnedAddress(userId, addressId);
         updateAddress(address, request);
+        log.info("배송지 수정 완료 - userId={}, addressId={}", userId, addressId);
         return AddressResponse.from(address);
     }
 
@@ -55,6 +61,7 @@ public class AddressService {
         Address target = getOwnedAddress(userId, addressId);
         changeDefaultAddress(userId, target.getAddressId());
         target.markAsDefault();
+        log.info("기본 배송지 변경 완료 - userId={}, addressId={}", userId, addressId);
         return AddressResponse.from(target);
     }
 
@@ -65,6 +72,8 @@ public class AddressService {
         boolean wasDefault = address.isDefault();
 
         address.softDelete(actorId);
+        log.info("배송지 삭제 완료 - actorId={}, addressId={}, 기본배송지여부={}",
+                actorId, addressId, wasDefault);
 
         setLatestAddressAsDefault(ownerId, wasDefault);
     }
@@ -117,7 +126,11 @@ public class AddressService {
 
         addressRepository.findAllByUserIdOrderByCreatedAtDesc(ownerId).stream()
                 .findFirst()
-                .ifPresent(Address::markAsDefault);
+                .ifPresent(address -> {
+                    address.markAsDefault();
+                    log.info("기본 배송지 재지정 완료 - userId={}, addressId={}",
+                            ownerId, address.getAddressId());
+                });
     }
 
     private Address getOwnedAddress(Long userId, UUID addressId) {

--- a/src/main/java/com/sparta/delivery/address/domain/entity/Address.java
+++ b/src/main/java/com/sparta/delivery/address/domain/entity/Address.java
@@ -1,5 +1,7 @@
 package com.sparta.delivery.address.domain.entity;
 
+import com.sparta.delivery.address.domain.exception.InvalidAddressException;
+import com.sparta.delivery.address.domain.exception.InvalidUserIdException;
 import com.sparta.delivery.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -52,11 +54,11 @@ public class Address extends BaseEntity {
             String zipCode,
             boolean isDefault
     ) {
-        this.userId = userId;
-        this.alias = alias;
-        this.address = address;
-        this.detail = detail;
-        this.zipCode = zipCode;
+        this.userId = requireUserId(userId);
+        this.alias = normalizeOptional(alias);
+        this.address = requireAddress(address);
+        this.detail = normalizeOptional(detail);
+        this.zipCode = normalizeOptional(zipCode);
         this.isDefault = isDefault;
     }
 
@@ -79,9 +81,40 @@ public class Address extends BaseEntity {
     }
 
     public void update(String alias, String address, String detail, String zipCode) {
-        this.alias = alias;
-        this.address = address;
-        this.detail = detail;
-        this.zipCode = zipCode;
+        this.alias = normalizeOptional(alias);
+        this.address = requireAddress(address);
+        this.detail = normalizeOptional(detail);
+        this.zipCode = normalizeOptional(zipCode);
+    }
+
+    public void markAsDefault() {
+        this.isDefault = true;
+    }
+
+    public void unmarkAsDefault() {
+        this.isDefault = false;
+    }
+
+    private static String requireAddress(String value) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidAddressException();
+        }
+        return value.trim();
+    }
+
+    private static Long requireUserId(Long userId) {
+        if (userId == null) {
+            throw new InvalidUserIdException();
+        }
+        return userId;
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/java/com/sparta/delivery/address/domain/exception/AddressErrorCode.java
+++ b/src/main/java/com/sparta/delivery/address/domain/exception/AddressErrorCode.java
@@ -1,0 +1,20 @@
+package com.sparta.delivery.address.domain.exception;
+
+import com.sparta.delivery.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AddressErrorCode implements ErrorCode {
+
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "ADDRESS-001", "배송지를 찾을 수 없습니다."),
+    ADDRESS_FORBIDDEN(HttpStatus.FORBIDDEN, "ADDRESS-002", "본인 배송지만 접근할 수 있습니다."),
+    INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "ADDRESS-003", "주소는 필수 입력값입니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "ADDRESS-004", "사용자 ID는 필수입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/address/domain/exception/AddressForbiddenException.java
+++ b/src/main/java/com/sparta/delivery/address/domain/exception/AddressForbiddenException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.address.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class AddressForbiddenException extends BaseException {
+
+    public AddressForbiddenException() {
+        super(AddressErrorCode.ADDRESS_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/sparta/delivery/address/domain/exception/AddressNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/address/domain/exception/AddressNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.address.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class AddressNotFoundException extends BaseException {
+
+    public AddressNotFoundException() {
+        super(AddressErrorCode.ADDRESS_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/address/domain/exception/InvalidAddressException.java
+++ b/src/main/java/com/sparta/delivery/address/domain/exception/InvalidAddressException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.address.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidAddressException extends BaseException {
+
+    public InvalidAddressException() {
+        super(AddressErrorCode.INVALID_ADDRESS);
+    }
+}

--- a/src/main/java/com/sparta/delivery/address/domain/exception/InvalidUserIdException.java
+++ b/src/main/java/com/sparta/delivery/address/domain/exception/InvalidUserIdException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.address.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidUserIdException extends BaseException {
+
+    public InvalidUserIdException() {
+        super(AddressErrorCode.INVALID_USER_ID);
+    }
+}

--- a/src/main/java/com/sparta/delivery/address/domain/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/delivery/address/domain/repository/AddressRepository.java
@@ -1,9 +1,16 @@
 package com.sparta.delivery.address.domain.repository;
 
 import com.sparta.delivery.address.domain.entity.Address;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.UUID;
-
 public interface AddressRepository extends JpaRepository<Address, UUID> {
+
+    List<Address> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Optional<Address> findByUserIdAndIsDefaultTrue(Long userId);
+
+    boolean existsByUserId(Long userId);
 }

--- a/src/main/java/com/sparta/delivery/address/presentation/AddressController.java
+++ b/src/main/java/com/sparta/delivery/address/presentation/AddressController.java
@@ -6,6 +6,7 @@ import com.sparta.delivery.address.presentation.dto.AddressResponse;
 import com.sparta.delivery.address.presentation.dto.AddressUpdateRequest;
 import com.sparta.delivery.common.config.security.UserPrincipal;
 import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.user.domain.entity.UserRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -92,7 +93,7 @@ public class AddressController {
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable UUID addressId
     ) {
-        addressService.delete(principal.getId(), principal.getRole(), addressId);
+        addressService.delete(principal.getId(), UserRole.valueOf(principal.getRole()), addressId);
         return ResponseEntity.ok(ApiResponse.ok());
     }
 }

--- a/src/main/java/com/sparta/delivery/address/presentation/AddressController.java
+++ b/src/main/java/com/sparta/delivery/address/presentation/AddressController.java
@@ -1,0 +1,98 @@
+package com.sparta.delivery.address.presentation;
+
+import com.sparta.delivery.address.application.AddressService;
+import com.sparta.delivery.address.presentation.dto.AddressCreateRequest;
+import com.sparta.delivery.address.presentation.dto.AddressResponse;
+import com.sparta.delivery.address.presentation.dto.AddressUpdateRequest;
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/addresses")
+@RequiredArgsConstructor
+@Tag(name = "Address", description = "배송지 API")
+@PreAuthorize("hasRole('CUSTOMER')")
+public class AddressController {
+
+    private final AddressService addressService;
+
+    @Operation(summary = "배송지 등록")
+    @PostMapping
+    public ResponseEntity<ApiResponse<AddressResponse>> create(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody @Valid AddressCreateRequest request
+    ) {
+        AddressResponse response = addressService.create(principal.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
+    }
+
+    @Operation(summary = "내 배송지 목록 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AddressResponse>>> getAddresses(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<AddressResponse> response = addressService.getAddresses(principal.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "배송지 상세 조회")
+    @GetMapping("/{addressId}")
+    public ResponseEntity<ApiResponse<AddressResponse>> getAddress(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID addressId
+    ) {
+        AddressResponse response = addressService.getAddress(principal.getId(), addressId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "배송지 수정")
+    @PutMapping("/{addressId}")
+    public ResponseEntity<ApiResponse<AddressResponse>> update(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID addressId,
+            @RequestBody @Valid AddressUpdateRequest request
+    ) {
+        AddressResponse response = addressService.update(principal.getId(), addressId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "기본 배송지 설정")
+    @PatchMapping("/{addressId}/default")
+    public ResponseEntity<ApiResponse<AddressResponse>> setDefault(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID addressId
+    ) {
+        AddressResponse response = addressService.setDefaultAddress(principal.getId(), addressId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "배송지 삭제")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'MASTER')")
+    @DeleteMapping("/{addressId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID addressId
+    ) {
+        addressService.delete(principal.getId(), principal.getRole(), addressId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+}

--- a/src/main/java/com/sparta/delivery/address/presentation/dto/AddressCreateRequest.java
+++ b/src/main/java/com/sparta/delivery/address/presentation/dto/AddressCreateRequest.java
@@ -1,0 +1,22 @@
+package com.sparta.delivery.address.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AddressCreateRequest(
+        @Size(max = 50, message = "배송지 별칭은 50자 이하여야 합니다.")
+        String alias,
+
+        @NotBlank(message = "주소는 필수 입력값입니다.")
+        @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
+        String address,
+
+        @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다.")
+        String detail,
+
+        @Size(max = 10, message = "우편번호는 10자 이하여야 합니다.")
+        String zipCode,
+
+        boolean isDefault
+) {
+}

--- a/src/main/java/com/sparta/delivery/address/presentation/dto/AddressResponse.java
+++ b/src/main/java/com/sparta/delivery/address/presentation/dto/AddressResponse.java
@@ -1,0 +1,30 @@
+package com.sparta.delivery.address.presentation.dto;
+
+import com.sparta.delivery.address.domain.entity.Address;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AddressResponse(
+        UUID addressId,
+        String alias,
+        String address,
+        String detail,
+        String zipCode,
+        boolean isDefault,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static AddressResponse from(Address address) {
+        return new AddressResponse(
+                address.getAddressId(),
+                address.getAlias(),
+                address.getAddress(),
+                address.getDetail(),
+                address.getZipCode(),
+                address.isDefault(),
+                address.getCreatedAt(),
+                address.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/address/presentation/dto/AddressUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/address/presentation/dto/AddressUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.sparta.delivery.address.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AddressUpdateRequest(
+        @Size(max = 50, message = "배송지 별칭은 50자 이하여야 합니다.")
+        String alias,
+
+        @NotBlank(message = "주소는 필수 입력값입니다.")
+        @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
+        String address,
+
+        @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다.")
+        String detail,
+
+        @Size(max = 10, message = "우편번호는 10자 이하여야 합니다.")
+        String zipCode
+) {
+}

--- a/src/test/java/com/sparta/delivery/address/application/AddressServiceTest.java
+++ b/src/test/java/com/sparta/delivery/address/application/AddressServiceTest.java
@@ -281,7 +281,7 @@ class AddressServiceTest {
                     .willReturn(List.of(latestAddress));
 
             // when
-            addressService.delete(userId, UserRole.CUSTOMER.name(), addressId);
+            addressService.delete(userId, UserRole.CUSTOMER, addressId);
 
             // then
             assertThat(deletedAddress.isDeleted()).isTrue();
@@ -308,7 +308,7 @@ class AddressServiceTest {
             given(addressRepository.findById(addressId)).willReturn(Optional.of(address));
 
             // when // then
-            assertThatThrownBy(() -> addressService.delete(userId, UserRole.CUSTOMER.name(), addressId))
+            assertThatThrownBy(() -> addressService.delete(userId, UserRole.CUSTOMER, addressId))
                     .isInstanceOf(AddressForbiddenException.class);
         }
     }

--- a/src/test/java/com/sparta/delivery/address/application/AddressServiceTest.java
+++ b/src/test/java/com/sparta/delivery/address/application/AddressServiceTest.java
@@ -1,0 +1,319 @@
+package com.sparta.delivery.address.application;
+
+import com.sparta.delivery.address.domain.entity.Address;
+import com.sparta.delivery.address.domain.exception.AddressForbiddenException;
+import com.sparta.delivery.address.domain.exception.InvalidAddressException;
+import com.sparta.delivery.address.domain.repository.AddressRepository;
+import com.sparta.delivery.address.presentation.dto.AddressCreateRequest;
+import com.sparta.delivery.address.presentation.dto.AddressResponse;
+import com.sparta.delivery.address.presentation.dto.AddressUpdateRequest;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AddressServiceTest {
+
+    @Mock
+    private AddressRepository addressRepository;
+
+    @InjectMocks
+    private AddressService addressService;
+
+    @Nested
+    @DisplayName("배송지 등록")
+    class Create {
+
+        @Test
+        @DisplayName("첫 배송지를 등록하면 기본 배송지로 저장된다")
+        void success() {
+            // given
+            Long userId = 1L;
+            AddressCreateRequest request = new AddressCreateRequest(
+                    "집",
+                    "서울시 강남구",
+                    "101호",
+                    "12345",
+                    false
+            );
+
+            given(addressRepository.existsByUserId(userId)).willReturn(false);
+            given(addressRepository.save(any(Address.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            AddressResponse response = addressService.create(userId, request);
+
+            // then
+            assertThat(response.isDefault()).isTrue();
+            assertThat(response.alias()).isEqualTo("집");
+            assertThat(response.address()).isEqualTo("서울시 강남구");
+        }
+
+        @Test
+        @DisplayName("주소가 비어 있으면 예외가 발생한다")
+        void invalidAddress() {
+            // given
+            Long userId = 1L;
+            AddressCreateRequest request = new AddressCreateRequest(
+                    "집",
+                    "   ",
+                    "101호",
+                    "12345",
+                    false
+            );
+
+            given(addressRepository.existsByUserId(userId)).willReturn(false);
+
+            // when // then
+            assertThatThrownBy(() -> addressService.create(userId, request))
+                    .isInstanceOf(InvalidAddressException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("본인 배송지를 상세 조회할 수 있다")
+    void getAddress() {
+        // given
+        Long userId = 1L;
+        UUID addressId = UUID.randomUUID();
+        Address address = Address.create(
+                userId,
+                "집",
+                "서울시 강남구",
+                "101호",
+                "12345",
+                true
+        );
+        setAddressId(address, addressId);
+
+        given(addressRepository.findById(addressId)).willReturn(Optional.of(address));
+
+        // when
+        AddressResponse response = addressService.getAddress(userId, addressId);
+
+        // then
+        assertThat(response.alias()).isEqualTo("집");
+        assertThat(response.address()).isEqualTo("서울시 강남구");
+        assertThat(response.isDefault()).isTrue();
+    }
+
+    @Nested
+    @DisplayName("배송지 수정")
+    class Update {
+
+        @Test
+        @DisplayName("본인 배송지를 수정할 수 있다")
+        void success() {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            Address address = Address.create(
+                    userId,
+                    "집",
+                    "서울시 강남구",
+                    "101호",
+                    "12345",
+                    true
+            );
+            setAddressId(address, addressId);
+            AddressUpdateRequest request = new AddressUpdateRequest(
+                    "회사",
+                    "서울시 서초구",
+                    "202호",
+                    "54321"
+            );
+
+            given(addressRepository.findById(addressId)).willReturn(Optional.of(address));
+
+            // when
+            AddressResponse response = addressService.update(userId, addressId, request);
+
+            // then
+            assertThat(response.alias()).isEqualTo("회사");
+            assertThat(response.address()).isEqualTo("서울시 서초구");
+            assertThat(response.detail()).isEqualTo("202호");
+            assertThat(response.zipCode()).isEqualTo("54321");
+        }
+
+        @Test
+        @DisplayName("본인 배송지가 아니면 수정할 수 없다")
+        void forbidden() {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            Address address = Address.create(
+                    2L,
+                    "집",
+                    "서울시 강남구",
+                    "101호",
+                    "12345",
+                    true
+            );
+            setAddressId(address, addressId);
+            AddressUpdateRequest request = new AddressUpdateRequest(
+                    "회사",
+                    "서울시 서초구",
+                    "202호",
+                    "54321"
+            );
+
+            given(addressRepository.findById(addressId)).willReturn(Optional.of(address));
+
+            // when // then
+            assertThatThrownBy(() -> addressService.update(userId, addressId, request))
+                    .isInstanceOf(AddressForbiddenException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("기본 배송지 설정")
+    class SetDefaultAddress {
+
+        @Test
+        @DisplayName("기존 기본 배송지를 해제하고 새 배송지를 기본으로 설정한다")
+        void success() {
+            // given
+            Long userId = 1L;
+            UUID targetAddressId = UUID.randomUUID();
+            Address currentDefault = Address.create(
+                    userId,
+                    "집",
+                    "서울시 강남구",
+                    "101호",
+                    "12345",
+                    true
+            );
+            setAddressId(currentDefault, UUID.randomUUID());
+            Address target = Address.create(
+                    userId,
+                    "회사",
+                    "서울시 서초구",
+                    "202호",
+                    "54321",
+                    false
+            );
+            setAddressId(target, targetAddressId);
+
+            given(addressRepository.findById(targetAddressId)).willReturn(Optional.of(target));
+            given(addressRepository.findByUserIdAndIsDefaultTrue(userId)).willReturn(Optional.of(currentDefault));
+
+            // when
+            AddressResponse response = addressService.setDefaultAddress(userId, targetAddressId);
+
+            // then
+            assertThat(currentDefault.isDefault()).isFalse();
+            assertThat(target.isDefault()).isTrue();
+            assertThat(response.isDefault()).isTrue();
+            assertThat(response.alias()).isEqualTo("회사");
+        }
+
+        @Test
+        @DisplayName("본인 배송지가 아니면 기본 배송지로 설정할 수 없다")
+        void forbidden() {
+            // given
+            Long userId = 1L;
+            UUID targetAddressId = UUID.randomUUID();
+            Address target = Address.create(
+                    2L,
+                    "회사",
+                    "서울시 서초구",
+                    "202호",
+                    "54321",
+                    false
+            );
+            setAddressId(target, targetAddressId);
+
+            given(addressRepository.findById(targetAddressId)).willReturn(Optional.of(target));
+
+            // when // then
+            assertThatThrownBy(() -> addressService.setDefaultAddress(userId, targetAddressId))
+                    .isInstanceOf(AddressForbiddenException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 삭제")
+    class Delete {
+
+        @Test
+        @DisplayName("기본 배송지를 삭제하면 최근 배송지가 기본 배송지로 변경된다")
+        void success() {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            Address deletedAddress = Address.create(
+                    userId,
+                    "집",
+                    "서울시 강남구",
+                    "101호",
+                    "12345",
+                    true
+            );
+            setAddressId(deletedAddress, addressId);
+            Address latestAddress = Address.create(
+                    userId,
+                    "회사",
+                    "서울시 서초구",
+                    "202호",
+                    "54321",
+                    false
+            );
+            setAddressId(latestAddress, UUID.randomUUID());
+
+            given(addressRepository.findById(addressId)).willReturn(Optional.of(deletedAddress));
+            given(addressRepository.findAllByUserIdOrderByCreatedAtDesc(userId))
+                    .willReturn(List.of(latestAddress));
+
+            // when
+            addressService.delete(userId, UserRole.CUSTOMER.name(), addressId);
+
+            // then
+            assertThat(deletedAddress.isDeleted()).isTrue();
+            assertThat(deletedAddress.getDeletedBy()).isEqualTo(userId);
+            assertThat(latestAddress.isDefault()).isTrue();
+        }
+
+        @Test
+        @DisplayName("본인 배송지가 아니면 삭제할 수 없다")
+        void forbidden() {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            Address address = Address.create(
+                    2L,
+                    "집",
+                    "서울시 강남구",
+                    "101호",
+                    "12345",
+                    true
+            );
+            setAddressId(address, addressId);
+
+            given(addressRepository.findById(addressId)).willReturn(Optional.of(address));
+
+            // when // then
+            assertThatThrownBy(() -> addressService.delete(userId, UserRole.CUSTOMER.name(), addressId))
+                    .isInstanceOf(AddressForbiddenException.class);
+        }
+    }
+
+    private void setAddressId(Address address, UUID addressId) {
+        ReflectionTestUtils.setField(address, "addressId", addressId);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #5  <!-- 연결된 이슈 번호 기재 -->

## ✨ 기능 요약
배송지 도메인의CRUD API를 구현하고 기본 배송지 정책 및 서비스 단위 테스트를 추가

## 📝 상세 내역
* `address` 패키지 전체 구조를 추가.
* 배송지 등록 / 목록 조회 / 상세 조회 / 수정 / 삭제 / 기본 배송지 설정 API를 구현
* `AddressErrorCode` 및 개별 예외 클래스를 추가하고 주소 정규화, 소프트 삭제, 사용자당 기본 배송지 1개 정책을 서비스에 반영.
* 첫 배송지 자동 기본 설정, 기존 기본 배송지 해제, 기본 배송지 삭제 시 최근 배송지 재지정 로직을 구현.
* `AddressServiceTest`를 추가해 성공·실패 케이스를 검증.
* 주요 상태 변경 흐름에 대해 서비스 로그를 추가.

---

## ✅ 테스트 체크리스트
- [x] 기능 정상 작동 확인
- [x] 예외/엣지 케이스 확인
- [x] 테스트 코드 작성 완료
- [x] API 연동 확인 (요청/응답 정상 동작)
---

## 📸 스웨거 캡처 사진
### 생성
<img width="990" height="512" alt="image" src="https://github.com/user-attachments/assets/2220b4e1-e933-4b54-af52-717727d7f979" />

### 조회
<img width="952" height="804" alt="image" src="https://github.com/user-attachments/assets/9e725dd9-f8f6-4f2c-a9f4-d7159126057b" />


### 삭제
<img width="420" height="180" alt="image" src="https://github.com/user-attachments/assets/6c0f0945-be9d-43c3-be7f-953ccc44e5ae" />


### 기본 배송지 지정
<img width="892" height="506" alt="image" src="https://github.com/user-attachments/assets/ef52ea00-a7bf-47e9-97e7-878fa3d34e73" />

## 🙋‍♀️ 리뷰어 참고사항
- 기본 배송지 정책
  - 사용자당 기본 배송지는 최대 1개만 허용.
  - 첫 배송지 등록 시 자동으로 기본 배송지로 설정.
  - 새 배송지를 기본 배송지로 설정하면 기존 기본 배송지는 해제.
  - 기본 배송지를 삭제하면 남아 있는 최근 배송지를 기본 배송지로 재지정.

- 삭제 정책
  - `BaseEntity.softDelete()` 기반 소프트 삭제.
  - 일반 조회에서는 삭제된 배송지가 제외되도록 구성.

- 권한 정책
  - 조회/수정/기본 배송지 설정은 본인 배송지만 가능.
  - 삭제는 `CUSTOMER(본인)` / `MASTER` 기준으로 처리.

- 테스트는 현재 서비스 단위 테스트 중심으로 작성.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

## 새로운 기능
* 배송지 관리 API 추가: 생성, 목록, 상세조회, 수정, 기본지정, 삭제(soft-delete) 지원.
* 기본 배송지 자동 재할당: 첫 배송지 자동 기본 지정 및 삭제 시 최신 배송지로 기본 전환.

## 검증 및 오류 처리
* 입력 검증 강화 및 도메인별 예외 추가(유효하지 않은 주소/유저, 조회·권한 오류).

## 테스트
* 배송지 서비스에 대한 단위 테스트 추가(생성/수정/기본설정/삭제 등).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->