### PR TITLE
feat: 주문 도메인 모델 정리

### DIFF
--- a/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
@@ -1,6 +1,13 @@
 package com.sparta.delivery.order.domain.entity;
 
 import com.sparta.delivery.common.model.BaseEntity;
+import com.sparta.delivery.order.domain.exception.CancelTimeExceededException;
+import com.sparta.delivery.order.domain.exception.InvalidCancelDeadlineException;
+import com.sparta.delivery.order.domain.exception.InvalidDeliveryAddressSnapshotException;
+import com.sparta.delivery.order.domain.exception.InvalidOrderException;
+import com.sparta.delivery.order.domain.exception.InvalidOrderItemException;
+import com.sparta.delivery.order.domain.exception.InvalidOrderStatusException;
+import com.sparta.delivery.order.domain.exception.InvalidOrderTotalPriceException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,8 +18,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -27,6 +34,8 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
+
+    private static final long CANCEL_WINDOW_MINUTES = 5L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -52,12 +61,13 @@ public class Order extends BaseEntity {
     private String deliveryAddressSnapshot;
 
     private LocalDateTime rejectedAt;
+    @Column(nullable = false, updatable = false)
     private LocalDateTime cancelDeadlineAt;
     private LocalDateTime completedAt;
     private LocalDateTime canceledAt;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<OrderItem> items = new ArrayList<>();
+    private List<OrderItem> items = new ArrayList<>();
 
     @Builder
     private Order(
@@ -72,14 +82,14 @@ public class Order extends BaseEntity {
             LocalDateTime completedAt,
             LocalDateTime canceledAt
     ) {
-        this.storeId = storeId;
-        this.addressId = addressId;
-        this.userId = userId;
-        this.totalPrice = totalPrice;
-        this.status = status;
-        this.deliveryAddressSnapshot = deliveryAddressSnapshot;
+        this.storeId = requireStoreId(storeId);
+        this.addressId = requireAddressId(addressId);
+        this.userId = requireUserId(userId);
+        this.totalPrice = requireTotalPrice(totalPrice);
+        this.status = requireStatus(status);
+        this.deliveryAddressSnapshot = requireDeliveryAddressSnapshot(deliveryAddressSnapshot);
+        this.cancelDeadlineAt = requireCancelDeadline(cancelDeadlineAt);
         this.rejectedAt = rejectedAt;
-        this.cancelDeadlineAt = cancelDeadlineAt;
         this.completedAt = completedAt;
         this.canceledAt = canceledAt;
     }
@@ -88,23 +98,152 @@ public class Order extends BaseEntity {
             UUID storeId,
             UUID addressId,
             Long userId,
-            Integer totalPrice,
             String deliveryAddressSnapshot,
-            LocalDateTime cancelDeadlineAt
+            List<OrderItem> items
     ) {
-        return Order.builder()
+        requireOrderItems(items);
+
+        Order order = Order.builder()
                 .storeId(storeId)
                 .addressId(addressId)
                 .userId(userId)
-                .totalPrice(totalPrice)
+                .totalPrice(calculateTotalPrice(items))
                 .status(OrderStatus.PENDING)
                 .deliveryAddressSnapshot(deliveryAddressSnapshot)
-                .cancelDeadlineAt(cancelDeadlineAt)
+                .cancelDeadlineAt(LocalDateTime.now().plusMinutes(CANCEL_WINDOW_MINUTES))
                 .build();
+
+        for (OrderItem item : items) {
+            order.addOrderItem(item);
+        }
+
+        return order;
     }
 
     public void addOrderItem(OrderItem item) {
+        requireOrderItem(item);
         this.items.add(item);
         item.setOrder(this);
+        this.totalPrice = calculateTotalPrice(this.items);
+    }
+
+    public void accept() {
+        requireCurrentStatus(OrderStatus.PENDING);
+        this.status = OrderStatus.ACCEPTED;
+    }
+
+    public void startCooking() {
+        requireCurrentStatus(OrderStatus.ACCEPTED);
+        this.status = OrderStatus.COOKING;
+    }
+
+    public void startDelivery() {
+        requireCurrentStatus(OrderStatus.COOKING);
+        this.status = OrderStatus.DELIVERING;
+    }
+
+    public void markDelivered() {
+        requireCurrentStatus(OrderStatus.DELIVERING);
+        this.status = OrderStatus.DELIVERED;
+    }
+
+    public void complete() {
+        requireCurrentStatus(OrderStatus.DELIVERED);
+        this.status = OrderStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        requireCurrentStatus(OrderStatus.PENDING);
+        this.status = OrderStatus.REJECTED;
+        this.rejectedAt = LocalDateTime.now();
+    }
+
+    public void cancel() {
+        if (isCancelDeadlineExceeded()) {
+            throw new CancelTimeExceededException();
+        }
+        if (status != OrderStatus.PENDING && status != OrderStatus.ACCEPTED) {
+            throw new InvalidOrderStatusException();
+        }
+        this.status = OrderStatus.CANCELED;
+        this.canceledAt = LocalDateTime.now();
+    }
+
+    public boolean isCancelDeadlineExceeded() {
+        return LocalDateTime.now().isAfter(cancelDeadlineAt);
+    }
+
+    private static UUID requireStoreId(UUID storeId) {
+        if (storeId == null) {
+            throw new InvalidOrderException();
+        }
+        return storeId;
+    }
+
+    private static UUID requireAddressId(UUID addressId) {
+        if (addressId == null) {
+            throw new InvalidOrderException();
+        }
+        return addressId;
+    }
+
+    private static Long requireUserId(Long userId) {
+        if (userId == null) {
+            throw new InvalidOrderException();
+        }
+        return userId;
+    }
+
+    private static Integer requireTotalPrice(Integer totalPrice) {
+        if (totalPrice == null || totalPrice <= 0) {
+            throw new InvalidOrderTotalPriceException();
+        }
+        return totalPrice;
+    }
+
+    private static OrderStatus requireStatus(OrderStatus status) {
+        if (status == null) {
+            throw new InvalidOrderStatusException();
+        }
+        return status;
+    }
+
+    private static String requireDeliveryAddressSnapshot(String deliveryAddressSnapshot) {
+        if (deliveryAddressSnapshot == null || deliveryAddressSnapshot.isBlank()) {
+            throw new InvalidDeliveryAddressSnapshotException();
+        }
+        return deliveryAddressSnapshot;
+    }
+
+    private static LocalDateTime requireCancelDeadline(LocalDateTime cancelDeadlineAt) {
+        if (cancelDeadlineAt == null) {
+            throw new InvalidCancelDeadlineException();
+        }
+        return cancelDeadlineAt;
+    }
+
+    private void requireCurrentStatus(OrderStatus expectedStatus) {
+        if (this.status != expectedStatus) {
+            throw new InvalidOrderStatusException();
+        }
+    }
+
+    private static void requireOrderItems(List<OrderItem> items) {
+        if (items == null || items.isEmpty()) {
+            throw new InvalidOrderItemException();
+        }
+    }
+
+    private static Integer calculateTotalPrice(List<OrderItem> items) {
+        return items.stream()
+                .map(OrderItem::getLineTotalPrice)
+                .reduce(0, Integer::sum);
+    }
+
+    private void requireOrderItem(OrderItem item) {
+        if (item == null || (item.getOrder() != null && item.getOrder() != this)) {
+            throw new InvalidOrderItemException();
+        }
     }
 }

--- a/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
@@ -1,5 +1,9 @@
 package com.sparta.delivery.order.domain.entity;
 
+import com.sparta.delivery.order.domain.exception.InvalidOrderItemException;
+import com.sparta.delivery.order.domain.exception.InvalidOrderItemQuantityException;
+import com.sparta.delivery.order.domain.exception.InvalidOrderItemUnitPriceException;
+import com.sparta.delivery.order.domain.exception.InvalidProductNameSnapshotException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -65,11 +69,11 @@ public class OrderItem {
             Integer unitPrice,
             String productNameSnapshot
     ) {
-        this.productId = productId;
-        this.quantity = quantity;
-        this.unitPrice = unitPrice;
-        this.lineTotalPrice = quantity * unitPrice;
-        this.productNameSnapshot = productNameSnapshot;
+        this.productId = requireProductId(productId);
+        this.quantity = requireQuantity(quantity);
+        this.unitPrice = requireUnitPrice(unitPrice);
+        this.lineTotalPrice = this.quantity * this.unitPrice;
+        this.productNameSnapshot = requireProductNameSnapshot(productNameSnapshot);
     }
 
     public static OrderItem create(
@@ -87,6 +91,37 @@ public class OrderItem {
     }
 
     void setOrder(Order order) {
+        if (order == null || (this.order != null && this.order != order)) {
+            throw new InvalidOrderItemException();
+        }
         this.order = order;
+    }
+
+    private static UUID requireProductId(UUID productId) {
+        if (productId == null) {
+            throw new InvalidOrderItemException();
+        }
+        return productId;
+    }
+
+    private static Integer requireQuantity(Integer quantity) {
+        if (quantity == null || quantity <= 0) {
+            throw new InvalidOrderItemQuantityException();
+        }
+        return quantity;
+    }
+
+    private static Integer requireUnitPrice(Integer unitPrice) {
+        if (unitPrice == null || unitPrice <= 0) {
+            throw new InvalidOrderItemUnitPriceException();
+        }
+        return unitPrice;
+    }
+
+    private static String requireProductNameSnapshot(String productNameSnapshot) {
+        if (productNameSnapshot == null || productNameSnapshot.isBlank()) {
+            throw new InvalidProductNameSnapshotException();
+        }
+        return productNameSnapshot;
     }
 }

--- a/src/main/java/com/sparta/delivery/order/domain/exception/CancelTimeExceededException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/CancelTimeExceededException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class CancelTimeExceededException extends BaseException {
+
+    public CancelTimeExceededException() {
+        super(OrderErrorCode.CANCEL_TIME_EXCEEDED);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidCancelDeadlineException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidCancelDeadlineException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidCancelDeadlineException extends BaseException {
+
+    public InvalidCancelDeadlineException() {
+        super(OrderErrorCode.INVALID_CANCEL_DEADLINE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidDeliveryAddressSnapshotException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidDeliveryAddressSnapshotException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidDeliveryAddressSnapshotException extends BaseException {
+
+    public InvalidDeliveryAddressSnapshotException() {
+        super(OrderErrorCode.INVALID_DELIVERY_ADDRESS_SNAPSHOT);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidOrderException extends BaseException {
+
+    public InvalidOrderException() {
+        super(OrderErrorCode.INVALID_ORDER);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderItemException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderItemException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidOrderItemException extends BaseException {
+
+    public InvalidOrderItemException() {
+        super(OrderErrorCode.INVALID_ORDER_ITEM);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderItemQuantityException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderItemQuantityException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidOrderItemQuantityException extends BaseException {
+
+    public InvalidOrderItemQuantityException() {
+        super(OrderErrorCode.INVALID_ORDER_ITEM_QUANTITY);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderItemUnitPriceException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderItemUnitPriceException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidOrderItemUnitPriceException extends BaseException {
+
+    public InvalidOrderItemUnitPriceException() {
+        super(OrderErrorCode.INVALID_ORDER_ITEM_UNIT_PRICE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderStatusException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderStatusException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidOrderStatusException extends BaseException {
+
+    public InvalidOrderStatusException() {
+        super(OrderErrorCode.INVALID_ORDER_STATUS);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderTotalPriceException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidOrderTotalPriceException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidOrderTotalPriceException extends BaseException {
+
+    public InvalidOrderTotalPriceException() {
+        super(OrderErrorCode.INVALID_ORDER_TOTAL_PRICE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/InvalidProductNameSnapshotException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/InvalidProductNameSnapshotException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidProductNameSnapshotException extends BaseException {
+
+    public InvalidProductNameSnapshotException() {
+        super(OrderErrorCode.INVALID_PRODUCT_NAME_SNAPSHOT);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/OrderErrorCode.java
@@ -1,0 +1,27 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER-001", "주문을 찾을 수 없습니다."),
+    INVALID_ORDER(HttpStatus.BAD_REQUEST, "ORDER-002", "주문 정보가 올바르지 않습니다."),
+    INVALID_ORDER_TOTAL_PRICE(HttpStatus.BAD_REQUEST, "ORDER-003", "주문 총액은 0보다 커야 합니다."),
+    INVALID_DELIVERY_ADDRESS_SNAPSHOT(HttpStatus.BAD_REQUEST, "ORDER-004", "배송지 스냅샷은 필수입니다."),
+    INVALID_CANCEL_DEADLINE(HttpStatus.BAD_REQUEST, "ORDER-005", "주문 취소 가능 시간은 필수입니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER-006", "주문 상태 전이가 올바르지 않습니다."),
+    CANCEL_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, "ORDER-007", "주문 취소 가능 시간이 지났습니다."),
+    INVALID_ORDER_ITEM_QUANTITY(HttpStatus.BAD_REQUEST, "ORDER-008", "주문 수량은 1개 이상이어야 합니다."),
+    INVALID_ORDER_ITEM_UNIT_PRICE(HttpStatus.BAD_REQUEST, "ORDER-009", "주문 단가는 0보다 커야 합니다."),
+    INVALID_PRODUCT_NAME_SNAPSHOT(HttpStatus.BAD_REQUEST, "ORDER-010", "상품명 스냅샷은 필수입니다."),
+    INVALID_ORDER_ITEM(HttpStatus.BAD_REQUEST, "ORDER-011", "주문 항목이 올바르지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/OrderNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/OrderNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class OrderNotFoundException extends BaseException {
+
+    public OrderNotFoundException() {
+        super(OrderErrorCode.ORDER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/sparta/delivery/order/domain/repository/OrderItemRepository.java
@@ -1,9 +1,0 @@
-package com.sparta.delivery.order.domain.repository;
-
-import com.sparta.delivery.order.domain.entity.OrderItem;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.UUID;
-
-public interface OrderItemRepository extends JpaRepository<OrderItem, UUID> {
-}

--- a/src/main/java/com/sparta/delivery/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/delivery/order/domain/repository/OrderRepository.java
@@ -3,7 +3,12 @@ package com.sparta.delivery.order.domain.repository;
 import com.sparta.delivery.order.domain.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
+
+    List<Order> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    List<Order> findAllByStoreIdOrderByCreatedAtDesc(UUID storeId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #45   <!-- 연결된 이슈 번호 기재 -->

## ✨ 기능 요약
주문 도메인의 엔티티, 상태, 예외, Repository 구조를 정리하고  
주문 생성/상태 전이/취소 규칙의 기반이 되는 도메인 모델을 구현

## 📝 상세 내역
* 주문 상태 전이 메서드 추가
* 주문 생성 시 취소 가능 시간 5분 규칙을 엔티티에 추가
* 주문 취소 시 취소 가능 시간 초과 여부를 엔티티에서 직접 검증
* `Order` aggregate root 기준으로 `OrderItem`을 관리
* `totalPrice`는 외부 입력값이 아니라 `OrderItem` 합계로 계산
*  빈 주문(품목 0개)은 생성되지 않도록 검증을 추가

---

## 🙋‍♀️ 리뷰어 참고사항
- `Order.items`는 aggregate 내부 예외 허용 컬렉션으로 사용.
- 주문 총액은 `OrderItem` 합계 기준으로 계산되도록 정리.
- 취소 가능 시간 정책은 현재 생성 후 5분 이내로 반영.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 상태 관리 강화: 주문 수락, 요리 시작, 배송 시작, 배송 완료, 주문 완료 등의 명확한 상태 전환 추가
  * 자동 취소 기한 설정: 새 주문 생성 시 5분 이내 취소 가능하도록 자동 설정

* **버그 수정**
  * 주문 생성 및 항목 검증 강화: 가격, 수량, 배송 주소 등에 대한 엄격한 검증 추가
  * 기한 초과 취소 방지: 취소 기한 초과 시 취소 불가능하도록 제한

<!-- end of auto-generated comment: release notes by coderabbit.ai -->