### PR TITLE
feat: Store 및 StoreCategory API 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/region/application/RegionService.java
+++ b/src/main/java/com/sparta/delivery/region/application/RegionService.java
@@ -28,12 +28,15 @@ public class RegionService {
     /** 지역 생성 */
     @Transactional
     public RegionResponse createRegion(RegionCreateRequest request) {
-        validateDuplicateRegionCode(request.regionCode());
+        String normalizedRegionCode = normalize(request.regionCode());
+        String normalizedRegionName = normalize(request.regionName());
+
+        validateDuplicateRegionCode(normalizedRegionCode);
         validateParentAndDepth(request.parentId(), request.depth());
 
         Region region = Region.create(
-                request.regionCode(),
-                request.regionName(),
+                normalizedRegionCode,
+                normalizedRegionName,
                 request.parentId(),
                 request.depth(),
                 request.isActive()
@@ -87,6 +90,7 @@ public class RegionService {
     @Transactional
     public RegionResponse updateRegion(UUID regionId, RegionUpdateRequest request) {
         Region region = getRegionOrThrow(regionId);
+        String normalizedRegionName = normalize(request.regionName());
 
         // 자기 자신을 부모로 지정할 수 없음
         if (request.parentId() != null && request.parentId().equals(regionId)) {
@@ -96,7 +100,7 @@ public class RegionService {
         validateParentAndDepth(request.parentId(), request.depth());
 
         region.update(
-                request.regionName(),
+                normalizedRegionName,
                 request.parentId(),
                 request.depth(),
                 request.isActive()
@@ -141,6 +145,10 @@ public class RegionService {
         if (regionRepository.existsByRegionCode(regionCode)) {
             throw new DuplicateRegionCodeException();
         }
+    }
+
+    private String normalize(String value) {
+        return value == null ? null : value.trim();
     }
 
     /** 부모 지역과 depth 규칙 검사 */

--- a/src/main/java/com/sparta/delivery/region/domain/entity/Region.java
+++ b/src/main/java/com/sparta/delivery/region/domain/entity/Region.java
@@ -43,13 +43,16 @@ public class Region extends BaseEntity {
     private Boolean isActive;
 
     private Region(String regionCode, String regionName, UUID parentId, Integer depth, Boolean isActive) {
-        validateRegionCode(regionCode);
-        validateRegionName(regionName);
+        String normalizedRegionCode = normalize(regionCode);
+        String normalizedRegionName = normalize(regionName);
+
+        validateRegionCode(normalizedRegionCode);
+        validateRegionName(normalizedRegionName);
         validateDepth(depth);
         validateIsActive(isActive);
 
-        this.regionCode = regionCode;
-        this.regionName = regionName;
+        this.regionCode = normalizedRegionCode;
+        this.regionName = normalizedRegionName;
         this.parentId = parentId;
         this.depth = depth;
         this.isActive = isActive;
@@ -65,11 +68,13 @@ public class Region extends BaseEntity {
             Integer depth,
             Boolean isActive
     ) {
-        validateRegionName(regionName);
+        String normalizedRegionName = normalize(regionName);
+
+        validateRegionName(normalizedRegionName);
         validateDepth(depth);
         validateIsActive(isActive);
 
-        this.regionName = regionName;
+        this.regionName = normalizedRegionName;
         this.parentId = parentId;
         this.depth = depth;
         this.isActive = isActive;
@@ -93,6 +98,10 @@ public class Region extends BaseEntity {
         if (regionName == null || regionName.isBlank()) {
             throw new InvalidRegionNameException();
         }
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.trim();
     }
 
     private static void validateDepth(Integer depth) {

--- a/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
@@ -31,13 +31,31 @@ public class StoreCategoryService {
         String normalizedCategoryName = normalize(request.categoryName());
 
         validateDuplicateCategoryName(normalizedCategoryName);
+        try {
+            Integer nextSortOrder = getNextSortOrder();
 
-        return createCategoryWithRetry(
-                normalizedCategoryName,
-                request.description(),
-                request.isActive(),
-                0
-        );
+            StoreCategory category = StoreCategory.create(
+                    normalizedCategoryName,
+                    request.description(),
+                    nextSortOrder,
+                    request.isActive()
+            );
+
+            StoreCategory savedCategory = storeCategoryRepository.saveAndFlush(category);
+
+            log.info("가게 카테고리 생성 완료 - categoryId={}, categoryName={}, sortOrder={}, 활성여부={}",
+                    savedCategory.getCategoryId(),
+                    savedCategory.getCategoryName(),
+                    savedCategory.getSortOrder(),
+                    savedCategory.getIsActive());
+
+            return StoreCategoryResponse.from(savedCategory);
+        } catch (DataIntegrityViolationException e) {
+            if (storeCategoryRepository.existsByCategoryNameIncludingDeleted(normalizedCategoryName)) {
+                throw new DuplicateCategoryNameException();
+            }
+            throw new DuplicateCategorySortOrderException();
+        }
     }
 
     /** 가게 카테고리 목록을 조회한다. */
@@ -109,21 +127,21 @@ public class StoreCategoryService {
     }
 
     private void validateDuplicateCategoryName(String categoryName) {
-        if (storeCategoryRepository.existsByCategoryName(categoryName)) {
+        if (storeCategoryRepository.existsByCategoryNameIncludingDeleted(categoryName)) {
             throw new DuplicateCategoryNameException();
         }
     }
 
     private void validateDuplicateCategoryName(StoreCategory category, String categoryName) {
         if (!category.getCategoryName().equals(categoryName)
-                && storeCategoryRepository.existsByCategoryName(categoryName)) {
+                && storeCategoryRepository.existsByCategoryNameIncludingDeleted(categoryName)) {
             throw new DuplicateCategoryNameException();
         }
     }
 
     private void validateDuplicateSortOrder(StoreCategory category, Integer sortOrder) {
         if (!category.getSortOrder().equals(sortOrder)
-                && storeCategoryRepository.existsBySortOrder(sortOrder)) {
+                && storeCategoryRepository.existsBySortOrderIncludingDeleted(sortOrder)) {
             throw new DuplicateCategorySortOrderException();
         }
     }
@@ -141,43 +159,5 @@ public class StoreCategoryService {
                 .stream()
                 .findFirst()
                 .orElse(null);
-    }
-
-    private StoreCategoryResponse createCategoryWithRetry(
-            String categoryName,
-            String description,
-            Boolean isActive,
-            int retryCount
-    ) {
-        try {
-            Integer nextSortOrder = getNextSortOrder();
-
-            StoreCategory category = StoreCategory.create(
-                    categoryName,
-                    description,
-                    nextSortOrder,
-                    isActive
-            );
-
-            StoreCategory savedCategory = storeCategoryRepository.saveAndFlush(category);
-
-            log.info("가게 카테고리 생성 완료 - categoryId={}, categoryName={}, sortOrder={}, 활성여부={}",
-                    savedCategory.getCategoryId(),
-                    savedCategory.getCategoryName(),
-                    savedCategory.getSortOrder(),
-                    savedCategory.getIsActive());
-
-            return StoreCategoryResponse.from(savedCategory);
-        } catch (DataIntegrityViolationException e) {
-            if (storeCategoryRepository.existsByCategoryName(categoryName)) {
-                throw new DuplicateCategoryNameException();
-            }
-
-            if (retryCount == 0) {
-                return createCategoryWithRetry(categoryName, description, isActive, 1);
-            }
-
-            throw new DuplicateCategorySortOrderException();
-        }
     }
 }

--- a/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
@@ -31,9 +31,8 @@ public class StoreCategoryService {
         String normalizedCategoryName = normalize(request.categoryName());
 
         validateDuplicateCategoryName(normalizedCategoryName);
+        Integer nextSortOrder = getNextSortOrder();
         try {
-            Integer nextSortOrder = getNextSortOrder();
-
             StoreCategory category = StoreCategory.create(
                     normalizedCategoryName,
                     request.description(),
@@ -54,7 +53,12 @@ public class StoreCategoryService {
             if (storeCategoryRepository.existsByCategoryNameIncludingDeleted(normalizedCategoryName)) {
                 throw new DuplicateCategoryNameException();
             }
-            throw new DuplicateCategorySortOrderException();
+
+            if (storeCategoryRepository.existsBySortOrderIncludingDeleted(nextSortOrder)) {
+                throw new DuplicateCategorySortOrderException();
+            }
+
+            throw e;
         }
     }
 

--- a/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
@@ -1,0 +1,122 @@
+package com.sparta.delivery.store.application;
+
+import com.sparta.delivery.store.domain.entity.StoreCategory;
+import com.sparta.delivery.store.domain.exception.DuplicateCategoryNameException;
+import com.sparta.delivery.store.domain.exception.DuplicateCategorySortOrderException;
+import com.sparta.delivery.store.domain.exception.StoreCategoryNotFoundException;
+import com.sparta.delivery.store.domain.repository.StoreCategoryRepository;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryResponse;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryUpdateRequest;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreCategoryService {
+
+    private final StoreCategoryRepository storeCategoryRepository;
+
+    /** 가게 카테고리를 생성한다. */
+    @Transactional
+    public StoreCategoryResponse createCategory(StoreCategoryCreateRequest request) {
+        String normalizedCategoryName = normalize(request.categoryName());
+
+        validateDuplicateCategoryName(normalizedCategoryName);
+
+        Integer nextSortOrder = getNextSortOrder();
+
+        StoreCategory category = StoreCategory.create(
+                normalizedCategoryName,
+                request.description(),
+                nextSortOrder,
+                request.isActive()
+        );
+
+        return StoreCategoryResponse.from(storeCategoryRepository.save(category));
+    }
+
+    /** 가게 카테고리 목록을 조회한다. */
+    public List<StoreCategoryResponse> getCategories() {
+        return storeCategoryRepository.findAllByOrderBySortOrderAsc().stream()
+                .map(StoreCategoryResponse::from)
+                .toList();
+    }
+
+    /** 활성화된 가게 카테고리 목록을 조회한다. */
+    public List<StoreCategoryResponse> getActiveCategories() {
+        return storeCategoryRepository.findAllByIsActiveTrueOrderBySortOrderAsc().stream()
+                .map(StoreCategoryResponse::from)
+                .toList();
+    }
+
+    /** 가게 카테고리를 단건 조회한다. */
+    public StoreCategoryResponse getCategory(UUID categoryId) {
+        return StoreCategoryResponse.from(getCategoryOrThrow(categoryId));
+    }
+
+    /** 가게 카테고리 정보를 수정한다. */
+    @Transactional
+    public StoreCategoryResponse updateCategory(UUID categoryId, StoreCategoryUpdateRequest request) {
+        StoreCategory category = getCategoryOrThrow(categoryId);
+        String normalizedCategoryName = normalize(request.categoryName());
+
+        validateDuplicateCategoryName(category, normalizedCategoryName);
+        validateDuplicateSortOrder(category, request.sortOrder());
+
+        category.update(
+                normalizedCategoryName,
+                request.description(),
+                request.sortOrder(),
+                request.isActive()
+        );
+
+        return StoreCategoryResponse.from(category);
+    }
+
+    /** 가게 카테고리를 삭제한다. */
+    @Transactional
+    public void deleteCategory(UUID categoryId, Long currentUserId) {
+        StoreCategory category = getCategoryOrThrow(categoryId);
+        category.softDelete(currentUserId);
+    }
+
+    private StoreCategory getCategoryOrThrow(UUID categoryId) {
+        return storeCategoryRepository.findByCategoryId(categoryId)
+                .orElseThrow(StoreCategoryNotFoundException::new);
+    }
+
+    private Integer getNextSortOrder() {
+        return storeCategoryRepository.findTopByOrderBySortOrderDesc()
+                .map(category -> category.getSortOrder() + 1)
+                .orElse(1);
+    }
+
+    private void validateDuplicateCategoryName(String categoryName) {
+        if (storeCategoryRepository.existsByCategoryName(categoryName)) {
+            throw new DuplicateCategoryNameException();
+        }
+    }
+
+    private void validateDuplicateCategoryName(StoreCategory category, String categoryName) {
+        if (!category.getCategoryName().equals(categoryName)
+                && storeCategoryRepository.existsByCategoryName(categoryName)) {
+            throw new DuplicateCategoryNameException();
+        }
+    }
+
+    private void validateDuplicateSortOrder(StoreCategory category, Integer sortOrder) {
+        if (!category.getSortOrder().equals(sortOrder)
+                && storeCategoryRepository.existsBySortOrder(sortOrder)) {
+            throw new DuplicateCategorySortOrderException();
+        }
+    }
+
+    private String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,24 +32,12 @@ public class StoreCategoryService {
 
         validateDuplicateCategoryName(normalizedCategoryName);
 
-        Integer nextSortOrder = getNextSortOrder();
-
-        StoreCategory category = StoreCategory.create(
+        return createCategoryWithRetry(
                 normalizedCategoryName,
                 request.description(),
-                nextSortOrder,
-                request.isActive()
+                request.isActive(),
+                0
         );
-
-        StoreCategory savedCategory = storeCategoryRepository.save(category);
-
-        log.info("가게 카테고리 생성 완료 - categoryId={}, categoryName={}, sortOrder={}, 활성여부={}",
-                savedCategory.getCategoryId(),
-                savedCategory.getCategoryName(),
-                savedCategory.getSortOrder(),
-                savedCategory.getIsActive());
-
-        return StoreCategoryResponse.from(savedCategory);
     }
 
     /** 가게 카테고리 목록을 조회한다. */
@@ -75,6 +65,7 @@ public class StoreCategoryService {
         StoreCategory category = getCategoryOrThrow(categoryId);
         String normalizedCategoryName = normalize(request.categoryName());
 
+        acquireSortOrderLock();
         validateDuplicateCategoryName(category, normalizedCategoryName);
         validateDuplicateSortOrder(category, request.sortOrder());
 
@@ -113,9 +104,8 @@ public class StoreCategoryService {
     }
 
     private Integer getNextSortOrder() {
-        return storeCategoryRepository.findTopByOrderBySortOrderDesc()
-                .map(category -> category.getSortOrder() + 1)
-                .orElse(1);
+        StoreCategory lastCategory = getLastCategoryWithLock();
+        return lastCategory == null ? 1 : lastCategory.getSortOrder() + 1;
     }
 
     private void validateDuplicateCategoryName(String categoryName) {
@@ -140,5 +130,54 @@ public class StoreCategoryService {
 
     private String normalize(String value) {
         return value == null ? null : value.trim();
+    }
+
+    private void acquireSortOrderLock() {
+        getLastCategoryWithLock();
+    }
+
+    private StoreCategory getLastCategoryWithLock() {
+        return storeCategoryRepository.findAllByOrderBySortOrderDesc(PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    private StoreCategoryResponse createCategoryWithRetry(
+            String categoryName,
+            String description,
+            Boolean isActive,
+            int retryCount
+    ) {
+        try {
+            Integer nextSortOrder = getNextSortOrder();
+
+            StoreCategory category = StoreCategory.create(
+                    categoryName,
+                    description,
+                    nextSortOrder,
+                    isActive
+            );
+
+            StoreCategory savedCategory = storeCategoryRepository.saveAndFlush(category);
+
+            log.info("가게 카테고리 생성 완료 - categoryId={}, categoryName={}, sortOrder={}, 활성여부={}",
+                    savedCategory.getCategoryId(),
+                    savedCategory.getCategoryName(),
+                    savedCategory.getSortOrder(),
+                    savedCategory.getIsActive());
+
+            return StoreCategoryResponse.from(savedCategory);
+        } catch (DataIntegrityViolationException e) {
+            if (storeCategoryRepository.existsByCategoryName(categoryName)) {
+                throw new DuplicateCategoryNameException();
+            }
+
+            if (retryCount == 0) {
+                return createCategoryWithRetry(categoryName, description, isActive, 1);
+            }
+
+            throw new DuplicateCategorySortOrderException();
+        }
     }
 }

--- a/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
@@ -11,9 +11,11 @@ import com.sparta.delivery.store.presentation.dto.StoreCategoryUpdateRequest;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -37,7 +39,15 @@ public class StoreCategoryService {
                 request.isActive()
         );
 
-        return StoreCategoryResponse.from(storeCategoryRepository.save(category));
+        StoreCategory savedCategory = storeCategoryRepository.save(category);
+
+        log.info("가게 카테고리 생성 완료 - categoryId={}, categoryName={}, sortOrder={}, 활성여부={}",
+                savedCategory.getCategoryId(),
+                savedCategory.getCategoryName(),
+                savedCategory.getSortOrder(),
+                savedCategory.getIsActive());
+
+        return StoreCategoryResponse.from(savedCategory);
     }
 
     /** 가게 카테고리 목록을 조회한다. */
@@ -75,6 +85,12 @@ public class StoreCategoryService {
                 request.isActive()
         );
 
+        log.info("가게 카테고리 수정 완료 - categoryId={}, categoryName={}, sortOrder={}, 활성여부={}",
+                categoryId,
+                category.getCategoryName(),
+                category.getSortOrder(),
+                category.getIsActive());
+
         return StoreCategoryResponse.from(category);
     }
 
@@ -83,6 +99,12 @@ public class StoreCategoryService {
     public void deleteCategory(UUID categoryId, Long currentUserId) {
         StoreCategory category = getCategoryOrThrow(categoryId);
         category.softDelete(currentUserId);
+
+        log.info("가게 카테고리 삭제 완료 - actorId={}, categoryId={}, categoryName={}, sortOrder={}",
+                currentUserId,
+                categoryId,
+                category.getCategoryName(),
+                category.getSortOrder());
     }
 
     private StoreCategory getCategoryOrThrow(UUID categoryId) {

--- a/src/main/java/com/sparta/delivery/store/application/StoreService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreService.java
@@ -1,0 +1,170 @@
+package com.sparta.delivery.store.application;
+
+import com.sparta.delivery.region.domain.entity.Region;
+import com.sparta.delivery.region.domain.repository.RegionRepository;
+import com.sparta.delivery.store.domain.entity.Store;
+import com.sparta.delivery.store.domain.entity.StoreCategory;
+import com.sparta.delivery.store.domain.exception.InactiveStoreCategoryException;
+import com.sparta.delivery.store.domain.exception.InactiveStoreRegionException;
+import com.sparta.delivery.store.domain.exception.InvalidStoreRegionDepthException;
+import com.sparta.delivery.store.domain.exception.StoreCategoryNotFoundException;
+import com.sparta.delivery.store.domain.exception.StoreForbiddenException;
+import com.sparta.delivery.store.domain.exception.StoreNotFoundException;
+import com.sparta.delivery.store.domain.exception.StoreRegionNotFoundException;
+import com.sparta.delivery.store.domain.repository.StoreCategoryRepository;
+import com.sparta.delivery.store.domain.repository.StoreRepository;
+import com.sparta.delivery.store.presentation.dto.StoreCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreResponse;
+import com.sparta.delivery.store.presentation.dto.StoreUpdateRequest;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+    private final StoreCategoryRepository storeCategoryRepository;
+    private final RegionRepository regionRepository;
+
+    /** 가게를 생성한다. */
+    @Transactional
+    public StoreResponse createStore(Long userId, StoreCreateRequest request) {
+        Region region = validateRegion(request.regionId());
+        StoreCategory category = validateCategory(request.categoryId());
+
+        Store store = Store.create(
+                region.getRegionId(),
+                category.getCategoryId(),
+                userId,
+                normalize(request.storeName()),
+                normalize(request.description()),
+                normalize(request.address()),
+                normalize(request.addressDetail()),
+                normalize(request.phoneNumber()),
+                request.minOrderAmount(),
+                request.isOpen(),
+                request.isActive(),
+                BigDecimal.ZERO,
+                0
+        );
+
+        return StoreResponse.from(storeRepository.save(store));
+    }
+
+    /** 조건에 따라 가게 목록을 조회한다. */
+    public List<StoreResponse> getStores(UUID regionId, UUID categoryId) {
+        List<Store> stores;
+
+        if (regionId != null && categoryId != null) {
+            stores = storeRepository.findByRegionIdAndCategoryId(regionId, categoryId);
+        } else if (regionId != null) {
+            stores = storeRepository.findByRegionId(regionId);
+        } else if (categoryId != null) {
+            stores = storeRepository.findByCategoryId(categoryId);
+        } else {
+            stores = storeRepository.findAll();
+        }
+
+        return stores.stream()
+                .map(StoreResponse::from)
+                .toList();
+    }
+
+    /** 가게를 단건 조회한다. */
+    public StoreResponse getStore(UUID storeId) {
+        return StoreResponse.from(getStoreOrThrow(storeId));
+    }
+
+    /** 가게 정보를 수정한다. */
+    @Transactional
+    public StoreResponse updateStore(
+            UUID storeId,
+            Long actorId,
+            UserRole actorRole,
+            StoreUpdateRequest request
+    ) {
+        Store store = getStoreOrThrow(storeId);
+        validateStoreAccess(store, actorId, actorRole);
+
+        Region region = validateRegion(request.regionId());
+        StoreCategory category = validateCategory(request.categoryId());
+
+        store.update(
+                region.getRegionId(),
+                category.getCategoryId(),
+                normalize(request.storeName()),
+                normalize(request.description()),
+                normalize(request.address()),
+                normalize(request.addressDetail()),
+                normalize(request.phoneNumber()),
+                request.minOrderAmount(),
+                request.isOpen(),
+                request.isActive()
+        );
+
+        return StoreResponse.from(store);
+    }
+
+    /** 가게를 삭제한다. */
+    @Transactional
+    public void deleteStore(UUID storeId, Long actorId, UserRole actorRole) {
+        Store store = getStoreOrThrow(storeId);
+        validateStoreAccess(store, actorId, actorRole);
+
+        store.softDelete(actorId);
+    }
+
+    private Store getStoreOrThrow(UUID storeId) {
+        return storeRepository.findByStoreId(storeId)
+                .orElseThrow(StoreNotFoundException::new);
+    }
+
+    private void validateStoreAccess(Store store, Long actorId, UserRole actorRole) {
+        if (actorRole == UserRole.MANAGER || actorRole == UserRole.MASTER) {
+            return;
+        }
+
+        if (actorRole == UserRole.OWNER && store.getUserId().equals(actorId)) {
+            return;
+        }
+
+        throw new StoreForbiddenException();
+    }
+
+    private Region validateRegion(UUID regionId) {
+        Region region = regionRepository.findByRegionId(regionId)
+                .orElseThrow(StoreRegionNotFoundException::new);
+
+        if (!region.getIsActive()) {
+            throw new InactiveStoreRegionException();
+        }
+
+        if (region.getDepth() != 3) {
+            throw new InvalidStoreRegionDepthException();
+        }
+
+        return region;
+    }
+
+    private StoreCategory validateCategory(UUID categoryId) {
+        StoreCategory category = storeCategoryRepository.findByCategoryId(categoryId)
+                .orElseThrow(StoreCategoryNotFoundException::new);
+
+        if (!category.getIsActive()) {
+            throw new InactiveStoreCategoryException();
+        }
+
+        return category;
+    }
+
+    private String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/application/StoreService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreService.java
@@ -70,10 +70,12 @@ public class StoreService {
     }
 
     /** 조건에 따라 가게 목록을 조회한다. */
-    public List<StoreResponse> getStores(UUID regionId, UUID categoryId) {
+    public List<StoreResponse> getStores(UUID regionId, UUID categoryId, Long userId) {
         List<Store> stores;
 
-        if (regionId != null && categoryId != null) {
+        if (userId != null) {
+            stores = storeRepository.findByUserId(userId);
+        } else if (regionId != null && categoryId != null) {
             stores = storeRepository.findByRegionIdAndCategoryId(regionId, categoryId);
         } else if (regionId != null) {
             stores = storeRepository.findByRegionId(regionId);

--- a/src/main/java/com/sparta/delivery/store/application/StoreService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreService.java
@@ -21,9 +21,11 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -55,7 +57,16 @@ public class StoreService {
                 0
         );
 
-        return StoreResponse.from(storeRepository.save(store));
+        Store savedStore = storeRepository.save(store);
+
+        log.info("가게 생성 완료 - userId={}, storeId={}, storeName={}, regionId={}, categoryId={}",
+                userId,
+                savedStore.getStoreId(),
+                savedStore.getStoreName(),
+                savedStore.getRegionId(),
+                savedStore.getCategoryId());
+
+        return StoreResponse.from(savedStore);
     }
 
     /** 조건에 따라 가게 목록을 조회한다. */
@@ -109,6 +120,14 @@ public class StoreService {
                 request.isActive()
         );
 
+        log.info("가게 수정 완료 - actorId={}, actorRole={}, storeId={}, storeName={}, regionId={}, categoryId={}",
+                actorId,
+                actorRole,
+                storeId,
+                store.getStoreName(),
+                store.getRegionId(),
+                store.getCategoryId());
+
         return StoreResponse.from(store);
     }
 
@@ -119,6 +138,12 @@ public class StoreService {
         validateStoreAccess(store, actorId, actorRole);
 
         store.softDelete(actorId);
+
+        log.info("가게 삭제 완료 - actorId={}, actorRole={}, storeId={}, storeName={}",
+                actorId,
+                actorRole,
+                storeId,
+                store.getStoreName());
     }
 
     private Store getStoreOrThrow(UUID storeId) {

--- a/src/main/java/com/sparta/delivery/store/domain/entity/Store.java
+++ b/src/main/java/com/sparta/delivery/store/domain/entity/Store.java
@@ -1,27 +1,38 @@
 package com.sparta.delivery.store.domain.entity;
 
 import com.sparta.delivery.common.model.BaseEntity;
+import com.sparta.delivery.store.domain.exception.InvalidCategoryIdException;
+import com.sparta.delivery.store.domain.exception.InvalidMinOrderAmountException;
+import com.sparta.delivery.store.domain.exception.InvalidRegionIdException;
+import com.sparta.delivery.store.domain.exception.InvalidReviewCountException;
+import com.sparta.delivery.store.domain.exception.InvalidStoreActiveStatusException;
+import com.sparta.delivery.store.domain.exception.InvalidStoreAddressException;
+import com.sparta.delivery.store.domain.exception.InvalidStoreNameException;
+import com.sparta.delivery.store.domain.exception.InvalidStoreOpenStatusException;
+import com.sparta.delivery.store.domain.exception.InvalidUserIdException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_store")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends BaseEntity {
 
     @Id
-    @GeneratedValue
-    @UuidGenerator
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "store_id", updatable = false, nullable = false)
     private UUID storeId;
 
@@ -64,6 +75,7 @@ public class Store extends BaseEntity {
     @Column(name = "review_count")
     private Integer reviewCount;
 
+    @Builder(access = AccessLevel.PRIVATE)
     private Store(
             UUID regionId,
             UUID categoryId,
@@ -79,14 +91,30 @@ public class Store extends BaseEntity {
             BigDecimal avgRating,
             Integer reviewCount
     ) {
+        String normalizedStoreName = normalize(storeName);
+        String normalizedDescription = normalize(description);
+        String normalizedAddress = normalize(address);
+        String normalizedAddressDetail = normalize(addressDetail);
+        String normalizedPhoneNumber = normalize(phoneNumber);
+
+        validateRegionId(regionId);
+        validateCategoryId(categoryId);
+        validateUserId(userId);
+        validateStoreName(normalizedStoreName);
+        validateAddress(normalizedAddress);
+        validateMinOrderAmount(minOrderAmount);
+        validateIsOpen(isOpen);
+        validateIsActive(isActive);
+        validateReviewCount(reviewCount);
+
         this.regionId = regionId;
         this.categoryId = categoryId;
         this.userId = userId;
-        this.storeName = storeName;
-        this.description = description;
-        this.address = address;
-        this.addressDetail = addressDetail;
-        this.phoneNumber = phoneNumber;
+        this.storeName = normalizedStoreName;
+        this.description = normalizedDescription;
+        this.address = normalizedAddress;
+        this.addressDetail = normalizedAddressDetail;
+        this.phoneNumber = normalizedPhoneNumber;
         this.minOrderAmount = minOrderAmount;
         this.isOpen = isOpen;
         this.isActive = isActive;
@@ -94,6 +122,7 @@ public class Store extends BaseEntity {
         this.reviewCount = reviewCount;
     }
 
+    /** 가게를 생성한다. */
     public static Store create(
             UUID regionId,
             UUID categoryId,
@@ -109,23 +138,24 @@ public class Store extends BaseEntity {
             BigDecimal avgRating,
             Integer reviewCount
     ) {
-        return new Store(
-                regionId,
-                categoryId,
-                userId,
-                storeName,
-                description,
-                address,
-                addressDetail,
-                phoneNumber,
-                minOrderAmount,
-                isOpen,
-                isActive,
-                avgRating,
-                reviewCount
-        );
+        return Store.builder()
+                .regionId(regionId)
+                .categoryId(categoryId)
+                .userId(userId)
+                .storeName(storeName)
+                .description(description)
+                .address(address)
+                .addressDetail(addressDetail)
+                .phoneNumber(phoneNumber)
+                .minOrderAmount(minOrderAmount)
+                .isOpen(isOpen)
+                .isActive(isActive)
+                .avgRating(avgRating)
+                .reviewCount(reviewCount)
+                .build();
     }
 
+    /** 가게 기본 정보를 수정한다. */
     public void update(
             UUID regionId,
             UUID categoryId,
@@ -138,36 +168,115 @@ public class Store extends BaseEntity {
             Boolean isOpen,
             Boolean isActive
     ) {
+        String normalizedStoreName = normalize(storeName);
+        String normalizedDescription = normalize(description);
+        String normalizedAddress = normalize(address);
+        String normalizedAddressDetail = normalize(addressDetail);
+        String normalizedPhoneNumber = normalize(phoneNumber);
+
+        validateRegionId(regionId);
+        validateCategoryId(categoryId);
+        validateStoreName(normalizedStoreName);
+        validateAddress(normalizedAddress);
+        validateMinOrderAmount(minOrderAmount);
+        validateIsOpen(isOpen);
+        validateIsActive(isActive);
+
         this.regionId = regionId;
         this.categoryId = categoryId;
-        this.storeName = storeName;
-        this.description = description;
-        this.address = address;
-        this.addressDetail = addressDetail;
-        this.phoneNumber = phoneNumber;
+        this.storeName = normalizedStoreName;
+        this.description = normalizedDescription;
+        this.address = normalizedAddress;
+        this.addressDetail = normalizedAddressDetail;
+        this.phoneNumber = normalizedPhoneNumber;
         this.minOrderAmount = minOrderAmount;
         this.isOpen = isOpen;
         this.isActive = isActive;
     }
 
+    /** 가게 영업 상태를 연다. */
     public void open() {
         this.isOpen = true;
     }
 
+    /** 가게 영업 상태를 닫는다. */
     public void close() {
         this.isOpen = false;
     }
 
+    /** 가게를 활성 상태로 변경한다. */
     public void activate() {
         this.isActive = true;
     }
 
+    /** 가게를 비활성 상태로 변경한다. */
     public void deactivate() {
         this.isActive = false;
     }
 
+    /** 가게의 리뷰 평점과 리뷰 수를 갱신한다. */
     public void updateRating(BigDecimal avgRating, Integer reviewCount) {
+        validateReviewCount(reviewCount);
+
         this.avgRating = avgRating;
         this.reviewCount = reviewCount;
+    }
+
+    private static void validateRegionId(UUID regionId) {
+        if (regionId == null) {
+            throw new InvalidRegionIdException();
+        }
+    }
+
+    private static void validateCategoryId(UUID categoryId) {
+        if (categoryId == null) {
+            throw new InvalidCategoryIdException();
+        }
+    }
+
+    private static void validateUserId(Long userId) {
+        if (userId == null || userId < 1) {
+            throw new InvalidUserIdException();
+        }
+    }
+
+    private static void validateStoreName(String storeName) {
+        if (storeName == null || storeName.isBlank()) {
+            throw new InvalidStoreNameException();
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private static void validateAddress(String address) {
+        if (address == null || address.isBlank()) {
+            throw new InvalidStoreAddressException();
+        }
+    }
+
+    private static void validateMinOrderAmount(Integer minOrderAmount) {
+        if (minOrderAmount == null || minOrderAmount < 0) {
+            throw new InvalidMinOrderAmountException();
+        }
+    }
+
+    private static void validateIsOpen(Boolean isOpen) {
+        if (isOpen == null) {
+            throw new InvalidStoreOpenStatusException();
+        }
+    }
+
+    private static void validateIsActive(Boolean isActive) {
+        if (isActive == null) {
+            throw new InvalidStoreActiveStatusException();
+        }
+    }
+
+    private static void validateReviewCount(Integer reviewCount) {
+        if (reviewCount != null && reviewCount < 0) {
+            throw new InvalidReviewCountException();
+        }
     }
 }

--- a/src/main/java/com/sparta/delivery/store/domain/entity/StoreCategory.java
+++ b/src/main/java/com/sparta/delivery/store/domain/entity/StoreCategory.java
@@ -1,79 +1,130 @@
 package com.sparta.delivery.store.domain.entity;
 
 import com.sparta.delivery.common.model.BaseEntity;
+import com.sparta.delivery.store.domain.exception.InvalidCategoryActiveStatusException;
+import com.sparta.delivery.store.domain.exception.InvalidCategoryNameException;
+import com.sparta.delivery.store.domain.exception.InvalidCategorySortOrderException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_store_category")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StoreCategory extends BaseEntity {
 
     @Id
-    @GeneratedValue
-    @UuidGenerator
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "category_id", updatable = false, nullable = false)
     private UUID categoryId;
 
-    @Column(name = "category_name", nullable = false, length = 100)
+    @Column(name = "category_name", nullable = false, unique = true, length = 100)
     private String categoryName;
 
     @Column(name = "description")
     private String description;
 
-    @Column(name = "sort_order")
+    @Column(name = "sort_order", unique = true)
     private Integer sortOrder;
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
 
+    @Builder(access = AccessLevel.PRIVATE)
     private StoreCategory(
             String categoryName,
             String description,
             Integer sortOrder,
             Boolean isActive
     ) {
-        this.categoryName = categoryName;
-        this.description = description;
+        String normalizedCategoryName = normalize(categoryName);
+        String normalizedDescription = normalize(description);
+
+        validateCategoryName(normalizedCategoryName);
+        validateSortOrder(sortOrder);
+        validateIsActive(isActive);
+
+        this.categoryName = normalizedCategoryName;
+        this.description = normalizedDescription;
         this.sortOrder = sortOrder;
         this.isActive = isActive;
     }
 
+    /** 가게 카테고리를 생성한다. */
     public static StoreCategory create(
             String categoryName,
             String description,
             Integer sortOrder,
             Boolean isActive
     ) {
-        return new StoreCategory(categoryName, description, sortOrder, isActive);
+        return StoreCategory.builder()
+                .categoryName(categoryName)
+                .description(description)
+                .sortOrder(sortOrder)
+                .isActive(isActive)
+                .build();
     }
 
+    /** 가게 카테고리 정보를 수정한다. */
     public void update(
             String categoryName,
             String description,
             Integer sortOrder,
             Boolean isActive
     ) {
-        this.categoryName = categoryName;
-        this.description = description;
+        String normalizedCategoryName = normalize(categoryName);
+        String normalizedDescription = normalize(description);
+
+        validateCategoryName(normalizedCategoryName);
+        validateSortOrder(sortOrder);
+        validateIsActive(isActive);
+
+        this.categoryName = normalizedCategoryName;
+        this.description = normalizedDescription;
         this.sortOrder = sortOrder;
         this.isActive = isActive;
     }
 
+    /** 가게 카테고리를 활성 상태로 변경한다. */
     public void activate() {
         this.isActive = true;
     }
 
+    /** 가게 카테고리를 비활성 상태로 변경한다. */
     public void deactivate() {
         this.isActive = false;
+    }
+
+    private static void validateCategoryName(String categoryName) {
+        if (categoryName == null || categoryName.isBlank()) {
+            throw new InvalidCategoryNameException();
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private static void validateSortOrder(Integer sortOrder) {
+        if (sortOrder != null && sortOrder < 0) {
+            throw new InvalidCategorySortOrderException();
+        }
+    }
+
+    private static void validateIsActive(Boolean isActive) {
+        if (isActive == null) {
+            throw new InvalidCategoryActiveStatusException();
+        }
     }
 }

--- a/src/main/java/com/sparta/delivery/store/domain/exception/DuplicateCategoryNameException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/DuplicateCategoryNameException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class DuplicateCategoryNameException extends BaseException {
+
+    public DuplicateCategoryNameException() {
+        super(StoreErrorCode.DUPLICATE_CATEGORY_NAME);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/DuplicateCategorySortOrderException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/DuplicateCategorySortOrderException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class DuplicateCategorySortOrderException extends BaseException {
+
+    public DuplicateCategorySortOrderException() {
+        super(StoreErrorCode.DUPLICATE_CATEGORY_SORT_ORDER);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InactiveStoreCategoryException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InactiveStoreCategoryException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InactiveStoreCategoryException extends BaseException {
+
+    public InactiveStoreCategoryException() {
+        super(StoreErrorCode.INACTIVE_STORE_CATEGORY);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InactiveStoreRegionException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InactiveStoreRegionException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InactiveStoreRegionException extends BaseException {
+
+    public InactiveStoreRegionException() {
+        super(StoreErrorCode.INACTIVE_STORE_REGION);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidCategoryActiveStatusException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidCategoryActiveStatusException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidCategoryActiveStatusException extends BaseException {
+
+    public InvalidCategoryActiveStatusException() {
+        super(StoreErrorCode.INVALID_CATEGORY_ACTIVE_STATUS);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidCategoryIdException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidCategoryIdException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidCategoryIdException extends BaseException {
+
+    public InvalidCategoryIdException() {
+        super(StoreErrorCode.INVALID_CATEGORY_ID);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidCategoryNameException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidCategoryNameException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidCategoryNameException extends BaseException {
+
+    public InvalidCategoryNameException() {
+        super(StoreErrorCode.INVALID_CATEGORY_NAME);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidCategorySortOrderException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidCategorySortOrderException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidCategorySortOrderException extends BaseException {
+
+    public InvalidCategorySortOrderException() {
+        super(StoreErrorCode.INVALID_CATEGORY_SORT_ORDER);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidMinOrderAmountException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidMinOrderAmountException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidMinOrderAmountException extends BaseException {
+
+    public InvalidMinOrderAmountException() {
+        super(StoreErrorCode.INVALID_MIN_ORDER_AMOUNT);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidRegionIdException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidRegionIdException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidRegionIdException extends BaseException {
+
+    public InvalidRegionIdException() {
+        super(StoreErrorCode.INVALID_REGION_ID);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidReviewCountException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidReviewCountException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidReviewCountException extends BaseException {
+
+    public InvalidReviewCountException() {
+        super(StoreErrorCode.INVALID_REVIEW_COUNT);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreActiveStatusException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreActiveStatusException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidStoreActiveStatusException extends BaseException {
+
+    public InvalidStoreActiveStatusException() {
+        super(StoreErrorCode.INVALID_STORE_ACTIVE_STATUS);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreAddressException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreAddressException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidStoreAddressException extends BaseException {
+
+    public InvalidStoreAddressException() {
+        super(StoreErrorCode.INVALID_STORE_ADDRESS);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreNameException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreNameException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidStoreNameException extends BaseException {
+
+    public InvalidStoreNameException() {
+        super(StoreErrorCode.INVALID_STORE_NAME);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreOpenStatusException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreOpenStatusException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidStoreOpenStatusException extends BaseException {
+
+    public InvalidStoreOpenStatusException() {
+        super(StoreErrorCode.INVALID_STORE_OPEN_STATUS);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreRegionDepthException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidStoreRegionDepthException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidStoreRegionDepthException extends BaseException {
+
+    public InvalidStoreRegionDepthException() {
+        super(StoreErrorCode.INVALID_STORE_REGION_DEPTH);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/InvalidUserIdException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/InvalidUserIdException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidUserIdException extends BaseException {
+
+    public InvalidUserIdException() {
+        super(StoreErrorCode.INVALID_USER_ID);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/StoreCategoryNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/StoreCategoryNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class StoreCategoryNotFoundException extends BaseException {
+
+    public StoreCategoryNotFoundException() {
+        super(StoreErrorCode.STORE_CATEGORY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/StoreErrorCode.java
@@ -1,0 +1,36 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StoreErrorCode implements ErrorCode {
+    INVALID_REGION_ID(HttpStatus.BAD_REQUEST, "STORE-001", "지역 ID는 필수입니다."),
+    INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "STORE-002", "카테고리 ID는 필수입니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "STORE-003", "사용자 ID가 올바르지 않습니다."),
+    INVALID_STORE_NAME(HttpStatus.BAD_REQUEST, "STORE-004", "가게명은 비어 있을 수 없습니다."),
+    INVALID_STORE_ADDRESS(HttpStatus.BAD_REQUEST, "STORE-005", "가게 주소는 비어 있을 수 없습니다."),
+    INVALID_MIN_ORDER_AMOUNT(HttpStatus.BAD_REQUEST, "STORE-006", "최소 주문 금액은 0 이상이어야 합니다."),
+    INVALID_STORE_OPEN_STATUS(HttpStatus.BAD_REQUEST, "STORE-007", "영업 상태는 필수입니다."),
+    INVALID_STORE_ACTIVE_STATUS(HttpStatus.BAD_REQUEST, "STORE-008", "활성 상태는 필수입니다."),
+    INVALID_REVIEW_COUNT(HttpStatus.BAD_REQUEST, "STORE-009", "리뷰 수는 0 이상이어야 합니다."),
+    INVALID_STORE_REGION_DEPTH(HttpStatus.BAD_REQUEST, "STORE-010", "가게 지역은 depth 3 지역만 선택할 수 있습니다."),
+    INVALID_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "STORE-011", "카테고리명은 비어 있을 수 없습니다."),
+    INVALID_CATEGORY_SORT_ORDER(HttpStatus.BAD_REQUEST, "STORE-012", "카테고리 정렬 순서는 0 이상이어야 합니다."),
+    INVALID_CATEGORY_ACTIVE_STATUS(HttpStatus.BAD_REQUEST, "STORE-013", "카테고리 활성 상태는 필수입니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE-014", "가게를 찾을 수 없습니다."),
+    STORE_FORBIDDEN(HttpStatus.FORBIDDEN, "STORE-015", "해당 가게에 대한 권한이 없습니다."),
+    STORE_REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE-016", "가게 지역을 찾을 수 없습니다."),
+    STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE-017", "가게 카테고리를 찾을 수 없습니다."),
+    INACTIVE_STORE_REGION(HttpStatus.BAD_REQUEST, "STORE-018", "비활성 지역에는 가게를 등록할 수 없습니다."),
+    INACTIVE_STORE_CATEGORY(HttpStatus.BAD_REQUEST, "STORE-019", "비활성 카테고리에는 가게를 등록할 수 없습니다."),
+    DUPLICATE_CATEGORY_NAME(HttpStatus.CONFLICT, "STORE-020", "이미 사용 중인 카테고리명입니다."),
+    DUPLICATE_CATEGORY_SORT_ORDER(HttpStatus.CONFLICT, "STORE-021", "이미 사용 중인 카테고리 정렬 순서입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/StoreForbiddenException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/StoreForbiddenException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class StoreForbiddenException extends BaseException {
+
+    public StoreForbiddenException() {
+        super(StoreErrorCode.STORE_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/StoreNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/StoreNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class StoreNotFoundException extends BaseException {
+
+    public StoreNotFoundException() {
+        super(StoreErrorCode.STORE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/exception/StoreRegionNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/store/domain/exception/StoreRegionNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.store.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class StoreRegionNotFoundException extends BaseException {
+
+    public StoreRegionNotFoundException() {
+        super(StoreErrorCode.STORE_REGION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/delivery/store/domain/repository/StoreCategoryRepository.java
@@ -4,7 +4,10 @@ import com.sparta.delivery.store.domain.entity.StoreCategory;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.domain.Pageable;
 
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
 
@@ -14,7 +17,8 @@ public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UU
 
     Optional<StoreCategory> findByCategoryId(UUID categoryId);
 
-    Optional<StoreCategory> findTopByOrderBySortOrderDesc();
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<StoreCategory> findAllByOrderBySortOrderDesc(Pageable pageable);
 
     List<StoreCategory> findAllByOrderBySortOrderAsc();
 

--- a/src/main/java/com/sparta/delivery/store/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/delivery/store/domain/repository/StoreCategoryRepository.java
@@ -8,11 +8,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
 
-    boolean existsByCategoryNameAndDeletedAtIsNull(String categoryName);
+    boolean existsByCategoryName(String categoryName);
 
-    Optional<StoreCategory> findByCategoryIdAndDeletedAtIsNull(UUID categoryId);
+    boolean existsBySortOrder(Integer sortOrder);
 
-    List<StoreCategory> findAllByDeletedAtIsNullOrderBySortOrderAsc();
+    Optional<StoreCategory> findByCategoryId(UUID categoryId);
 
-    List<StoreCategory> findAllByIsActiveTrueAndDeletedAtIsNullOrderBySortOrderAsc();
+    Optional<StoreCategory> findTopByOrderBySortOrderDesc();
+
+    List<StoreCategory> findAllByOrderBySortOrderAsc();
+
+    List<StoreCategory> findAllByIsActiveTrueOrderBySortOrderAsc();
 }

--- a/src/main/java/com/sparta/delivery/store/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/delivery/store/domain/repository/StoreCategoryRepository.java
@@ -6,14 +6,28 @@ import java.util.Optional;
 import java.util.UUID;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
 
     boolean existsByCategoryName(String categoryName);
 
     boolean existsBySortOrder(Integer sortOrder);
+
+    @Query(
+            value = "select exists (select 1 from p_store_category where category_name = :categoryName)",
+            nativeQuery = true
+    )
+    boolean existsByCategoryNameIncludingDeleted(@Param("categoryName") String categoryName);
+
+    @Query(
+            value = "select exists (select 1 from p_store_category where sort_order = :sortOrder)",
+            nativeQuery = true
+    )
+    boolean existsBySortOrderIncludingDeleted(@Param("sortOrder") Integer sortOrder);
 
     Optional<StoreCategory> findByCategoryId(UUID categoryId);
 

--- a/src/main/java/com/sparta/delivery/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/delivery/store/domain/repository/StoreRepository.java
@@ -8,11 +8,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
 
-    Optional<Store> findByStoreIdAndDeletedAtIsNull(UUID storeId);
+    Optional<Store> findByStoreId(UUID storeId);
 
-    List<Store> findByUserIdAndDeletedAtIsNull(Long userId);
+    List<Store> findByUserId(Long userId);
 
-    List<Store> findByRegionIdAndDeletedAtIsNull(UUID regionId);
+    List<Store> findByRegionId(UUID regionId);
 
-    List<Store> findByCategoryIdAndDeletedAtIsNull(UUID categoryId);
+    List<Store> findByCategoryId(UUID categoryId);
+
+    List<Store> findByRegionIdAndCategoryId(UUID regionId, UUID categoryId);
 }

--- a/src/main/java/com/sparta/delivery/store/presentation/StoreCategoryController.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/StoreCategoryController.java
@@ -1,0 +1,89 @@
+package com.sparta.delivery.store.presentation;
+
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.store.application.StoreCategoryService;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryResponse;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "StoreCategory", description = "가게 카테고리 관리 API")
+@RestController
+@RequestMapping("/api/v1/store-categories")
+@RequiredArgsConstructor
+public class StoreCategoryController {
+
+    private final StoreCategoryService storeCategoryService;
+
+    @Operation(summary = "가게 카테고리 생성")
+    @PostMapping
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<StoreCategoryResponse>> createCategory(
+            @RequestBody @Valid StoreCategoryCreateRequest request
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(storeCategoryService.createCategory(request)));
+    }
+
+    @Operation(summary = "가게 카테고리 목록 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<StoreCategoryResponse>>> getCategories() {
+        return ResponseEntity.ok(ApiResponse.success(storeCategoryService.getCategories()));
+    }
+
+    @Operation(summary = "활성 가게 카테고리 목록 조회")
+    @GetMapping("/active")
+    public ResponseEntity<ApiResponse<List<StoreCategoryResponse>>> getActiveCategories() {
+        return ResponseEntity.ok(ApiResponse.success(storeCategoryService.getActiveCategories()));
+    }
+
+    @Operation(summary = "가게 카테고리 단건 조회")
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<ApiResponse<StoreCategoryResponse>> getCategory(
+            @PathVariable UUID categoryId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(storeCategoryService.getCategory(categoryId)));
+    }
+
+    @Operation(summary = "가게 카테고리 수정")
+    @PutMapping("/{categoryId}")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<StoreCategoryResponse>> updateCategory(
+            @PathVariable UUID categoryId,
+            @RequestBody @Valid StoreCategoryUpdateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                storeCategoryService.updateCategory(categoryId, request)
+        ));
+    }
+
+    @Operation(summary = "가게 카테고리 삭제")
+    @DeleteMapping("/{categoryId}")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<Void>> deleteCategory(
+            @PathVariable UUID categoryId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        storeCategoryService.deleteCategory(categoryId, principal.getId());
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/presentation/StoreController.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/StoreController.java
@@ -1,0 +1,99 @@
+package com.sparta.delivery.store.presentation;
+
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.store.application.StoreService;
+import com.sparta.delivery.store.presentation.dto.StoreCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreResponse;
+import com.sparta.delivery.store.presentation.dto.StoreUpdateRequest;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Store", description = "가게 관리 API")
+@RestController
+@RequestMapping("/api/v1/stores")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @Operation(summary = "가게 생성")
+    @PostMapping
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ResponseEntity<ApiResponse<StoreResponse>> createStore(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody @Valid StoreCreateRequest request
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(storeService.createStore(principal.getId(), request)));
+    }
+
+    @Operation(summary = "가게 목록 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<StoreResponse>>> getStores(
+            @RequestParam(required = false) UUID regionId,
+            @RequestParam(required = false) UUID categoryId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(storeService.getStores(regionId, categoryId)));
+    }
+
+    @Operation(summary = "가게 단건 조회")
+    @GetMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<StoreResponse>> getStore(
+            @PathVariable UUID storeId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(storeService.getStore(storeId)));
+    }
+
+    @Operation(summary = "가게 수정")
+    @PutMapping("/{storeId}")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<StoreResponse>> updateStore(
+            @PathVariable UUID storeId,
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody @Valid StoreUpdateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                storeService.updateStore(
+                        storeId,
+                        principal.getId(),
+                        UserRole.valueOf(principal.getRole()),
+                        request
+                )
+        ));
+    }
+
+    @Operation(summary = "가게 삭제")
+    @DeleteMapping("/{storeId}")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<Void>> deleteStore(
+            @PathVariable UUID storeId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        storeService.deleteStore(
+                storeId,
+                principal.getId(),
+                UserRole.valueOf(principal.getRole())
+        );
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/presentation/StoreController.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/StoreController.java
@@ -51,9 +51,10 @@ public class StoreController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<StoreResponse>>> getStores(
             @RequestParam(required = false) UUID regionId,
-            @RequestParam(required = false) UUID categoryId
+            @RequestParam(required = false) UUID categoryId,
+            @RequestParam(required = false) Long userId
     ) {
-        return ResponseEntity.ok(ApiResponse.success(storeService.getStores(regionId, categoryId)));
+        return ResponseEntity.ok(ApiResponse.success(storeService.getStores(regionId, categoryId, userId)));
     }
 
     @Operation(summary = "가게 단건 조회")

--- a/src/main/java/com/sparta/delivery/store/presentation/dto/StoreCategoryCreateRequest.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/dto/StoreCategoryCreateRequest.java
@@ -1,0 +1,18 @@
+package com.sparta.delivery.store.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record StoreCategoryCreateRequest(
+
+        @NotBlank(message = "카테고리명은 필수입니다.")
+        @Size(max = 100, message = "카테고리명은 100자 이하여야 합니다.")
+        String categoryName,
+
+        String description,
+
+        @NotNull(message = "활성 상태는 필수입니다.")
+        Boolean isActive
+) {
+}

--- a/src/main/java/com/sparta/delivery/store/presentation/dto/StoreCategoryResponse.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/dto/StoreCategoryResponse.java
@@ -1,0 +1,23 @@
+package com.sparta.delivery.store.presentation.dto;
+
+import com.sparta.delivery.store.domain.entity.StoreCategory;
+import java.util.UUID;
+
+public record StoreCategoryResponse(
+        UUID categoryId,
+        String categoryName,
+        String description,
+        Integer sortOrder,
+        Boolean isActive
+) {
+
+    public static StoreCategoryResponse from(StoreCategory storeCategory) {
+        return new StoreCategoryResponse(
+                storeCategory.getCategoryId(),
+                storeCategory.getCategoryName(),
+                storeCategory.getDescription(),
+                storeCategory.getSortOrder(),
+                storeCategory.getIsActive()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/presentation/dto/StoreCategoryUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/dto/StoreCategoryUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.sparta.delivery.store.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+public record StoreCategoryUpdateRequest(
+
+        @NotBlank(message = "카테고리명은 필수입니다.")
+        @Size(max = 100, message = "카테고리명은 100자 이하여야 합니다.")
+        String categoryName,
+
+        String description,
+
+        @NotNull(message = "정렬 순서는 필수입니다.")
+        @PositiveOrZero(message = "정렬 순서는 0 이상이어야 합니다.")
+        Integer sortOrder,
+
+        @NotNull(message = "활성 상태는 필수입니다.")
+        Boolean isActive
+) {
+}

--- a/src/main/java/com/sparta/delivery/store/presentation/dto/StoreCreateRequest.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/dto/StoreCreateRequest.java
@@ -1,0 +1,43 @@
+package com.sparta.delivery.store.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record StoreCreateRequest(
+
+        @NotNull(message = "지역 ID는 필수입니다.")
+        UUID regionId,
+
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        UUID categoryId,
+
+        @NotBlank(message = "가게명은 필수입니다.")
+        @Size(max = 100, message = "가게명은 100자 이하여야 합니다.")
+        String storeName,
+
+        String description,
+
+        @NotBlank(message = "주소는 필수입니다.")
+        @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
+        String address,
+
+        @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다.")
+        String addressDetail,
+
+        @Size(max = 20, message = "전화번호는 20자 이하여야 합니다.")
+        String phoneNumber,
+
+        @NotNull(message = "최소 주문 금액은 필수입니다.")
+        @PositiveOrZero(message = "최소 주문 금액은 0 이상이어야 합니다.")
+        Integer minOrderAmount,
+
+        @NotNull(message = "영업 상태는 필수입니다.")
+        Boolean isOpen,
+
+        @NotNull(message = "활성 상태는 필수입니다.")
+        Boolean isActive
+) {
+}

--- a/src/main/java/com/sparta/delivery/store/presentation/dto/StoreResponse.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/dto/StoreResponse.java
@@ -1,0 +1,42 @@
+package com.sparta.delivery.store.presentation.dto;
+
+import com.sparta.delivery.store.domain.entity.Store;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record StoreResponse(
+        UUID storeId,
+        UUID regionId,
+        UUID categoryId,
+        Long userId,
+        String storeName,
+        String description,
+        String address,
+        String addressDetail,
+        String phoneNumber,
+        Integer minOrderAmount,
+        Boolean isOpen,
+        Boolean isActive,
+        BigDecimal avgRating,
+        Integer reviewCount
+) {
+
+    public static StoreResponse from(Store store) {
+        return new StoreResponse(
+                store.getStoreId(),
+                store.getRegionId(),
+                store.getCategoryId(),
+                store.getUserId(),
+                store.getStoreName(),
+                store.getDescription(),
+                store.getAddress(),
+                store.getAddressDetail(),
+                store.getPhoneNumber(),
+                store.getMinOrderAmount(),
+                store.getIsOpen(),
+                store.getIsActive(),
+                store.getAvgRating(),
+                store.getReviewCount()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/store/presentation/dto/StoreUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/dto/StoreUpdateRequest.java
@@ -1,0 +1,43 @@
+package com.sparta.delivery.store.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record StoreUpdateRequest(
+
+        @NotNull(message = "지역 ID는 필수입니다.")
+        UUID regionId,
+
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        UUID categoryId,
+
+        @NotBlank(message = "가게명은 필수입니다.")
+        @Size(max = 100, message = "가게명은 100자 이하여야 합니다.")
+        String storeName,
+
+        String description,
+
+        @NotBlank(message = "주소는 필수입니다.")
+        @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
+        String address,
+
+        @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다.")
+        String addressDetail,
+
+        @Size(max = 20, message = "전화번호는 20자 이하여야 합니다.")
+        String phoneNumber,
+
+        @NotNull(message = "최소 주문 금액은 필수입니다.")
+        @PositiveOrZero(message = "최소 주문 금액은 0 이상이어야 합니다.")
+        Integer minOrderAmount,
+
+        @NotNull(message = "영업 상태는 필수입니다.")
+        Boolean isOpen,
+
+        @NotNull(message = "활성 상태는 필수입니다.")
+        Boolean isActive
+) {
+}

--- a/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,8 +54,9 @@ class StoreCategoryServiceTest {
             StoreCategory lastCategory = createCategory(UUID.randomUUID(), "피자", 3, true);
 
             given(storeCategoryRepository.existsByCategoryName("치킨")).willReturn(false);
-            given(storeCategoryRepository.findTopByOrderBySortOrderDesc()).willReturn(Optional.of(lastCategory));
-            given(storeCategoryRepository.save(any(StoreCategory.class))).willAnswer(invocation -> {
+            given(storeCategoryRepository.findAllByOrderBySortOrderDesc(PageRequest.of(0, 1)))
+                    .willReturn(List.of(lastCategory));
+            given(storeCategoryRepository.saveAndFlush(any(StoreCategory.class))).willAnswer(invocation -> {
                 StoreCategory savedCategory = invocation.getArgument(0);
                 ReflectionTestUtils.setField(savedCategory, "categoryId", categoryId);
                 return savedCategory;
@@ -70,8 +72,8 @@ class StoreCategoryServiceTest {
             assertThat(response.isActive()).isTrue();
 
             then(storeCategoryRepository).should().existsByCategoryName("치킨");
-            then(storeCategoryRepository).should().findTopByOrderBySortOrderDesc();
-            then(storeCategoryRepository).should().save(any(StoreCategory.class));
+            then(storeCategoryRepository).should().findAllByOrderBySortOrderDesc(PageRequest.of(0, 1));
+            then(storeCategoryRepository).should().saveAndFlush(any(StoreCategory.class));
         }
 
         @Test
@@ -86,8 +88,9 @@ class StoreCategoryServiceTest {
             );
 
             given(storeCategoryRepository.existsByCategoryName("치킨")).willReturn(false);
-            given(storeCategoryRepository.findTopByOrderBySortOrderDesc()).willReturn(Optional.empty());
-            given(storeCategoryRepository.save(any(StoreCategory.class))).willAnswer(invocation -> {
+            given(storeCategoryRepository.findAllByOrderBySortOrderDesc(PageRequest.of(0, 1)))
+                    .willReturn(List.of());
+            given(storeCategoryRepository.saveAndFlush(any(StoreCategory.class))).willAnswer(invocation -> {
                 StoreCategory savedCategory = invocation.getArgument(0);
                 ReflectionTestUtils.setField(savedCategory, "categoryId", categoryId);
                 return savedCategory;

--- a/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
@@ -53,7 +53,7 @@ class StoreCategoryServiceTest {
 
             StoreCategory lastCategory = createCategory(UUID.randomUUID(), "피자", 3, true);
 
-            given(storeCategoryRepository.existsByCategoryName("치킨")).willReturn(false);
+            given(storeCategoryRepository.existsByCategoryNameIncludingDeleted("치킨")).willReturn(false);
             given(storeCategoryRepository.findAllByOrderBySortOrderDesc(PageRequest.of(0, 1)))
                     .willReturn(List.of(lastCategory));
             given(storeCategoryRepository.saveAndFlush(any(StoreCategory.class))).willAnswer(invocation -> {
@@ -71,7 +71,7 @@ class StoreCategoryServiceTest {
             assertThat(response.sortOrder()).isEqualTo(4);
             assertThat(response.isActive()).isTrue();
 
-            then(storeCategoryRepository).should().existsByCategoryName("치킨");
+            then(storeCategoryRepository).should().existsByCategoryNameIncludingDeleted("치킨");
             then(storeCategoryRepository).should().findAllByOrderBySortOrderDesc(PageRequest.of(0, 1));
             then(storeCategoryRepository).should().saveAndFlush(any(StoreCategory.class));
         }
@@ -87,7 +87,7 @@ class StoreCategoryServiceTest {
                     true
             );
 
-            given(storeCategoryRepository.existsByCategoryName("치킨")).willReturn(false);
+            given(storeCategoryRepository.existsByCategoryNameIncludingDeleted("치킨")).willReturn(false);
             given(storeCategoryRepository.findAllByOrderBySortOrderDesc(PageRequest.of(0, 1)))
                     .willReturn(List.of());
             given(storeCategoryRepository.saveAndFlush(any(StoreCategory.class))).willAnswer(invocation -> {
@@ -113,13 +113,13 @@ class StoreCategoryServiceTest {
                     true
             );
 
-            given(storeCategoryRepository.existsByCategoryName("치킨")).willReturn(true);
+            given(storeCategoryRepository.existsByCategoryNameIncludingDeleted("치킨")).willReturn(true);
 
             // when & then
             assertThatThrownBy(() -> storeCategoryService.createCategory(request))
                     .isInstanceOf(DuplicateCategoryNameException.class);
 
-            then(storeCategoryRepository).should(never()).save(any());
+            then(storeCategoryRepository).should(never()).saveAndFlush(any());
         }
     }
 
@@ -210,8 +210,10 @@ class StoreCategoryServiceTest {
             );
 
             given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
-            given(storeCategoryRepository.existsByCategoryName("치킨 수정")).willReturn(false);
-            given(storeCategoryRepository.existsBySortOrder(2)).willReturn(false);
+            given(storeCategoryRepository.existsByCategoryNameIncludingDeleted("치킨 수정")).willReturn(false);
+            given(storeCategoryRepository.existsBySortOrderIncludingDeleted(2)).willReturn(false);
+            given(storeCategoryRepository.findAllByOrderBySortOrderDesc(PageRequest.of(0, 1)))
+                    .willReturn(List.of(category));
 
             // when
             var response = storeCategoryService.updateCategory(categoryId, request);
@@ -238,7 +240,9 @@ class StoreCategoryServiceTest {
             );
 
             given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
-            given(storeCategoryRepository.existsByCategoryName("피자")).willReturn(true);
+            given(storeCategoryRepository.findAllByOrderBySortOrderDesc(PageRequest.of(0, 1)))
+                    .willReturn(List.of(category));
+            given(storeCategoryRepository.existsByCategoryNameIncludingDeleted("피자")).willReturn(true);
 
             // when & then
             assertThatThrownBy(() -> storeCategoryService.updateCategory(categoryId, request))
@@ -260,7 +264,9 @@ class StoreCategoryServiceTest {
             );
 
             given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
-            given(storeCategoryRepository.existsBySortOrder(2)).willReturn(true);
+            given(storeCategoryRepository.findAllByOrderBySortOrderDesc(PageRequest.of(0, 1)))
+                    .willReturn(List.of(category));
+            given(storeCategoryRepository.existsBySortOrderIncludingDeleted(2)).willReturn(true);
 
             // when & then
             assertThatThrownBy(() -> storeCategoryService.updateCategory(categoryId, request))

--- a/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
@@ -1,0 +1,301 @@
+package com.sparta.delivery.store.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+
+import com.sparta.delivery.store.domain.entity.StoreCategory;
+import com.sparta.delivery.store.domain.exception.DuplicateCategoryNameException;
+import com.sparta.delivery.store.domain.exception.DuplicateCategorySortOrderException;
+import com.sparta.delivery.store.domain.exception.StoreCategoryNotFoundException;
+import com.sparta.delivery.store.domain.repository.StoreCategoryRepository;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryUpdateRequest;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class StoreCategoryServiceTest {
+
+    @Mock
+    private StoreCategoryRepository storeCategoryRepository;
+
+    @InjectMocks
+    private StoreCategoryService storeCategoryService;
+
+    @Nested
+    @DisplayName("카테고리 생성")
+    class CreateCategoryTest {
+
+        @Test
+        @DisplayName("정상적으로 카테고리를 생성하고 sortOrder를 자동 부여한다")
+        void createCategory_success() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategoryCreateRequest request = new StoreCategoryCreateRequest(
+                    "치킨",
+                    "치킨 카테고리",
+                    true
+            );
+
+            StoreCategory lastCategory = createCategory(UUID.randomUUID(), "피자", 3, true);
+
+            given(storeCategoryRepository.existsByCategoryName("치킨")).willReturn(false);
+            given(storeCategoryRepository.findTopByOrderBySortOrderDesc()).willReturn(Optional.of(lastCategory));
+            given(storeCategoryRepository.save(any(StoreCategory.class))).willAnswer(invocation -> {
+                StoreCategory savedCategory = invocation.getArgument(0);
+                ReflectionTestUtils.setField(savedCategory, "categoryId", categoryId);
+                return savedCategory;
+            });
+
+            // when
+            var response = storeCategoryService.createCategory(request);
+
+            // then
+            assertThat(response.categoryId()).isEqualTo(categoryId);
+            assertThat(response.categoryName()).isEqualTo("치킨");
+            assertThat(response.sortOrder()).isEqualTo(4);
+            assertThat(response.isActive()).isTrue();
+
+            then(storeCategoryRepository).should().existsByCategoryName("치킨");
+            then(storeCategoryRepository).should().findTopByOrderBySortOrderDesc();
+            then(storeCategoryRepository).should().save(any(StoreCategory.class));
+        }
+
+        @Test
+        @DisplayName("첫 카테고리 생성이면 sortOrder를 1로 부여한다")
+        void createCategory_success_whenFirstCategory() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategoryCreateRequest request = new StoreCategoryCreateRequest(
+                    "치킨",
+                    "치킨 카테고리",
+                    true
+            );
+
+            given(storeCategoryRepository.existsByCategoryName("치킨")).willReturn(false);
+            given(storeCategoryRepository.findTopByOrderBySortOrderDesc()).willReturn(Optional.empty());
+            given(storeCategoryRepository.save(any(StoreCategory.class))).willAnswer(invocation -> {
+                StoreCategory savedCategory = invocation.getArgument(0);
+                ReflectionTestUtils.setField(savedCategory, "categoryId", categoryId);
+                return savedCategory;
+            });
+
+            // when
+            var response = storeCategoryService.createCategory(request);
+
+            // then
+            assertThat(response.sortOrder()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("카테고리명이 중복되면 예외가 발생한다")
+        void createCategory_fail_whenDuplicateName() {
+            // given
+            StoreCategoryCreateRequest request = new StoreCategoryCreateRequest(
+                    "치킨",
+                    "치킨 카테고리",
+                    true
+            );
+
+            given(storeCategoryRepository.existsByCategoryName("치킨")).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> storeCategoryService.createCategory(request))
+                    .isInstanceOf(DuplicateCategoryNameException.class);
+
+            then(storeCategoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 조회")
+    class GetCategoryTest {
+
+        @Test
+        @DisplayName("카테고리를 단건 조회한다")
+        void getCategory_success() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategory category = createCategory(categoryId, "치킨", 1, true);
+
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
+
+            // when
+            var response = storeCategoryService.getCategory(categoryId);
+
+            // then
+            assertThat(response.categoryId()).isEqualTo(categoryId);
+            assertThat(response.categoryName()).isEqualTo("치킨");
+        }
+
+        @Test
+        @DisplayName("카테고리가 없으면 예외가 발생한다")
+        void getCategory_fail_whenNotFound() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeCategoryService.getCategory(categoryId))
+                    .isInstanceOf(StoreCategoryNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("전체 카테고리 목록을 조회한다")
+        void getCategories_success() {
+            // given
+            StoreCategory chicken = createCategory(UUID.randomUUID(), "치킨", 1, true);
+            StoreCategory pizza = createCategory(UUID.randomUUID(), "피자", 2, true);
+
+            given(storeCategoryRepository.findAllByOrderBySortOrderAsc()).willReturn(List.of(chicken, pizza));
+
+            // when
+            var responses = storeCategoryService.getCategories();
+
+            // then
+            assertThat(responses).hasSize(2);
+            assertThat(responses.get(0).categoryName()).isEqualTo("치킨");
+            assertThat(responses.get(1).categoryName()).isEqualTo("피자");
+        }
+
+        @Test
+        @DisplayName("활성 카테고리 목록을 조회한다")
+        void getActiveCategories_success() {
+            // given
+            StoreCategory chicken = createCategory(UUID.randomUUID(), "치킨", 1, true);
+
+            given(storeCategoryRepository.findAllByIsActiveTrueOrderBySortOrderAsc()).willReturn(List.of(chicken));
+
+            // when
+            var responses = storeCategoryService.getActiveCategories();
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).categoryName()).isEqualTo("치킨");
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 수정")
+    class UpdateCategoryTest {
+
+        @Test
+        @DisplayName("정상적으로 카테고리를 수정한다")
+        void updateCategory_success() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategory category = createCategory(categoryId, "치킨", 1, true);
+
+            StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest(
+                    "치킨 수정",
+                    "설명 수정",
+                    2,
+                    false
+            );
+
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
+            given(storeCategoryRepository.existsByCategoryName("치킨 수정")).willReturn(false);
+            given(storeCategoryRepository.existsBySortOrder(2)).willReturn(false);
+
+            // when
+            var response = storeCategoryService.updateCategory(categoryId, request);
+
+            // then
+            assertThat(response.categoryName()).isEqualTo("치킨 수정");
+            assertThat(response.description()).isEqualTo("설명 수정");
+            assertThat(response.sortOrder()).isEqualTo(2);
+            assertThat(response.isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("카테고리명이 중복되면 예외가 발생한다")
+        void updateCategory_fail_whenDuplicateName() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategory category = createCategory(categoryId, "치킨", 1, true);
+
+            StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest(
+                    "피자",
+                    "설명 수정",
+                    2,
+                    true
+            );
+
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
+            given(storeCategoryRepository.existsByCategoryName("피자")).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> storeCategoryService.updateCategory(categoryId, request))
+                    .isInstanceOf(DuplicateCategoryNameException.class);
+        }
+
+        @Test
+        @DisplayName("정렬 순서가 중복되면 예외가 발생한다")
+        void updateCategory_fail_whenDuplicateSortOrder() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategory category = createCategory(categoryId, "치킨", 1, true);
+
+            StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest(
+                    "치킨",
+                    "설명 수정",
+                    2,
+                    true
+            );
+
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
+            given(storeCategoryRepository.existsBySortOrder(2)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> storeCategoryService.updateCategory(categoryId, request))
+                    .isInstanceOf(DuplicateCategorySortOrderException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 삭제")
+    class DeleteCategoryTest {
+
+        @Test
+        @DisplayName("카테고리를 soft delete 처리한다")
+        void deleteCategory_success() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            Long currentUserId = 1L;
+            StoreCategory category = createCategory(categoryId, "치킨", 1, true);
+
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
+
+            // when
+            storeCategoryService.deleteCategory(categoryId, currentUserId);
+
+            // then
+            assertThat(category.isDeleted()).isTrue();
+            assertThat(category.getDeletedBy()).isEqualTo(currentUserId);
+        }
+    }
+
+    private StoreCategory createCategory(UUID categoryId, String categoryName, Integer sortOrder, Boolean isActive) {
+        StoreCategory category = StoreCategory.create(
+                categoryName,
+                categoryName + " 설명",
+                sortOrder,
+                isActive
+        );
+        ReflectionTestUtils.setField(category, "categoryId", categoryId);
+        return category;
+    }
+}

--- a/src/test/java/com/sparta/delivery/store/application/StoreServiceTest.java
+++ b/src/test/java/com/sparta/delivery/store/application/StoreServiceTest.java
@@ -1,0 +1,622 @@
+package com.sparta.delivery.store.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+
+import com.sparta.delivery.region.domain.entity.Region;
+import com.sparta.delivery.region.domain.repository.RegionRepository;
+import com.sparta.delivery.store.domain.entity.Store;
+import com.sparta.delivery.store.domain.entity.StoreCategory;
+import com.sparta.delivery.store.domain.exception.InactiveStoreCategoryException;
+import com.sparta.delivery.store.domain.exception.InactiveStoreRegionException;
+import com.sparta.delivery.store.domain.exception.InvalidStoreRegionDepthException;
+import com.sparta.delivery.store.domain.exception.StoreCategoryNotFoundException;
+import com.sparta.delivery.store.domain.exception.StoreForbiddenException;
+import com.sparta.delivery.store.domain.exception.StoreNotFoundException;
+import com.sparta.delivery.store.domain.exception.StoreRegionNotFoundException;
+import com.sparta.delivery.store.domain.repository.StoreCategoryRepository;
+import com.sparta.delivery.store.domain.repository.StoreRepository;
+import com.sparta.delivery.store.presentation.dto.StoreCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreUpdateRequest;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private StoreCategoryRepository storeCategoryRepository;
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @InjectMocks
+    private StoreService storeService;
+
+    @Nested
+    @DisplayName("가게 생성")
+    class CreateStoreTest {
+
+        @Test
+        @DisplayName("정상적으로 가게를 생성한다")
+        void createStore_success() {
+            // given
+            Long userId = 1L;
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+
+            StoreCreateRequest request = new StoreCreateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true
+            );
+
+            Region region = createRegion(regionId, 3, true);
+            StoreCategory category = createCategory(categoryId, true);
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
+            given(storeRepository.save(any(Store.class))).willAnswer(invocation -> {
+                Store savedStore = invocation.getArgument(0);
+                ReflectionTestUtils.setField(savedStore, "storeId", storeId);
+                return savedStore;
+            });
+
+            // when
+            var response = storeService.createStore(userId, request);
+
+            // then
+            assertThat(response.storeId()).isEqualTo(storeId);
+            assertThat(response.regionId()).isEqualTo(regionId);
+            assertThat(response.categoryId()).isEqualTo(categoryId);
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.storeName()).isEqualTo("왕조치킨");
+            assertThat(response.reviewCount()).isEqualTo(0);
+
+            then(regionRepository).should().findByRegionId(regionId);
+            then(storeCategoryRepository).should().findByCategoryId(categoryId);
+            then(storeRepository).should().save(any(Store.class));
+        }
+
+        @Test
+        @DisplayName("지역이 없으면 예외가 발생한다")
+        void createStore_fail_whenRegionNotFound() {
+            // given
+            Long userId = 1L;
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            StoreCreateRequest request = new StoreCreateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true
+            );
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.createStore(userId, request))
+                    .isInstanceOf(StoreRegionNotFoundException.class);
+
+            then(storeRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("지역이 비활성이면 예외가 발생한다")
+        void createStore_fail_whenRegionInactive() {
+            // given
+            Long userId = 1L;
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            StoreCreateRequest request = new StoreCreateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true
+            );
+
+            Region inactiveRegion = createRegion(regionId, 3, false);
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(inactiveRegion));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.createStore(userId, request))
+                    .isInstanceOf(InactiveStoreRegionException.class);
+
+            then(storeRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("지역 depth가 3이 아니면 예외가 발생한다")
+        void createStore_fail_whenRegionDepthInvalid() {
+            // given
+            Long userId = 1L;
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            StoreCreateRequest request = new StoreCreateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true
+            );
+
+            Region invalidDepthRegion = createRegion(regionId, 2, true);
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(invalidDepthRegion));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.createStore(userId, request))
+                    .isInstanceOf(InvalidStoreRegionDepthException.class);
+
+            then(storeRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("카테고리가 없으면 예외가 발생한다")
+        void createStore_fail_whenCategoryNotFound() {
+            // given
+            Long userId = 1L;
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            StoreCreateRequest request = new StoreCreateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true
+            );
+
+            Region region = createRegion(regionId, 3, true);
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.createStore(userId, request))
+                    .isInstanceOf(StoreCategoryNotFoundException.class);
+
+            then(storeRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("카테고리가 비활성이면 예외가 발생한다")
+        void createStore_fail_whenCategoryInactive() {
+            // given
+            Long userId = 1L;
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            StoreCreateRequest request = new StoreCreateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true
+            );
+
+            Region region = createRegion(regionId, 3, true);
+            StoreCategory inactiveCategory = createCategory(categoryId, false);
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(inactiveCategory));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.createStore(userId, request))
+                    .isInstanceOf(InactiveStoreCategoryException.class);
+
+            then(storeRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 목록 조회")
+    class GetStoresTest {
+
+        @Test
+        @DisplayName("조건이 없으면 전체 가게 목록을 조회한다")
+        void getStores_success_withoutCondition() {
+            // given
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), 1L);
+            given(storeRepository.findAll()).willReturn(List.of(store));
+
+            // when
+            var responses = storeService.getStores(null, null);
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).storeName()).isEqualTo("왕조치킨");
+
+            then(storeRepository).should().findAll();
+        }
+
+        @Test
+        @DisplayName("지역 조건으로 가게 목록을 조회한다")
+        void getStores_success_byRegion() {
+            // given
+            UUID regionId = UUID.randomUUID();
+            Store store = createStoreEntity(regionId, UUID.randomUUID(), 1L);
+
+            given(storeRepository.findByRegionId(regionId)).willReturn(List.of(store));
+
+            // when
+            var responses = storeService.getStores(regionId, null);
+
+            // then
+            assertThat(responses).hasSize(1);
+            then(storeRepository).should().findByRegionId(regionId);
+        }
+
+        @Test
+        @DisplayName("카테고리 조건으로 가게 목록을 조회한다")
+        void getStores_success_byCategory() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            Store store = createStoreEntity(UUID.randomUUID(), categoryId, 1L);
+
+            given(storeRepository.findByCategoryId(categoryId)).willReturn(List.of(store));
+
+            // when
+            var responses = storeService.getStores(null, categoryId);
+
+            // then
+            assertThat(responses).hasSize(1);
+            then(storeRepository).should().findByCategoryId(categoryId);
+        }
+
+        @Test
+        @DisplayName("지역과 카테고리 조건으로 가게 목록을 조회한다")
+        void getStores_success_byRegionAndCategory() {
+            // given
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            Store store = createStoreEntity(regionId, categoryId, 1L);
+
+            given(storeRepository.findByRegionIdAndCategoryId(regionId, categoryId))
+                    .willReturn(List.of(store));
+
+            // when
+            var responses = storeService.getStores(regionId, categoryId);
+
+            // then
+            assertThat(responses).hasSize(1);
+            then(storeRepository).should().findByRegionIdAndCategoryId(regionId, categoryId);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 단건 조회")
+    class GetStoreTest {
+
+        @Test
+        @DisplayName("가게를 단건 조회한다")
+        void getStore_success() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), 1L);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+
+            // when
+            var response = storeService.getStore(storeId);
+
+            // then
+            assertThat(response.storeId()).isEqualTo(storeId);
+            assertThat(response.storeName()).isEqualTo("왕조치킨");
+        }
+
+        @Test
+        @DisplayName("가게가 없으면 예외가 발생한다")
+        void getStore_fail_whenNotFound() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.getStore(storeId))
+                    .isInstanceOf(StoreNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 수정")
+    class UpdateStoreTest {
+
+        @Test
+        @DisplayName("본인 가게를 정상적으로 수정한다")
+        void updateStore_success() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Long userId = 1L;
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            Store store = createStoreEntity(regionId, categoryId, userId);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            Region region = createRegion(regionId, 3, true);
+            StoreCategory category = createCategory(categoryId, true);
+
+            StoreUpdateRequest request = new StoreUpdateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨 수정",
+                    "설명 수정",
+                    "주소 수정",
+                    "상세주소 수정",
+                    "02-9999-8888",
+                    20000,
+                    false,
+                    true
+            );
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
+
+            // when
+            var response = storeService.updateStore(storeId, userId, UserRole.OWNER, request);
+
+            // then
+            assertThat(response.storeName()).isEqualTo("왕조치킨 수정");
+            assertThat(response.minOrderAmount()).isEqualTo(20000);
+            assertThat(response.isOpen()).isFalse();
+        }
+
+        @Test
+        @DisplayName("본인 가게가 아니면 예외가 발생한다")
+        void updateStore_fail_whenForbidden() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), 1L);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            StoreUpdateRequest request = new StoreUpdateRequest(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    "왕조치킨 수정",
+                    "설명 수정",
+                    "주소 수정",
+                    "상세주소 수정",
+                    "02-9999-8888",
+                    20000,
+                    false,
+                    true
+            );
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.updateStore(storeId, 2L, UserRole.OWNER, request))
+                    .isInstanceOf(StoreForbiddenException.class);
+        }
+
+        @Test
+        @DisplayName("매니저는 다른 가게도 수정할 수 있다")
+        void updateStore_success_whenManager() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            Store store = createStoreEntity(regionId, categoryId, 1L);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            Region region = createRegion(regionId, 3, true);
+            StoreCategory category = createCategory(categoryId, true);
+
+            StoreUpdateRequest request = new StoreUpdateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨 수정",
+                    "설명 수정",
+                    "주소 수정",
+                    "상세주소 수정",
+                    "02-9999-8888",
+                    20000,
+                    false,
+                    true
+            );
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(region));
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(category));
+
+            // when
+            var response = storeService.updateStore(storeId, 99L, UserRole.MANAGER, request);
+
+            // then
+            assertThat(response.storeName()).isEqualTo("왕조치킨 수정");
+            assertThat(response.minOrderAmount()).isEqualTo(20000);
+        }
+
+        @Test
+        @DisplayName("고객은 가게를 수정할 수 없다")
+        void updateStore_fail_whenCustomer() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), 1L);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            StoreUpdateRequest request = new StoreUpdateRequest(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    "왕조치킨 수정",
+                    "설명 수정",
+                    "주소 수정",
+                    "상세주소 수정",
+                    "02-9999-8888",
+                    20000,
+                    false,
+                    true
+            );
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.updateStore(storeId, 1L, UserRole.CUSTOMER, request))
+                    .isInstanceOf(StoreForbiddenException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 삭제")
+    class DeleteStoreTest {
+
+        @Test
+        @DisplayName("본인 가게를 soft delete 처리한다")
+        void deleteStore_success() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Long userId = 1L;
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), userId);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+
+            // when
+            storeService.deleteStore(storeId, userId, UserRole.OWNER);
+
+            // then
+            assertThat(store.isDeleted()).isTrue();
+            assertThat(store.getDeletedBy()).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("본인 가게가 아니면 삭제할 수 없다")
+        void deleteStore_fail_whenForbidden() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), 1L);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.deleteStore(storeId, 2L, UserRole.OWNER))
+                    .isInstanceOf(StoreForbiddenException.class);
+        }
+
+        @Test
+        @DisplayName("매니저는 다른 가게도 삭제할 수 있다")
+        void deleteStore_success_whenManager() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Long actorId = 99L;
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), 1L);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+
+            // when
+            storeService.deleteStore(storeId, actorId, UserRole.MANAGER);
+
+            // then
+            assertThat(store.isDeleted()).isTrue();
+            assertThat(store.getDeletedBy()).isEqualTo(actorId);
+        }
+
+        @Test
+        @DisplayName("고객은 가게를 삭제할 수 없다")
+        void deleteStore_fail_whenCustomer() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), 1L);
+            ReflectionTestUtils.setField(store, "storeId", storeId);
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.deleteStore(storeId, 1L, UserRole.CUSTOMER))
+                    .isInstanceOf(StoreForbiddenException.class);
+        }
+    }
+
+    private Region createRegion(UUID regionId, Integer depth, Boolean isActive) {
+        Region region = Region.create("1111012300", "청운효자동", UUID.randomUUID(), depth, isActive);
+        ReflectionTestUtils.setField(region, "regionId", regionId);
+        return region;
+    }
+
+    private StoreCategory createCategory(UUID categoryId, Boolean isActive) {
+        StoreCategory category = StoreCategory.create("치킨", "치킨 카테고리", 1, isActive);
+        ReflectionTestUtils.setField(category, "categoryId", categoryId);
+        return category;
+    }
+
+    private Store createStoreEntity(UUID regionId, UUID categoryId, Long userId) {
+        return Store.create(
+                regionId,
+                categoryId,
+                userId,
+                "왕조치킨",
+                "설명",
+                "주소",
+                "상세주소",
+                "02-1111-2222",
+                15000,
+                true,
+                true,
+                BigDecimal.ZERO,
+                0
+        );
+    }
+}

--- a/src/test/java/com/sparta/delivery/store/application/StoreServiceTest.java
+++ b/src/test/java/com/sparta/delivery/store/application/StoreServiceTest.java
@@ -278,7 +278,7 @@ class StoreServiceTest {
             given(storeRepository.findAll()).willReturn(List.of(store));
 
             // when
-            var responses = storeService.getStores(null, null);
+            var responses = storeService.getStores(null, null, null);
 
             // then
             assertThat(responses).hasSize(1);
@@ -297,7 +297,7 @@ class StoreServiceTest {
             given(storeRepository.findByRegionId(regionId)).willReturn(List.of(store));
 
             // when
-            var responses = storeService.getStores(regionId, null);
+            var responses = storeService.getStores(regionId, null, null);
 
             // then
             assertThat(responses).hasSize(1);
@@ -314,7 +314,7 @@ class StoreServiceTest {
             given(storeRepository.findByCategoryId(categoryId)).willReturn(List.of(store));
 
             // when
-            var responses = storeService.getStores(null, categoryId);
+            var responses = storeService.getStores(null, categoryId, null);
 
             // then
             assertThat(responses).hasSize(1);
@@ -333,11 +333,28 @@ class StoreServiceTest {
                     .willReturn(List.of(store));
 
             // when
-            var responses = storeService.getStores(regionId, categoryId);
+            var responses = storeService.getStores(regionId, categoryId, null);
 
             // then
             assertThat(responses).hasSize(1);
             then(storeRepository).should().findByRegionIdAndCategoryId(regionId, categoryId);
+        }
+
+        @Test
+        @DisplayName("사용자 조건으로 가게 목록을 조회한다")
+        void getStores_success_byUserId() {
+            // given
+            Long userId = 1L;
+            Store store = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), userId);
+
+            given(storeRepository.findByUserId(userId)).willReturn(List.of(store));
+
+            // when
+            var responses = storeService.getStores(null, null, userId);
+
+            // then
+            assertThat(responses).hasSize(1);
+            then(storeRepository).should().findByUserId(userId);
         }
     }
 

--- a/src/test/java/com/sparta/delivery/store/presentation/StoreCategoryControllerTest.java
+++ b/src/test/java/com/sparta/delivery/store/presentation/StoreCategoryControllerTest.java
@@ -1,0 +1,362 @@
+package com.sparta.delivery.store.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationFilter;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtProvider;
+import com.sparta.delivery.common.config.security.SecurityConfig;
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.store.application.StoreCategoryService;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryResponse;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryUpdateRequest;
+import com.sparta.delivery.user.application.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StoreCategoryController.class)
+@Import(SecurityConfig.class)
+class StoreCategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private StoreCategoryService storeCategoryService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private UserService userService;
+
+    @BeforeEach
+    void setUpFilter() throws Exception {
+        doAnswer(invocation -> {
+            ServletRequest request = invocation.getArgument(0);
+            ServletResponse response = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Nested
+    @DisplayName("가게 카테고리 생성 API")
+    class CreateCategoryApiTest {
+
+        @Test
+        @DisplayName("MANAGER 권한이면 가게 카테고리를 생성한다")
+        void createCategory_success() throws Exception {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategoryCreateRequest request = new StoreCategoryCreateRequest(
+                    "치킨",
+                    "치킨 카테고리",
+                    true
+            );
+            StoreCategoryResponse response = new StoreCategoryResponse(
+                    categoryId,
+                    "치킨",
+                    "치킨 카테고리",
+                    1,
+                    true
+            );
+
+            given(storeCategoryService.createCategory(any(StoreCategoryCreateRequest.class))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/store-categories")
+                            .with(csrf())
+                            .with(authentication(managerAuthentication()))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.categoryId").value(categoryId.toString()))
+                    .andExpect(jsonPath("$.data.categoryName").value("치킨"))
+                    .andExpect(jsonPath("$.data.sortOrder").value(1));
+
+            then(storeCategoryService).should().createCategory(any(StoreCategoryCreateRequest.class));
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한이면 가게 카테고리를 생성할 수 없다")
+        void createCategory_fail_whenCustomer() throws Exception {
+            // given
+            StoreCategoryCreateRequest request = new StoreCategoryCreateRequest(
+                    "치킨",
+                    "치킨 카테고리",
+                    true
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/v1/store-categories")
+                            .with(csrf())
+                            .with(authentication(customerAuthentication()))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden());
+
+            then(storeCategoryService).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 카테고리 조회 API")
+    class GetCategoryApiTest {
+
+        @Test
+        @DisplayName("가게 카테고리 목록을 조회한다")
+        void getCategories_success() throws Exception {
+            // given
+            StoreCategoryResponse response = new StoreCategoryResponse(
+                    UUID.randomUUID(),
+                    "치킨",
+                    "치킨 카테고리",
+                    1,
+                    true
+            );
+
+            given(storeCategoryService.getCategories()).willReturn(List.of(response));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/store-categories")
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data[0].categoryName").value("치킨"))
+                    .andExpect(jsonPath("$.data[0].sortOrder").value(1));
+
+            then(storeCategoryService).should().getCategories();
+        }
+
+        @Test
+        @DisplayName("활성 가게 카테고리 목록을 조회한다")
+        void getActiveCategories_success() throws Exception {
+            // given
+            StoreCategoryResponse response = new StoreCategoryResponse(
+                    UUID.randomUUID(),
+                    "치킨",
+                    "치킨 카테고리",
+                    1,
+                    true
+            );
+
+            given(storeCategoryService.getActiveCategories()).willReturn(List.of(response));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/store-categories/active")
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data[0].categoryName").value("치킨"));
+
+            then(storeCategoryService).should().getActiveCategories();
+        }
+
+        @Test
+        @DisplayName("가게 카테고리를 단건 조회한다")
+        void getCategory_success() throws Exception {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategoryResponse response = new StoreCategoryResponse(
+                    categoryId,
+                    "치킨",
+                    "치킨 카테고리",
+                    1,
+                    true
+            );
+
+            given(storeCategoryService.getCategory(categoryId)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/store-categories/{categoryId}", categoryId)
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.categoryId").value(categoryId.toString()))
+                    .andExpect(jsonPath("$.data.categoryName").value("치킨"));
+
+            then(storeCategoryService).should().getCategory(categoryId);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 카테고리 수정 API")
+    class UpdateCategoryApiTest {
+
+        @Test
+        @DisplayName("MANAGER 권한이면 가게 카테고리를 수정한다")
+        void updateCategory_success() throws Exception {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest(
+                    "치킨 수정",
+                    "설명 수정",
+                    2,
+                    false
+            );
+            StoreCategoryResponse response = new StoreCategoryResponse(
+                    categoryId,
+                    "치킨 수정",
+                    "설명 수정",
+                    2,
+                    false
+            );
+
+            given(storeCategoryService.updateCategory(eq(categoryId), any(StoreCategoryUpdateRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(put("/api/v1/store-categories/{categoryId}", categoryId)
+                            .with(csrf())
+                            .with(authentication(managerAuthentication()))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.categoryName").value("치킨 수정"))
+                    .andExpect(jsonPath("$.data.sortOrder").value(2));
+
+            then(storeCategoryService).should().updateCategory(eq(categoryId), any(StoreCategoryUpdateRequest.class));
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한이면 가게 카테고리를 수정할 수 없다")
+        void updateCategory_fail_whenCustomer() throws Exception {
+            // given
+            StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest(
+                    "치킨 수정",
+                    "설명 수정",
+                    2,
+                    false
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/v1/store-categories/{categoryId}", UUID.randomUUID())
+                            .with(csrf())
+                            .with(authentication(customerAuthentication()))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden());
+
+            then(storeCategoryService).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 카테고리 삭제 API")
+    class DeleteCategoryApiTest {
+
+        @Test
+        @DisplayName("MASTER 권한이면 가게 카테고리를 삭제한다")
+        void deleteCategory_success() throws Exception {
+            // given
+            UUID categoryId = UUID.randomUUID();
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/store-categories/{categoryId}", categoryId)
+                            .with(csrf())
+                            .with(authentication(masterAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            then(storeCategoryService).should().deleteCategory(categoryId, 1L);
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한이면 가게 카테고리를 삭제할 수 없다")
+        void deleteCategory_fail_whenCustomer() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/api/v1/store-categories/{categoryId}", UUID.randomUUID())
+                            .with(csrf())
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isForbidden());
+
+            then(storeCategoryService).shouldHaveNoInteractions();
+        }
+    }
+
+    private UsernamePasswordAuthenticationToken managerAuthentication() {
+        return createAuthentication("MANAGER", "ROLE_MANAGER");
+    }
+
+    private UsernamePasswordAuthenticationToken masterAuthentication() {
+        return createAuthentication("MASTER", "ROLE_MASTER");
+    }
+
+    private UsernamePasswordAuthenticationToken customerAuthentication() {
+        return createAuthentication("CUSTOMER", "ROLE_CUSTOMER");
+    }
+
+    private UsernamePasswordAuthenticationToken createAuthentication(String role, String authority) {
+        TestUserPrincipal principal = new TestUserPrincipal(1L, role.toLowerCase(), role);
+
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority(authority))
+        );
+    }
+
+    private record TestUserPrincipal(
+            Long id,
+            String username,
+            String role
+    ) implements UserPrincipal {
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public String getUsername() {
+            return username;
+        }
+
+        @Override
+        public String getRole() {
+            return role;
+        }
+    }
+}

--- a/src/test/java/com/sparta/delivery/store/presentation/StoreControllerTest.java
+++ b/src/test/java/com/sparta/delivery/store/presentation/StoreControllerTest.java
@@ -193,7 +193,7 @@ class StoreControllerTest {
                     0
             );
 
-            given(storeService.getStores(null, null)).willReturn(List.of(response));
+            given(storeService.getStores(null, null, null)).willReturn(List.of(response));
 
             // when & then
             mockMvc.perform(get("/api/v1/stores")
@@ -202,7 +202,7 @@ class StoreControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data[0].storeName").value("왕조치킨"));
 
-            then(storeService).should().getStores(null, null);
+            then(storeService).should().getStores(null, null, null);
         }
 
         @Test
@@ -212,7 +212,7 @@ class StoreControllerTest {
             UUID regionId = UUID.randomUUID();
             UUID categoryId = UUID.randomUUID();
 
-            given(storeService.getStores(regionId, categoryId)).willReturn(List.of());
+            given(storeService.getStores(regionId, categoryId, null)).willReturn(List.of());
 
             // when & then
             mockMvc.perform(get("/api/v1/stores")
@@ -222,7 +222,42 @@ class StoreControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true));
 
-            then(storeService).should().getStores(regionId, categoryId);
+            then(storeService).should().getStores(regionId, categoryId, null);
+        }
+
+        @Test
+        @DisplayName("사용자 조건으로 가게 목록을 조회한다")
+        void getStores_success_withUserId() throws Exception {
+            // given
+            Long userId = 1L;
+            StoreResponse response = new StoreResponse(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    userId,
+                    "왕조치킨",
+                    "설명",
+                    "주소",
+                    "상세주소",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true,
+                    BigDecimal.ZERO,
+                    0
+            );
+
+            given(storeService.getStores(null, null, userId)).willReturn(List.of(response));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/stores")
+                            .with(authentication(customerAuthentication()))
+                            .param("userId", userId.toString()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data[0].userId").value(userId));
+
+            then(storeService).should().getStores(null, null, userId);
         }
 
         @Test

--- a/src/test/java/com/sparta/delivery/store/presentation/StoreControllerTest.java
+++ b/src/test/java/com/sparta/delivery/store/presentation/StoreControllerTest.java
@@ -1,0 +1,440 @@
+package com.sparta.delivery.store.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationFilter;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtProvider;
+import com.sparta.delivery.common.config.security.SecurityConfig;
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.store.application.StoreService;
+import com.sparta.delivery.store.presentation.dto.StoreCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreResponse;
+import com.sparta.delivery.store.presentation.dto.StoreUpdateRequest;
+import com.sparta.delivery.user.application.UserService;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StoreController.class)
+@Import(SecurityConfig.class)
+class StoreControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private StoreService storeService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private UserService userService;
+
+    @BeforeEach
+    void setUpFilter() throws Exception {
+        doAnswer(invocation -> {
+            ServletRequest request = invocation.getArgument(0);
+            ServletResponse response = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Nested
+    @DisplayName("가게 생성 API")
+    class CreateStoreApiTest {
+
+        @Test
+        @DisplayName("OWNER 권한이면 가게를 생성한다")
+        void createStore_success() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            StoreCreateRequest request = new StoreCreateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true
+            );
+
+            StoreResponse response = new StoreResponse(
+                    storeId,
+                    regionId,
+                    categoryId,
+                    1L,
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true,
+                    BigDecimal.ZERO,
+                    0
+            );
+
+            given(storeService.createStore(eq(1L), any(StoreCreateRequest.class))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/stores")
+                            .with(csrf())
+                            .with(authentication(ownerAuthentication()))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.storeId").value(storeId.toString()))
+                    .andExpect(jsonPath("$.data.storeName").value("왕조치킨"));
+
+            then(storeService).should().createStore(eq(1L), any(StoreCreateRequest.class));
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한이면 가게를 생성할 수 없다")
+        void createStore_fail_whenCustomer() throws Exception {
+            // given
+            StoreCreateRequest request = new StoreCreateRequest(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    "왕조치킨",
+                    "바삭한 치킨 전문점",
+                    "서울시 종로구 1번지",
+                    "101호",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/v1/stores")
+                            .with(csrf())
+                            .with(authentication(customerAuthentication()))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden());
+
+            then(storeService).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 조회 API")
+    class GetStoreApiTest {
+
+        @Test
+        @DisplayName("조건 없이 전체 가게 목록을 조회한다")
+        void getStores_success() throws Exception {
+            // given
+            StoreResponse response = new StoreResponse(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    1L,
+                    "왕조치킨",
+                    "설명",
+                    "주소",
+                    "상세주소",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true,
+                    BigDecimal.ZERO,
+                    0
+            );
+
+            given(storeService.getStores(null, null)).willReturn(List.of(response));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/stores")
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data[0].storeName").value("왕조치킨"));
+
+            then(storeService).should().getStores(null, null);
+        }
+
+        @Test
+        @DisplayName("지역과 카테고리 조건으로 가게 목록을 조회한다")
+        void getStores_success_withConditions() throws Exception {
+            // given
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            given(storeService.getStores(regionId, categoryId)).willReturn(List.of());
+
+            // when & then
+            mockMvc.perform(get("/api/v1/stores")
+                            .with(authentication(customerAuthentication()))
+                            .param("regionId", regionId.toString())
+                            .param("categoryId", categoryId.toString()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            then(storeService).should().getStores(regionId, categoryId);
+        }
+
+        @Test
+        @DisplayName("가게를 단건 조회한다")
+        void getStore_success() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            StoreResponse response = new StoreResponse(
+                    storeId,
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    1L,
+                    "왕조치킨",
+                    "설명",
+                    "주소",
+                    "상세주소",
+                    "02-1234-5678",
+                    15000,
+                    true,
+                    true,
+                    BigDecimal.ZERO,
+                    0
+            );
+
+            given(storeService.getStore(storeId)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/stores/{storeId}", storeId)
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.storeId").value(storeId.toString()))
+                    .andExpect(jsonPath("$.data.storeName").value("왕조치킨"));
+
+            then(storeService).should().getStore(storeId);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 수정 API")
+    class UpdateStoreApiTest {
+
+        @Test
+        @DisplayName("MANAGER 권한이면 가게를 수정한다")
+        void updateStore_success() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            UUID regionId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+
+            StoreUpdateRequest request = new StoreUpdateRequest(
+                    regionId,
+                    categoryId,
+                    "왕조치킨 수정",
+                    "설명 수정",
+                    "주소 수정",
+                    "상세주소 수정",
+                    "02-9999-8888",
+                    20000,
+                    false,
+                    true
+            );
+
+            StoreResponse response = new StoreResponse(
+                    storeId,
+                    regionId,
+                    categoryId,
+                    1L,
+                    "왕조치킨 수정",
+                    "설명 수정",
+                    "주소 수정",
+                    "상세주소 수정",
+                    "02-9999-8888",
+                    20000,
+                    false,
+                    true,
+                    BigDecimal.ZERO,
+                    0
+            );
+
+            given(storeService.updateStore(
+                    eq(storeId),
+                    eq(1L),
+                    eq(UserRole.MANAGER),
+                    any(StoreUpdateRequest.class)
+            )).willReturn(response);
+
+            // when & then
+            mockMvc.perform(put("/api/v1/stores/{storeId}", storeId)
+                            .with(csrf())
+                            .with(authentication(managerAuthentication()))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.storeName").value("왕조치킨 수정"));
+
+            then(storeService).should().updateStore(
+                    eq(storeId),
+                    eq(1L),
+                    eq(UserRole.MANAGER),
+                    any(StoreUpdateRequest.class)
+            );
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한이면 가게를 수정할 수 없다")
+        void updateStore_fail_whenCustomer() throws Exception {
+            // given
+            StoreUpdateRequest request = new StoreUpdateRequest(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    "왕조치킨 수정",
+                    "설명 수정",
+                    "주소 수정",
+                    "상세주소 수정",
+                    "02-9999-8888",
+                    20000,
+                    false,
+                    true
+            );
+
+            // when & then
+            mockMvc.perform(put("/api/v1/stores/{storeId}", UUID.randomUUID())
+                            .with(csrf())
+                            .with(authentication(customerAuthentication()))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden());
+
+            then(storeService).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 삭제 API")
+    class DeleteStoreApiTest {
+
+        @Test
+        @DisplayName("MASTER 권한이면 가게를 삭제한다")
+        void deleteStore_success() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/stores/{storeId}", storeId)
+                            .with(csrf())
+                            .with(authentication(masterAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            then(storeService).should().deleteStore(storeId, 1L, UserRole.MASTER);
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한이면 가게를 삭제할 수 없다")
+        void deleteStore_fail_whenCustomer() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/api/v1/stores/{storeId}", UUID.randomUUID())
+                            .with(csrf())
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isForbidden());
+
+            then(storeService).shouldHaveNoInteractions();
+        }
+    }
+
+    private UsernamePasswordAuthenticationToken ownerAuthentication() {
+        return createAuthentication("OWNER", "ROLE_OWNER");
+    }
+
+    private UsernamePasswordAuthenticationToken managerAuthentication() {
+        return createAuthentication("MANAGER", "ROLE_MANAGER");
+    }
+
+    private UsernamePasswordAuthenticationToken masterAuthentication() {
+        return createAuthentication("MASTER", "ROLE_MASTER");
+    }
+
+    private UsernamePasswordAuthenticationToken customerAuthentication() {
+        return createAuthentication("CUSTOMER", "ROLE_CUSTOMER");
+    }
+
+    private UsernamePasswordAuthenticationToken createAuthentication(String role, String authority) {
+        TestUserPrincipal principal = new TestUserPrincipal(1L, role.toLowerCase(), role);
+
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority(authority))
+        );
+    }
+
+    private record TestUserPrincipal(
+            Long id,
+            String username,
+            String role
+    ) implements UserPrincipal {
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public String getUsername() {
+            return username;
+        }
+
+        @Override
+        public String getRole() {
+            return role;
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #49

## ✨ 기능 요약
Store 및 StoreCategory 도메인의 API와 서비스 로직을 구현하고, 카테고리 정렬 순서 자동 부여 및 입력값 정규화를 적용한다.

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | Store 도메인에 생성/목록 조회/단건 조회/수정/삭제 서비스 및 컨트롤러 구현 |
| 2️⃣ | Store 목록 조회 시 `regionId`, `categoryId` 조건 필터링 지원 |
| 3️⃣ | Store 수정/삭제 권한을 `OWNER(본인)`, `MANAGER`, `MASTER` 기준으로 검증하도록 정비 |
| 4️⃣ | Store 도메인 서비스 테스트 및 컨트롤러 테스트 작성 |
| 5️⃣ | StoreCategory 도메인에 생성/목록 조회/활성 목록 조회/단건 조회/수정/삭제 서비스 및 컨트롤러 구현 |
| 6️⃣ | StoreCategory 생성 시 `sortOrder`를 서버에서 자동 부여하도록 구현 |
| 7️⃣ | `categoryName`, `sortOrder` 중복 예외 및 검증 로직 추가 |
| 8️⃣ | StoreCategory 서비스 테스트 및 컨트롤러 테스트 작성 |
| 9️⃣ | Store, StoreCategory, Region 입력값에 대해 trim 기반 정규화 적용 |
| 🔟 | Store/StoreCategory 서비스에 생성/수정/삭제 성공 로그 추가 |

---

## ✅ 테스트 체크리스트
- [x] StoreService 테스트 작성 및 통과
- [x] StoreController 테스트 작성 및 통과
- [x] StoreCategoryService 테스트 작성 및 통과
- [x] StoreCategoryController 테스트 작성 및 통과
- [x] RegionService 테스트 통과

---

## 📸 포스트맨 캡처 사진

---

## 🙋‍♀️ 리뷰어 참고사항
- Store 생성/수정 시 지역 존재 여부, 활성 여부, depth 3 여부를 검증합니다.
- Store 생성/수정 시 카테고리 존재 여부와 활성 여부를 검증합니다.
- Store 수정/삭제는 `OWNER` 본인만 가능하며, `MANAGER`, `MASTER`는 전체 가게에 대해 처리할 수 있습니다.
- StoreCategory 생성 요청에서는 `sortOrder`를 받지 않고, 현재 최대 순서를 기준으로 서버가 다음 값을 자동 부여합니다.
- `categoryName`, `sortOrder`는 단일 유니크 기준으로 관리합니다.
- 입력값 비교 전에는 서비스에서 정규화하고, 최종 저장 전에는 엔티티에서 다시 정규화 및 검증하도록 맞췄습니다.
- 현재 StoreService는 지역/카테고리 검증을 위해 `RegionRepository`, `StoreCategoryRepository`를 직접 주입하고 있으나, 문서 가이드의 도메인 간 서비스 호출 방향에 맞춰 추후 읽기/검증용 서비스 메서드를 통해 접근하는 방식으로 리팩토링할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 스토어 카테고리 CRUD API 추가 (생성/조회/수정/삭제, 활성화 필터)
  * 스토어 CRUD API 추가 (생성·조회·수정·삭제, 지역/카테고리/사용자 필터)

* **개선사항**
  * 입력 문자열 자동 정규화(공백 트림·null 보존) 일관 적용
  * 도메인 유효성 강화 및 상세한 오류 코드/예외 추가
  * UUID 표준화 및 소프트 삭제로 데이터 보존·가시성 개선

* **테스트**
  * 서비스 및 컨트롤러 단위·웹 계층 테스트 대폭 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->