### PR TITLE
refactor: Payment 도메인 생성/검증/예외 정책 정리

### DIFF
--- a/src/main/java/com/sparta/delivery/payment/domain/entity/Payment.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/entity/Payment.java
@@ -21,6 +21,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.sparta.delivery.common.model.BaseEntity;
+import com.sparta.delivery.payment.domain.exception.InvalidOrderIdException;
+import com.sparta.delivery.payment.domain.exception.InvalidPaymentMethodException;
+import com.sparta.delivery.payment.domain.exception.InvalidPaymentStatusTransitionException;
+import com.sparta.delivery.payment.domain.exception.InvalidTotalPriceException;
 
 @Entity
 @Table(name = "p_payment", uniqueConstraints = {@UniqueConstraint(name = "uk_payment_order_id", columnNames = "order_id")})
@@ -87,32 +91,44 @@ public class Payment extends BaseEntity {
                 .build();
     }
 
+    private static void validate(UUID orderId, PaymentMethod paymentMethod, Integer totalPrice) {
+        if (orderId == null) throw new InvalidOrderIdException();
+        if (paymentMethod == null) throw new InvalidPaymentMethodException();
+        if (totalPrice == null || totalPrice <= 0) throw new InvalidTotalPriceException();
+    }
+
+    private static String normalizeNullableText(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
     public void approve(String pgProvider, String pgTransactionId) {
         if(this.paymentStatus != PaymentStatus.PENDING) {
-            throw new IllegalStateException();
+            throw new InvalidPaymentStatusTransitionException();
         }
 
         this.paymentStatus = PaymentStatus.APPROVED;
         this.approvedAt = LocalDateTime.now();
-        this.pgProvider = pgProvider;
-        this.pgTransactionId = pgTransactionId;
+        this.pgProvider = normalizeNullableText(pgProvider);
+        this.pgTransactionId = normalizeNullableText(pgTransactionId);
     }
 
     public void fail(String failureReason) {
 
         if(this.paymentStatus != PaymentStatus.PENDING) {
-            throw new IllegalStateException();
+            throw new InvalidPaymentStatusTransitionException();
         }
 
         this.paymentStatus = PaymentStatus.FAILED;
         this.failedAt = LocalDateTime.now();
-        this.failureReason = failureReason;
+        this.failureReason = normalizeNullableText(failureReason);
     }
 
     public void cancel() {
 
         if(this.paymentStatus != PaymentStatus.APPROVED) {
-            throw new IllegalStateException();
+            throw new InvalidPaymentStatusTransitionException();
         }
 
         this.cancelledAt = LocalDateTime.now();

--- a/src/main/java/com/sparta/delivery/payment/domain/entity/Payment.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/entity/Payment.java
@@ -13,6 +13,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +24,7 @@ import com.sparta.delivery.common.model.BaseEntity;
 
 @Entity
 @Table(name = "p_payment", uniqueConstraints = {@UniqueConstraint(name = "uk_payment_order_id", columnNames = "order_id")})
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Payment extends BaseEntity {
@@ -45,25 +48,22 @@ public class Payment extends BaseEntity {
     @Column(name = "total_price", nullable = false)
     private Integer totalPrice;
 
-    @Column(name = "approved_at")
     private LocalDateTime approvedAt;
 
-    @Column(name = "failed_at")
     private LocalDateTime failedAt;
 
-    @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
-    @Column(name = "failure_reason", length = 255)
+    @Column(length = 255)
     private String failureReason;
 
-    @Column(name = "pg_provider", length = 50)
+    @Column(length = 50)
     private String pgProvider;
 
-    @Column(name = "pg_transaction_id", length = 100)
+    @Column(length = 100)
     private String pgTransactionId;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Payment(UUID orderId, PaymentMethod paymentMethod, Integer totalPrice, LocalDateTime approvedAt, LocalDateTime failedAt, LocalDateTime cancelledAt, String failureReason, String pgProvider, String pgTransactionId) {
         this.orderId = orderId;
         this.paymentMethod = paymentMethod;
@@ -75,6 +75,16 @@ public class Payment extends BaseEntity {
         this.failureReason = failureReason;
         this.pgProvider = pgProvider;
         this.pgTransactionId = pgTransactionId;
+    }
+
+    // 최초 객체 생성 시, 외부 입력이 필요한 값
+    public static Payment create(UUID orderId, PaymentMethod paymentMethod, Integer totalPrice) {
+        validate(orderId, paymentMethod, totalPrice);
+        return Payment.builder()
+                .orderId(orderId)
+                .paymentMethod(paymentMethod)
+                .totalPrice(totalPrice)
+                .build();
     }
 
     public void approve(String pgProvider, String pgTransactionId) {

--- a/src/main/java/com/sparta/delivery/payment/domain/exception/InvalidOrderIdException.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/exception/InvalidOrderIdException.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.payment.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidOrderIdException extends BaseException {
+
+    public InvalidOrderIdException() {
+        super(PaymentErrorCode.INVALID_ORDER_ID);
+    }
+
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/exception/InvalidPaymentMethodException.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/exception/InvalidPaymentMethodException.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.payment.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidPaymentMethodException extends BaseException {
+
+    public InvalidPaymentMethodException() {
+        super(PaymentErrorCode.INVALID_PAYMENT_METHOD);
+    }
+
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/exception/InvalidPaymentStatusTransitionException.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/exception/InvalidPaymentStatusTransitionException.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.payment.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidPaymentStatusTransitionException extends BaseException {
+
+    public InvalidPaymentStatusTransitionException() {
+        super(PaymentErrorCode.INVALID_PAYMENT_STATUS_TRANSITION);
+    }
+
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/exception/InvalidTotalPriceException.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/exception/InvalidTotalPriceException.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.payment.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidTotalPriceException extends BaseException {
+
+    public InvalidTotalPriceException() {
+        super(PaymentErrorCode.INVALID_TOTAL_PRICE);
+    }
+
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/exception/PaymentErrorCode.java
@@ -1,0 +1,23 @@
+package com.sparta.delivery.payment.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.delivery.common.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements ErrorCode {
+
+    INVALID_ORDER_ID(HttpStatus.BAD_REQUEST, "PAYMENT-001", "유효하지 않은 주문 ID입니다."),
+    INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "PAYMENT-002", "결제 방법은 CARD만 선택 가능합니다."),
+    INVALID_TOTAL_PRICE(HttpStatus.BAD_REQUEST, "PAYMENT-003", "전체 가격은 0보다 커야 합니다."),
+    INVALID_PAYMENT_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "PAYMENT-004", "결제 상태 전이가 올바르지 않습니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT-005", "결제 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/repository/PaymentRepository.java
@@ -9,10 +9,10 @@ import com.sparta.delivery.payment.domain.entity.Payment;
 
 public interface PaymentRepository extends JpaRepository<Payment, UUID> {
 
-    boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId);
+    boolean existsByOrderId(UUID orderId);
 
-    Optional<Payment> findByOrderIdAndDeletedAtIsNull(UUID orderId);
+    Optional<Payment> findByOrderId(UUID orderId);
 
-    Optional<Payment> findByPaymentIdAndDeletedAtIsNull(UUID paymentId);
+    Optional<Payment> findByPaymentId(UUID paymentId);
 
 }

--- a/src/test/java/com/sparta/delivery/payment/domain/entity/PaymentTest.java
+++ b/src/test/java/com/sparta/delivery/payment/domain/entity/PaymentTest.java
@@ -1,0 +1,90 @@
+package com.sparta.delivery.payment.domain.entity;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.sparta.delivery.payment.domain.exception.InvalidOrderIdException;
+import com.sparta.delivery.payment.domain.exception.InvalidPaymentMethodException;
+import com.sparta.delivery.payment.domain.exception.InvalidPaymentStatusTransitionException;
+import com.sparta.delivery.payment.domain.exception.InvalidTotalPriceException;
+
+public class PaymentTest {
+
+    @Test
+    @DisplayName("create: 정상 생성 시 PENDING 상태로 생성된다.")
+    void create_success() {
+        Payment payment = Payment.create(UUID.randomUUID(), PaymentMethod.CARD, 10000);
+
+        assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
+        assertThat(payment.getTotalPrice()).isEqualTo(10000);
+        assertThat(payment.getApprovedAt()).isNull();
+        assertThat(payment.getFailedAt()).isNull();
+        assertThat(payment.getCancelledAt()).isNull();
+    }
+
+    @Test
+    void create_fail_whenOrderIdNull() {
+        assertThatThrownBy(() -> Payment.create(null, PaymentMethod.CARD, 10000))
+                .isInstanceOf(InvalidOrderIdException.class);
+    }
+
+    @Test
+    void create_fail_whenPaymentMethodNull() {
+        assertThatThrownBy(() -> Payment.create(UUID.randomUUID(), null, 10000))
+                .isInstanceOf(InvalidPaymentMethodException.class);
+    }
+
+    @Test
+    void crete_fail_whenTotalPriceInvalid() {
+        assertThatThrownBy(() -> Payment.create(UUID.randomUUID(), PaymentMethod.CARD, 0))
+                .isInstanceOf(InvalidTotalPriceException.class);
+    }
+
+    @Test
+    void approve_success_andNormalize() {
+        Payment payment = Payment.create(UUID.randomUUID(), PaymentMethod.CARD, 10000);
+
+        payment.approve(" toss ", "  ");
+        assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.APPROVED);
+        assertThat(payment.getApprovedAt()).isNotNull();
+        assertThat(payment.getPgProvider()).isEqualTo("toss");
+        assertThat(payment.getPgTransactionId()).isNull();
+
+    }
+
+    @Test
+    void fail_success_andNormalize() {
+        Payment payment = Payment.create(UUID.randomUUID(), PaymentMethod.CARD, 1000);
+
+        payment.fail("   ");
+
+        assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.FAILED);
+        assertThat(payment.getFailedAt()).isNotNull();
+        assertThat(payment.getFailureReason()).isNull();
+    }
+
+    @Test
+    void cancel_success_afterApprove() {
+        Payment payment = Payment.create(UUID.randomUUID(), PaymentMethod.CARD, 1000);
+        payment.approve("pg", "tx");
+
+        payment.cancel();
+
+        assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELLED);
+        assertThat(payment.getCancelledAt()).isNotNull();
+    }
+
+    @Test
+    void statusTransition_fail() {
+        Payment payment = Payment.create(UUID.randomUUID(), PaymentMethod.CARD, 1000);
+        payment.fail("reason");
+
+        assertThatThrownBy(() -> payment.approve("pg", "tx"))
+                .isInstanceOf(InvalidPaymentStatusTransitionException.class);
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #34 

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Payment 도메인 리팩토링 |
| 🔍 목적 | 생성 경로 통일(create + private builder), 도메인 검증/예외 일원화, soft delete 조회 정책 반영 |
| 🛠️ 변경사항 | Payment 엔티티/예외/리포지토리/단위테스트 정리 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `Payment` 엔티티에 `@SQLRestriction("deleted_at IS NULL")` 적용 |
| 2️⃣ | 생성 경로를 `public static create(...) -> private @Builder`로 통일 |
| 3️⃣ | `create` 단계 도메인 검증(`orderId`, `paymentMethod`, `totalPrice`) 추가 |
| 4️⃣ | 상태 전이 예외를 `IllegalStateException`에서 payment 도메인 예외로 교체 |
| 5️⃣ | nullable 문자열 필드 정규화(trim 후 blank -> null) 적용 (`pgProvider`, `pgTransactionId`, `failureReason`) |
| 6️⃣ | `PaymentErrorCode` 및 예외 클래스 4종 추가 |
| 7️⃣ | `PaymentRepository`의 `...AndDeletedAtIsNull` 메서드를 `@SQLRestriction` 기반 조회 메서드로 정리 |
| 8️⃣ | `PaymentTest` 단위테스트 추가 (생성 검증/상태전이/정규화) |

---

## ✅ 테스트 체크리스트
- [x] `./gradlew compileJava`
- [x] `./gradlew test --tests "com.sparta.delivery.payment.domain.entity.PaymentTest"`
- [ ] `./gradlew test` 전체 (로컬 DB 미기동 시 `DeliveryApplicationTests` 실패 가능)

---

## 🙋‍♀️ 리뷰어 참고사항
- 이번 PR 범위는 **payment domain** 중심입니다. (`service` 리팩토링은 별도 진행)
- soft delete 조회는 `@SQLRestriction` 기준으로 동작하도록 맞췄습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 생성 시 주문ID, 결제 방법, 총액에 대한 필수 검증 추가
  * 결제 작업 중 발생하는 오류에 대해 구체적인 오류 코드 및 설명 제공

* **개선**
  * 결제 상태 전환 시 잘못된 상태 감지 및 처리 개선
  * 입력값 정규화 처리 추가

* **테스트**
  * 결제 도메인 엔티티 전체 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->