### PR TITLE
refactor: Llm 엔티티 생성 방식과 provider 구조 정리

### DIFF
--- a/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
@@ -5,6 +5,7 @@ import com.sparta.delivery.ai.domain.exception.InvalidLlmNameException;
 import com.sparta.delivery.common.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
@@ -26,17 +27,36 @@ public class Llm extends BaseEntity {
     @Column(name = "llm_name", nullable = false, unique = true, length = 100)
     private String llmName;
 
+    @Column(name = "provider", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private LlmProvider provider;
+
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
 
-    public static Llm create(String llmName, boolean isActive) {
+    @Builder
+    private Llm(
+            String llmName,
+            LlmProvider provider,
+            boolean isActive
+    ) {
+        this.llmName = llmName;
+        this.provider = provider;
+        this.isActive = isActive;
+    }
+
+    public static Llm create(
+            String llmName,
+            LlmProvider provider,
+            boolean isActive
+    ) {
         validateLlmName(llmName);
 
-        Llm llm = new Llm();
-        llm.llmName = llmName;
-        llm.isActive = isActive;
-
-        return llm;
+        return Llm.builder()
+                .llmName(llmName)
+                .provider(provider)
+                .isActive(isActive)
+                .build();
     }
 
     public void updateName(String llmName) {
@@ -52,9 +72,9 @@ public class Llm extends BaseEntity {
         this.isActive = false;
     }
 
-    // not null, non-blank and max length 100
+    // max length 100
     private static void validateLlmName(String llmName) {
-        if (llmName.length() > 100) {
+        if (llmName != null && llmName.length() > 100) {
             throw new InvalidLlmNameException();
         }
     }

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.ai.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -43,6 +44,27 @@ public class LlmCall {
     @Column(name = "created_by", nullable = false)
     private Long createdBy;
 
+    @Builder
+    private LlmCall(
+            UUID llmId,
+            UUID productId,
+            String inputSnapshot,
+            String providerStatusCode,
+            String rawResponse,
+            String generatedText,
+            LocalDateTime createdAt,
+            Long createdBy
+    ) {
+        this.llmId = llmId;
+        this.productId = productId;
+        this.inputSnapshot = inputSnapshot;
+        this.providerStatusCode = providerStatusCode;
+        this.rawResponse = rawResponse;
+        this.generatedText = generatedText;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+    }
+
     public static LlmCall create(
             UUID llmId,
             UUID productId,
@@ -52,16 +74,16 @@ public class LlmCall {
             String generatedText,
             Long createdBy
     ) {
-        LlmCall llmCall = new LlmCall();
-        llmCall.llmId = llmId;
-        llmCall.productId = productId;
-        llmCall.inputSnapshot = inputSnapshot;
-        llmCall.providerStatusCode = providerStatusCode;
-        llmCall.rawResponse = rawResponse;
-        llmCall.generatedText = generatedText;
-        llmCall.createdAt = LocalDateTime.now();
-        llmCall.createdBy = createdBy;
-        return llmCall;
+        return LlmCall.builder()
+                .llmId(llmId)
+                .productId(productId)
+                .inputSnapshot(inputSnapshot)
+                .providerStatusCode(providerStatusCode)
+                .rawResponse(rawResponse)
+                .generatedText(generatedText)
+                .createdAt(LocalDateTime.now())
+                .createdBy(createdBy)
+                .build();
     }
 
 }

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/LlmProvider.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/LlmProvider.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.ai.domain.entity;
+
+public enum LlmProvider {
+    OPENAI,
+    GOOGLE,
+    ANTHROPIC
+}

--- a/src/test/java/com/sparta/delivery/ai/domain/entity/LlmTest.java
+++ b/src/test/java/com/sparta/delivery/ai/domain/entity/LlmTest.java
@@ -17,13 +17,15 @@ class LlmTest {
     void create_shouldCreateLlmSuccessfully() {
         // given
         String llmName = "gemini-1.5-flash";
+        LlmProvider provider = LlmProvider.OPENAI;
         boolean isActive = true;
 
         // when
-        Llm llm = Llm.create(llmName, isActive);
+        Llm llm = Llm.create(llmName, provider, isActive);
 
         // then
         assertThat(llm.getLlmName()).isEqualTo(llmName);
+        assertThat(llm.getProvider()).isEqualTo(provider);
         assertThat(llm.isActive()).isTrue();
     }
 
@@ -34,7 +36,7 @@ class LlmTest {
         String llmName = "a".repeat(101);
 
         // when
-        Throwable thrown = catchThrowable(() -> Llm.create(llmName, false));
+        Throwable thrown = catchThrowable(() -> Llm.create(llmName, LlmProvider.OPENAI, false));
 
         // then
         assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
@@ -46,7 +48,7 @@ class LlmTest {
     @DisplayName("updateName should change llmName successfully")
     void updateName_shouldChangeLlmNameSuccessfully() {
         // given
-        Llm llm = Llm.create("gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", LlmProvider.OPENAI, false);
         String updatedName = "gemini-2.0-flash";
 
         // when
@@ -60,7 +62,7 @@ class LlmTest {
     @DisplayName("updateName should throw when llmName length exceeds 100")
     void updateName_shouldThrow_whenLlmNameLengthExceeds100() {
         // given
-        Llm llm = Llm.create("gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", LlmProvider.OPENAI, false);
 
         // when
         Throwable thrown = catchThrowable(() -> llm.updateName("a".repeat(101)));
@@ -75,7 +77,7 @@ class LlmTest {
     @DisplayName("activate should set isActive to true")
     void activate_shouldSetIsActiveToTrue() {
         // given
-        Llm llm = Llm.create("gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", LlmProvider.OPENAI, false);
 
         // when
         llm.activate();
@@ -88,7 +90,7 @@ class LlmTest {
     @DisplayName("deactivate should set isActive to false")
     void deactivate_shouldSetIsActiveToFalse() {
         // given
-        Llm llm = Llm.create("gemini-1.5-flash", true);
+        Llm llm = Llm.create("gemini-1.5-flash", LlmProvider.OPENAI, true);
 
         // when
         llm.deactivate();
@@ -101,7 +103,7 @@ class LlmTest {
     @DisplayName("softDelete should mark entity as deleted")
     void softDelete_shouldMarkEntityAsDeleted() {
         // given
-        Llm llm = Llm.create("gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", LlmProvider.OPENAI, false);
         Long deletedBy = 1L;
 
         // when
@@ -117,7 +119,7 @@ class LlmTest {
     @DisplayName("softDelete should keep first deleted state when called twice")
     void softDelete_shouldKeepFirstDeletedState_whenCalledTwice() {
         // given
-        Llm llm = Llm.create("gemini-1.5-flash", false);
+        Llm llm = Llm.create("gemini-1.5-flash", LlmProvider.OPENAI, false);
 
         // when
         llm.softDelete(1L);


### PR DESCRIPTION
## 📌 관련 이슈
- Relates to #29

---

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | AI 엔티티 생성 경로 및 provider(OpenAI, Google 등) 구조 정리 |
| 🔍 목적 | AI API 구현 전에 `Llm`, `LlmCall` 엔티티 생성 방식을 정리하고, 이후 provider 기반 확장이 가능하도록 기반을 맞추기 위함 |
| 🛠️ 변경사항 | `Llm`에 provider 필드 추가, `Llm`/`LlmCall` 생성 경로를 `create() + private builder` 방식으로 통일 |

---

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `Llm` 엔티티에 `provider` 필드를 추가 |
| 2️⃣ | `Llm` 생성 방식을 `create() + private builder` 구조로 정리 |
| 3️⃣ | `LlmCall` 생성 방식도 `create() + private builder` 구조로 통일 |
| 4️⃣ | `Llm` 관련 테스트를 현재 엔티티 시그니처에 맞게 수정 |

---

✅ 테스트 체크리스트
- [x] AI 도메인 테스트 실행
- [x] `Llm` 엔티티 테스트 확인
- [x] `LlmCall` 엔티티 테스트 확인

---

## 🙋‍♀️ 리뷰어 참고사항
- 이번 PR은 AI API 구현 전 선행 리팩터 성격의 PR
- 현재 MVP 단계에서는 OpenAI를 우선 적용할 예정이지만, 이후 Gemini 등 provider 확장을 고려해 `Llm` 엔티티에 `provider` Enum 필드 선반영
- 서비스/컨트롤러/API 레벨 구현은 후속 PR에서 진행 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 여러 LLM 서비스 제공자 지원 추가: OpenAI, Google, Anthropic을 선택하여 사용 가능

* **리팩터**
  * 시스템 내부 객체 생성 및 관리 로직 개선으로 코드 유지보수성 강화
  * 향후 기능 추가를 위한 확장성 개선
  * 관련 테스트 코드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->