### PR TITLE
feat: Product 검색/정렬/페이징 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/product/application/ProductService.java
+++ b/src/main/java/com/sparta/delivery/product/application/ProductService.java
@@ -23,7 +23,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -79,7 +78,9 @@ public class ProductService {
             UUID storeId,
             int page,
             int size,
-            String sort) {
+            String sort,
+            String keyword
+    ) {
         Store store = getStoreOrThrow(storeId);
 
         boolean canViewHidden =
@@ -93,9 +94,9 @@ public class ProductService {
                 normalizeSort(sort)
         );
 
-        Page<Product> products =  canViewHidden
-                ? productRepository.findByStoreId(storeId, pageable)
-                : productRepository.findByStoreIdAndIsHiddenFalse(storeId, pageable);
+        String normalizedKeyword = normalizeKeyword(keyword);
+
+        Page<Product> products =  getProductPage(storeId, normalizedKeyword, canViewHidden, pageable);
 
         return products.map(ProductResponse::from);
     }
@@ -234,6 +235,30 @@ public class ProductService {
                 : Sort.Direction.DESC;
 
         return Sort.by(sortDirection, property);
+    }
+
+    private Page<Product> getProductPage(
+            UUID storeId,
+            String keyword,
+            boolean canViewHidden,
+            Pageable pageable
+    ) {
+        if (keyword == null) {
+            return canViewHidden
+                    ? productRepository.findByStoreId(storeId, pageable)
+                    : productRepository.findByStoreIdAndIsHiddenFalse(storeId, pageable);
+        }
+
+        return canViewHidden
+                ? productRepository.findByStoreIdAndProductNameContainingIgnoreCase(storeId, keyword, pageable)
+                : productRepository.findByStoreIdAndIsHiddenFalseAndProductNameContainingIgnoreCase(storeId, keyword, pageable);
+    }
+
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return keyword.trim();
     }
 
 }

--- a/src/main/java/com/sparta/delivery/product/application/ProductService.java
+++ b/src/main/java/com/sparta/delivery/product/application/ProductService.java
@@ -16,6 +16,10 @@ import com.sparta.delivery.store.domain.repository.StoreRepository;
 import com.sparta.delivery.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,7 +73,13 @@ public class ProductService {
         return ProductResponse.from(product);
     }
 
-    public List<ProductResponse> getProducts(Long actorId, UserRole actorRole, UUID storeId) {
+    public Page<ProductResponse> getProducts(
+            Long actorId,
+            UserRole actorRole,
+            UUID storeId,
+            int page,
+            int size,
+            String sort) {
         Store store = getStoreOrThrow(storeId);
 
         boolean canViewHidden =
@@ -77,15 +87,19 @@ public class ProductService {
                 || actorRole == UserRole.MASTER
                 || (actorRole == UserRole.OWNER && store.getUserId().equals(actorId));
 
-        List<Product> products =  canViewHidden
-                ? productRepository.findAllByStoreIdOrderByDisplayOrderAsc(storeId)
-                : productRepository.findAllByStoreIdAndIsHiddenFalseOrderByDisplayOrderAsc(storeId);
+        Pageable pageable = PageRequest.of(
+                Math.max(page, 0),
+                normalizePageSize(size),
+                normalizeSort(sort)
+        );
 
-        return products
-                .stream()
-                .map(ProductResponse::from)
-                .toList();
+        Page<Product> products =  canViewHidden
+                ? productRepository.findByStoreId(storeId, pageable)
+                : productRepository.findByStoreIdAndIsHiddenFalse(storeId, pageable);
+
+        return products.map(ProductResponse::from);
     }
+
 
     @Transactional
     public ProductResponse update(Long actorId, UserRole actorRole, UUID productId, ProductUpdateRequest request) {
@@ -194,4 +208,32 @@ public class ProductService {
                 request.displayOrder()
         );
     }
+
+    private int normalizePageSize(int size) {
+        return (size == 10 || size == 30 || size == 50) ? size : 10;
+    }
+    private Sort normalizeSort(String sort) {
+        if (sort == null || sort.isBlank()) {
+            return Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+
+        String[] parts = sort.split(",");
+        String property = parts[0].trim();
+        String direction = parts.length > 1 ? parts[1].trim().toLowerCase() : "desc";
+
+        if (!property.equals("createdAt")
+                && !property.equals("price")
+                && !property.equals("displayOrder")
+                && !property.equals("productName")
+        ) {
+            return Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+
+        Sort.Direction sortDirection = direction.equals("asc")
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+
+        return Sort.by(sortDirection, property);
+    }
+
 }

--- a/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
+++ b/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
@@ -4,6 +4,7 @@ import com.sparta.delivery.common.model.BaseEntity;
 import com.sparta.delivery.product.domain.exception.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
@@ -47,6 +48,25 @@ public class Product extends BaseEntity {
     @Column(name = "display_order")
     private Integer displayOrder;
 
+    @Builder(access = AccessLevel.PRIVATE)
+    private Product(
+            UUID storeId,
+            String productName,
+            String description,
+            DescriptionSource descriptionSource,
+            Integer price,
+            Integer displayOrder
+    ) {
+        this.storeId = storeId;
+        this.productName = productName;
+        this.description = description;
+        this.descriptionSource = descriptionSource;
+        this.price = price;
+        this.isSoldOut = false;
+        this.isHidden = false;
+        this.displayOrder = displayOrder;
+    }
+
     public static Product create(
             UUID storeId,
             String productName,
@@ -60,17 +80,14 @@ public class Product extends BaseEntity {
         validatePrice(price);
         validateDisplayOrder(displayOrder);
 
-        Product product = new Product();
-        product.storeId = storeId;
-        product.productName = productName;
-        product.description = description;
-        product.descriptionSource = descriptionSource;
-        product.price = price;
-        product.isSoldOut = false;
-        product.isHidden = false;
-        product.displayOrder = displayOrder;
-
-        return product;
+        return Product.builder()
+                .storeId(storeId)
+                .productName(productName)
+                .description(description)
+                .descriptionSource(descriptionSource)
+                .price(price)
+                .displayOrder(displayOrder)
+                .build();
     }
 
     public void updateInfo(

--- a/src/main/java/com/sparta/delivery/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/delivery/product/domain/repository/ProductRepository.java
@@ -27,5 +27,13 @@ public interface ProductRepository extends JpaRepository<Product, UUID> {
 
     Page<Product> findByStoreIdAndIsHiddenFalse(UUID storeId, Pageable pageable);
 
+    Page<Product> findByStoreIdAndProductNameContainingIgnoreCase(
+            UUID storeId, String keyword, Pageable pageable
+    );
+
+    Page<Product> findByStoreIdAndIsHiddenFalseAndProductNameContainingIgnoreCase(
+            UUID storeId, String keyword, Pageable pageable
+    );
+
     boolean existsByStoreIdAndProductName(UUID storeId, String productName);
 }

--- a/src/main/java/com/sparta/delivery/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/delivery/product/domain/repository/ProductRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.delivery.product.domain.repository;
 
 import com.sparta.delivery.product.domain.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -20,6 +22,10 @@ public interface ProductRepository extends JpaRepository<Product, UUID> {
     List<Product> findAllByStoreIdOrderByDisplayOrderAsc(UUID storeId);
 
     List<Product> findAllByStoreIdAndIsHiddenFalseOrderByDisplayOrderAsc(UUID storeId);
+
+    Page<Product> findByStoreId(UUID storeId, Pageable pageable);
+
+    Page<Product> findByStoreIdAndIsHiddenFalse(UUID storeId, Pageable pageable);
 
     boolean existsByStoreIdAndProductName(UUID storeId, String productName);
 }

--- a/src/main/java/com/sparta/delivery/product/presentation/ProductController.java
+++ b/src/main/java/com/sparta/delivery/product/presentation/ProductController.java
@@ -71,7 +71,8 @@ public class ProductController {
             @PathVariable UUID storeId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) String sort
+            @RequestParam(required = false) String sort,
+            @RequestParam(required = false) String keyword
     ) {
         Long actorId = principal == null ? null : principal.getId();
         UserRole actorRole = principal == null ? null : UserRole.valueOf(principal.getRole());
@@ -82,7 +83,8 @@ public class ProductController {
                 storeId,
                 page,
                 size,
-                sort
+                sort,
+                keyword
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/sparta/delivery/product/presentation/ProductController.java
+++ b/src/main/java/com/sparta/delivery/product/presentation/ProductController.java
@@ -13,13 +13,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -66,17 +66,23 @@ public class ProductController {
 
     @Operation(summary = "상품 목록 조회")
     @GetMapping("/stores/{storeId}/products")
-    public ResponseEntity<ApiResponse<List<ProductResponse>>> getProducts(
+    public ResponseEntity<ApiResponse<Page<ProductResponse>>> getProducts(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable UUID storeId
+            @PathVariable UUID storeId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String sort
     ) {
         Long actorId = principal == null ? null : principal.getId();
         UserRole actorRole = principal == null ? null : UserRole.valueOf(principal.getRole());
 
-        List<ProductResponse> response = productService.getProducts(
+        Page<ProductResponse> response = productService.getProducts(
                 actorId,
                 actorRole,
-                storeId
+                storeId,
+                page,
+                size,
+                sort
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/test/java/com/sparta/delivery/product/application/ProductServiceTest.java
+++ b/src/test/java/com/sparta/delivery/product/application/ProductServiceTest.java
@@ -3,6 +3,8 @@ package com.sparta.delivery.product.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -17,6 +19,7 @@ import com.sparta.delivery.product.presentation.dto.request.ProductCreateRequest
 import com.sparta.delivery.product.presentation.dto.request.ProductHiddenUpdateRequest;
 import com.sparta.delivery.product.presentation.dto.request.ProductSoldOutUpdateRequest;
 import com.sparta.delivery.product.presentation.dto.request.ProductUpdateRequest;
+import com.sparta.delivery.product.presentation.dto.response.ProductResponse;
 import com.sparta.delivery.store.domain.entity.Store;
 import com.sparta.delivery.store.domain.repository.StoreRepository;
 import com.sparta.delivery.user.domain.entity.UserRole;
@@ -31,6 +34,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,11 +53,11 @@ class ProductServiceTest {
     private ProductService productService;
 
     @Nested
-    @DisplayName("상품 생성")
+    @DisplayName("Create product")
     class Create {
 
         @Test
-        @DisplayName("OWNER가 본인 가게에 상품을 생성한다")
+        @DisplayName("creates a product for owned store")
         void create_success_owner() {
             // given
             Long ownerId = 1L;
@@ -77,7 +84,7 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("권한이 없으면 상품을 생성할 수 없다")
+        @DisplayName("fails when actor has no permission")
         void create_fail_forbidden() {
             // given
             Long actorId = 2L;
@@ -94,7 +101,7 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("같은 가게에 동일한 상품명이 있으면 생성할 수 없다")
+        @DisplayName("fails when product name is duplicated in store")
         void create_fail_duplicateName() {
             // given
             Long ownerId = 1L;
@@ -113,11 +120,11 @@ class ProductServiceTest {
     }
 
     @Nested
-    @DisplayName("상품 조회")
+    @DisplayName("Read product")
     class Read {
 
         @Test
-        @DisplayName("숨김 상품이 아니면 비로그인 사용자도 단건 조회할 수 있다")
+        @DisplayName("reads visible product for anonymous user")
         void getProduct_success_anonymous_whenVisible() {
             // given
             UUID productId = UUID.randomUUID();
@@ -135,7 +142,7 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("비로그인 사용자는 숨김 상품을 단건 조회할 수 없다")
+        @DisplayName("fails to read hidden product for anonymous user")
         void getProduct_fail_anonymous_whenHidden() {
             // given
             UUID productId = UUID.randomUUID();
@@ -152,7 +159,7 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("OWNER는 본인 가게의 숨김 상품을 단건 조회할 수 있다")
+        @DisplayName("reads hidden product for store owner")
         void getProduct_success_owner_whenHiddenAndOwned() {
             // given
             Long ownerId = 1L;
@@ -173,27 +180,27 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("비로그인 사용자는 목록 조회 시 숨김 상품을 제외한다")
+        @DisplayName("excludes hidden products for anonymous list read")
         void getProducts_success_anonymous_excludesHidden() {
             // given
             UUID storeId = UUID.randomUUID();
             Product visibleProduct = createProduct(UUID.randomUUID(), storeId, "Americano");
 
             given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(createStore(storeId, 1L)));
-            given(productRepository.findAllByStoreIdAndIsHiddenFalseOrderByDisplayOrderAsc(storeId))
-                    .willReturn(List.of(visibleProduct));
+            given(productRepository.findByStoreIdAndIsHiddenFalse(eq(storeId), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(visibleProduct)));
 
             // when
-            var responses = productService.getProducts(null, null, storeId);
+            Page<ProductResponse> responses = productService.getProducts(null, null, storeId, 0, 10, null);
 
             // then
-            assertThat(responses).hasSize(1);
-            assertThat(responses.get(0).productName()).isEqualTo("Americano");
-            then(productRepository).should(never()).findAllByStoreIdOrderByDisplayOrderAsc(storeId);
+            assertThat(responses.getContent()).hasSize(1);
+            assertThat(responses.getContent().get(0).productName()).isEqualTo("Americano");
+            then(productRepository).should(never()).findByStoreId(eq(storeId), any(Pageable.class));
         }
 
         @Test
-        @DisplayName("MANAGER는 목록 조회 시 숨김 상품을 포함한다")
+        @DisplayName("includes hidden products for manager list read")
         void getProducts_success_manager_includesHidden() {
             // given
             UUID storeId = UUID.randomUUID();
@@ -201,24 +208,46 @@ class ProductServiceTest {
             hiddenProduct.changeHidden(true);
 
             given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(createStore(storeId, 1L)));
-            given(productRepository.findAllByStoreIdOrderByDisplayOrderAsc(storeId)).willReturn(List.of(hiddenProduct));
+            given(productRepository.findByStoreId(eq(storeId), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(hiddenProduct)));
 
             // when
-            var responses = productService.getProducts(99L, UserRole.MANAGER, storeId);
+            Page<ProductResponse> responses = productService.getProducts(99L, UserRole.MANAGER, storeId, 0, 10, null);
 
             // then
-            assertThat(responses).hasSize(1);
-            assertThat(responses.get(0).isHidden()).isTrue();
-            then(productRepository).should(never()).findAllByStoreIdAndIsHiddenFalseOrderByDisplayOrderAsc(storeId);
+            assertThat(responses.getContent()).hasSize(1);
+            assertThat(responses.getContent().get(0).isHidden()).isTrue();
+            then(productRepository).should(never()).findByStoreIdAndIsHiddenFalse(eq(storeId), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("normalizes invalid page size and applies default sort")
+        void getProducts_normalizesPageable() {
+            // given
+            UUID storeId = UUID.randomUUID();
+
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(createStore(storeId, 1L)));
+            given(productRepository.findByStoreId(eq(storeId), any(Pageable.class)))
+                    .willReturn(Page.empty());
+
+            // when
+            productService.getProducts(99L, UserRole.MANAGER, storeId, 0, 999, null);
+
+            // then
+            then(productRepository).should().findByStoreId(eq(storeId), argThat(pageable ->
+                    pageable.getPageNumber() == 0
+                            && pageable.getPageSize() == 10
+                            && pageable.getSort().equals(Sort.by(Sort.Direction.DESC, "createdAt"))
+            ));
         }
     }
 
     @Nested
-    @DisplayName("상품 수정")
+    @DisplayName("Update product")
     class Update {
 
         @Test
-        @DisplayName("상품 일반 정보를 수정한다")
+        @DisplayName("updates product info")
         void update_success() {
             // given
             Long ownerId = 1L;
@@ -241,7 +270,7 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("상품명 변경 시 중복되면 수정할 수 없다")
+        @DisplayName("fails update when changed name is duplicated")
         void update_fail_duplicateName_whenNameChanged() {
             // given
             Long ownerId = 1L;
@@ -261,11 +290,11 @@ class ProductServiceTest {
     }
 
     @Nested
-    @DisplayName("상품 상태 변경 및 삭제")
+    @DisplayName("Product status and delete")
     class StatusAndDelete {
 
         @Test
-        @DisplayName("상품 숨김 상태를 변경한다")
+        @DisplayName("changes hidden status")
         void changeHidden_success() {
             // given
             Long ownerId = 1L;
@@ -284,7 +313,7 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("상품 품절 상태를 변경한다")
+        @DisplayName("changes sold-out status")
         void changeSoldOut_success() {
             // given
             Long ownerId = 1L;
@@ -303,7 +332,7 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("상품을 soft delete 처리한다")
+        @DisplayName("soft deletes product")
         void delete_success() {
             // given
             Long ownerId = 1L;

--- a/src/test/java/com/sparta/delivery/product/application/ProductServiceTest.java
+++ b/src/test/java/com/sparta/delivery/product/application/ProductServiceTest.java
@@ -191,7 +191,7 @@ class ProductServiceTest {
                     .willReturn(new PageImpl<>(List.of(visibleProduct)));
 
             // when
-            Page<ProductResponse> responses = productService.getProducts(null, null, storeId, 0, 10, null);
+            Page<ProductResponse> responses = productService.getProducts(null, null, storeId, 0, 10, null, null);
 
             // then
             assertThat(responses.getContent()).hasSize(1);
@@ -212,7 +212,7 @@ class ProductServiceTest {
                     .willReturn(new PageImpl<>(List.of(hiddenProduct)));
 
             // when
-            Page<ProductResponse> responses = productService.getProducts(99L, UserRole.MANAGER, storeId, 0, 10, null);
+            Page<ProductResponse> responses = productService.getProducts(99L, UserRole.MANAGER, storeId, 0, 10, null, null);
 
             // then
             assertThat(responses.getContent()).hasSize(1);
@@ -231,7 +231,7 @@ class ProductServiceTest {
                     .willReturn(Page.empty());
 
             // when
-            productService.getProducts(99L, UserRole.MANAGER, storeId, 0, 999, null);
+            productService.getProducts(99L, UserRole.MANAGER, storeId, 0, 999, null, null);
 
             // then
             then(productRepository).should().findByStoreId(eq(storeId), argThat(pageable ->
@@ -239,6 +239,70 @@ class ProductServiceTest {
                             && pageable.getPageSize() == 10
                             && pageable.getSort().equals(Sort.by(Sort.Direction.DESC, "createdAt"))
             ));
+        }
+
+        @Test
+        @DisplayName("searches visible products by keyword for anonymous user")
+        void getProducts_search_success_anonymous() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Product visibleProduct = createProduct(UUID.randomUUID(), storeId, "Americano");
+
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(createStore(storeId, 1L)));
+            given(productRepository.findByStoreIdAndIsHiddenFalseAndProductNameContainingIgnoreCase(
+                    eq(storeId), eq("Ameri"), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(visibleProduct)));
+
+            // when
+            Page<ProductResponse> responses = productService.getProducts(null, null, storeId, 0, 10, null, "Ameri");
+
+            // then
+            assertThat(responses.getContent()).hasSize(1);
+            assertThat(responses.getContent().get(0).productName()).isEqualTo("Americano");
+            then(productRepository).should(never())
+                    .findByStoreIdAndProductNameContainingIgnoreCase(eq(storeId), eq("Ameri"), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("searches all products by keyword for manager")
+        void getProducts_search_success_manager() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Product hiddenProduct = createProduct(UUID.randomUUID(), storeId, "Latte");
+            hiddenProduct.changeHidden(true);
+
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(createStore(storeId, 1L)));
+            given(productRepository.findByStoreIdAndProductNameContainingIgnoreCase(
+                    eq(storeId), eq("Lat"), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(hiddenProduct)));
+
+            // when
+            Page<ProductResponse> responses = productService.getProducts(99L, UserRole.MANAGER, storeId, 0, 10, null, "Lat");
+
+            // then
+            assertThat(responses.getContent()).hasSize(1);
+            assertThat(responses.getContent().get(0).isHidden()).isTrue();
+            then(productRepository).should(never())
+                    .findByStoreIdAndIsHiddenFalseAndProductNameContainingIgnoreCase(eq(storeId), eq("Lat"), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("normalizes blank keyword to default list read")
+        void getProducts_normalizesBlankKeyword() {
+            // given
+            UUID storeId = UUID.randomUUID();
+
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(createStore(storeId, 1L)));
+            given(productRepository.findByStoreId(eq(storeId), any(Pageable.class)))
+                    .willReturn(Page.empty());
+
+            // when
+            productService.getProducts(99L, UserRole.MANAGER, storeId, 0, 10, null, "   ");
+
+            // then
+            then(productRepository).should().findByStoreId(eq(storeId), any(Pageable.class));
+            then(productRepository).should(never())
+                    .findByStoreIdAndProductNameContainingIgnoreCase(eq(storeId), any(), any(Pageable.class));
         }
     }
 

--- a/src/test/java/com/sparta/delivery/product/presentation/ProductControllerTest.java
+++ b/src/test/java/com/sparta/delivery/product/presentation/ProductControllerTest.java
@@ -154,7 +154,7 @@ class ProductControllerTest {
             UUID storeId = UUID.randomUUID();
             ProductResponse response = productResponse(UUID.randomUUID(), storeId, "Americano", false, false);
 
-            given(productService.getProducts(null, null, storeId, 0, 10, null))
+            given(productService.getProducts(null, null, storeId, 0, 10, null, null))
                     .willReturn(new PageImpl<>(List.of(response)));
 
             // when & then
@@ -166,7 +166,30 @@ class ProductControllerTest {
                     .andExpect(jsonPath("$.data.content[0].storeId").value(storeId.toString()))
                     .andExpect(jsonPath("$.data.content[0].productName").value("Americano"));
 
-            then(productService).should().getProducts(null, null, storeId, 0, 10, null);
+            then(productService).should().getProducts(null, null, storeId, 0, 10, null, null);
+        }
+
+        @Test
+        @DisplayName("reads searched product list for anonymous user")
+        void getProducts_search_success_anonymous() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            ProductResponse response = productResponse(UUID.randomUUID(), storeId, "Americano", false, false);
+
+            given(productService.getProducts(null, null, storeId, 0, 10, null, "Ameri"))
+                    .willReturn(new PageImpl<>(List.of(response)));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/stores/{storeId}/products", storeId)
+                            .param("page", "0")
+                            .param("size", "10")
+                            .param("keyword", "Ameri"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content[0].storeId").value(storeId.toString()))
+                    .andExpect(jsonPath("$.data.content[0].productName").value("Americano"));
+
+            then(productService).should().getProducts(null, null, storeId, 0, 10, null, "Ameri");
         }
     }
 

--- a/src/test/java/com/sparta/delivery/product/presentation/ProductControllerTest.java
+++ b/src/test/java/com/sparta/delivery/product/presentation/ProductControllerTest.java
@@ -15,6 +15,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationFilter;
 import com.sparta.delivery.common.config.security.UserPrincipal;
 import com.sparta.delivery.product.application.ProductService;
 import com.sparta.delivery.product.domain.entity.DescriptionSource;
@@ -31,15 +33,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.TestSecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import com.sparta.delivery.common.config.security.SecurityConfig;
 
 @WebMvcTest(ProductController.class)
+@AutoConfigureMockMvc(addFilters = false)
 @Import(SecurityConfig.class)
 class ProductControllerTest {
 
@@ -52,60 +58,78 @@ class ProductControllerTest {
     @MockitoBean
     private ProductService productService;
 
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
     @Nested
-    @DisplayName("상품 생성 API")
+    @DisplayName("Create product API")
     class CreateProductApi {
 
         @Test
-        @DisplayName("OWNER 권한이면 상품을 생성한다")
+        @DisplayName("creates a product for OWNER role")
         void createProduct_success() throws Exception {
             // given
             UUID storeId = UUID.randomUUID();
             ProductCreateRequest request = new ProductCreateRequest("Americano", 4500, "coffee", 1);
             ProductResponse response = productResponse(UUID.randomUUID(), storeId, "Americano", false, false);
+            UsernamePasswordAuthenticationToken auth = authenticationToken(UserRole.OWNER);
 
             given(productService.create(eq(1L), eq(UserRole.OWNER), eq(storeId), any(ProductCreateRequest.class)))
                     .willReturn(response);
 
             // when & then
-            mockMvc.perform(post("/api/v1/stores/{storeId}/products", storeId)
-                            .with(csrf())
-                            .with(authentication(authenticationToken(UserRole.OWNER)))
-                            .contentType("application/json")
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.status").value(201))
-                    .andExpect(jsonPath("$.data.productName").value("Americano"));
+            TestSecurityContextHolder.setAuthentication(auth);
+            try {
+                mockMvc.perform(post("/api/v1/stores/{storeId}/products", storeId)
+                                .with(csrf())
+                                .with(authentication(auth))
+                                .contentType("application/json")
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.status").value(201))
+                        .andExpect(jsonPath("$.data.productName").value("Americano"));
+            } finally {
+                TestSecurityContextHolder.clearContext();
+            }
 
             then(productService).should().create(eq(1L), eq(UserRole.OWNER), eq(storeId), any(ProductCreateRequest.class));
         }
 
         @Test
-        @DisplayName("상품명이 비어있으면 400을 반환한다")
+        @DisplayName("returns 400 when product name is blank")
         void createProduct_fail_whenProductNameBlank() throws Exception {
             // given
             UUID storeId = UUID.randomUUID();
             ProductCreateRequest request = new ProductCreateRequest("", 4500, null, 1);
+            UsernamePasswordAuthenticationToken auth = authenticationToken(UserRole.OWNER);
 
             // when & then
-            mockMvc.perform(post("/api/v1/stores/{storeId}/products", storeId)
-                            .with(csrf())
-                            .with(authentication(authenticationToken(UserRole.OWNER)))
-                            .contentType("application/json")
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
+            TestSecurityContextHolder.setAuthentication(auth);
+            try {
+                mockMvc.perform(post("/api/v1/stores/{storeId}/products", storeId)
+                                .with(csrf())
+                                .with(authentication(auth))
+                                .contentType("application/json")
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest());
+            } finally {
+                TestSecurityContextHolder.clearContext();
+            }
 
             then(productService).shouldHaveNoInteractions();
         }
     }
 
     @Nested
-    @DisplayName("상품 조회 API")
+    @DisplayName("Read product API")
     class ReadProductApi {
 
         @Test
-        @DisplayName("비로그인 사용자가 상품을 단건 조회한다")
+        @DisplayName("reads a single product for anonymous user")
         void getProduct_success_anonymous() throws Exception {
             // given
             UUID productId = UUID.randomUUID();
@@ -124,121 +148,148 @@ class ProductControllerTest {
         }
 
         @Test
-        @DisplayName("비로그인 사용자가 가게 상품 목록을 조회한다")
+        @DisplayName("reads paged product list for anonymous user")
         void getProducts_success_anonymous() throws Exception {
             // given
             UUID storeId = UUID.randomUUID();
             ProductResponse response = productResponse(UUID.randomUUID(), storeId, "Americano", false, false);
 
-            given(productService.getProducts(null, null, storeId)).willReturn(List.of(response));
+            given(productService.getProducts(null, null, storeId, 0, 10, null))
+                    .willReturn(new PageImpl<>(List.of(response)));
 
             // when & then
-            mockMvc.perform(get("/api/v1/stores/{storeId}/products", storeId))
+            mockMvc.perform(get("/api/v1/stores/{storeId}/products", storeId)
+                            .param("page", "0")
+                            .param("size", "10"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data[0].storeId").value(storeId.toString()))
-                    .andExpect(jsonPath("$.data[0].productName").value("Americano"));
+                    .andExpect(jsonPath("$.data.content[0].storeId").value(storeId.toString()))
+                    .andExpect(jsonPath("$.data.content[0].productName").value("Americano"));
 
-            then(productService).should().getProducts(null, null, storeId);
+            then(productService).should().getProducts(null, null, storeId, 0, 10, null);
         }
     }
 
     @Nested
-    @DisplayName("상품 수정 API")
+    @DisplayName("Update product API")
     class UpdateProductApi {
 
         @Test
-        @DisplayName("OWNER 권한이면 상품 일반 정보를 수정한다")
+        @DisplayName("updates product info for OWNER role")
         void updateProduct_success() throws Exception {
             // given
             UUID productId = UUID.randomUUID();
             UUID storeId = UUID.randomUUID();
             ProductUpdateRequest request = new ProductUpdateRequest("Latte", 5500, "milk coffee", 2);
             ProductResponse response = productResponse(productId, storeId, "Latte", false, false);
+            UsernamePasswordAuthenticationToken auth = authenticationToken(UserRole.OWNER);
 
             given(productService.update(eq(1L), eq(UserRole.OWNER), eq(productId), any(ProductUpdateRequest.class)))
                     .willReturn(response);
 
             // when & then
-            mockMvc.perform(put("/api/v1/products/{productId}", productId)
-                            .with(csrf())
-                            .with(authentication(authenticationToken(UserRole.OWNER)))
-                            .contentType("application/json")
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.productName").value("Latte"));
+            TestSecurityContextHolder.setAuthentication(auth);
+            try {
+                mockMvc.perform(put("/api/v1/products/{productId}", productId)
+                                .with(csrf())
+                                .with(authentication(auth))
+                                .contentType("application/json")
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.data.productName").value("Latte"));
+            } finally {
+                TestSecurityContextHolder.clearContext();
+            }
 
             then(productService).should().update(eq(1L), eq(UserRole.OWNER), eq(productId), any(ProductUpdateRequest.class));
         }
     }
 
     @Nested
-    @DisplayName("상품 상태 변경 및 삭제 API")
+    @DisplayName("Product status and delete API")
     class StatusAndDeleteApi {
 
         @Test
-        @DisplayName("OWNER 권한이면 상품 숨김 상태를 변경한다")
+        @DisplayName("changes hidden status for OWNER role")
         void changeHidden_success() throws Exception {
             // given
             UUID productId = UUID.randomUUID();
             ProductHiddenUpdateRequest request = new ProductHiddenUpdateRequest(true);
             ProductResponse response = productResponse(productId, UUID.randomUUID(), "Americano", true, false);
+            UsernamePasswordAuthenticationToken auth = authenticationToken(UserRole.OWNER);
 
             given(productService.changeHidden(eq(1L), eq(UserRole.OWNER), eq(productId), any(ProductHiddenUpdateRequest.class)))
                     .willReturn(response);
 
             // when & then
-            mockMvc.perform(patch("/api/v1/products/{productId}/hidden", productId)
-                            .with(csrf())
-                            .with(authentication(authenticationToken(UserRole.OWNER)))
-                            .contentType("application/json")
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.isHidden").value(true));
+            TestSecurityContextHolder.setAuthentication(auth);
+            try {
+                mockMvc.perform(patch("/api/v1/products/{productId}/hidden", productId)
+                                .with(csrf())
+                                .with(authentication(auth))
+                                .contentType("application/json")
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.isHidden").value(true));
+            } finally {
+                TestSecurityContextHolder.clearContext();
+            }
 
             then(productService).should().changeHidden(eq(1L), eq(UserRole.OWNER), eq(productId), any(ProductHiddenUpdateRequest.class));
         }
 
         @Test
-        @DisplayName("OWNER 권한이면 상품 품절 상태를 변경한다")
+        @DisplayName("changes sold-out status for OWNER role")
         void changeSoldOut_success() throws Exception {
             // given
             UUID productId = UUID.randomUUID();
             ProductSoldOutUpdateRequest request = new ProductSoldOutUpdateRequest(true);
             ProductResponse response = productResponse(productId, UUID.randomUUID(), "Americano", false, true);
+            UsernamePasswordAuthenticationToken auth = authenticationToken(UserRole.OWNER);
 
             given(productService.changeSoldOut(eq(1L), eq(UserRole.OWNER), eq(productId), any(ProductSoldOutUpdateRequest.class)))
                     .willReturn(response);
 
             // when & then
-            mockMvc.perform(patch("/api/v1/products/{productId}/sold-out", productId)
-                            .with(csrf())
-                            .with(authentication(authenticationToken(UserRole.OWNER)))
-                            .contentType("application/json")
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.isSoldOut").value(true));
+            TestSecurityContextHolder.setAuthentication(auth);
+            try {
+                mockMvc.perform(patch("/api/v1/products/{productId}/sold-out", productId)
+                                .with(csrf())
+                                .with(authentication(auth))
+                                .contentType("application/json")
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.isSoldOut").value(true));
+            } finally {
+                TestSecurityContextHolder.clearContext();
+            }
 
             then(productService).should().changeSoldOut(eq(1L), eq(UserRole.OWNER), eq(productId), any(ProductSoldOutUpdateRequest.class));
         }
 
         @Test
-        @DisplayName("OWNER 권한이면 상품을 삭제한다")
+        @DisplayName("deletes a product for OWNER role")
         void deleteProduct_success() throws Exception {
             // given
             UUID productId = UUID.randomUUID();
             ProductResponse response = productResponse(productId, UUID.randomUUID(), "Americano", false, false);
+            UsernamePasswordAuthenticationToken auth = authenticationToken(UserRole.OWNER);
 
             given(productService.delete(1L, UserRole.OWNER, productId)).willReturn(response);
 
             // when & then
-            mockMvc.perform(delete("/api/v1/products/{productId}", productId)
-                            .with(csrf())
-                            .with(authentication(authenticationToken(UserRole.OWNER))))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.productId").value(productId.toString()));
+            TestSecurityContextHolder.setAuthentication(auth);
+            try {
+                mockMvc.perform(delete("/api/v1/products/{productId}", productId)
+                                .with(csrf())
+                                .with(authentication(auth)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.data.productId").value(productId.toString()));
+            } finally {
+                TestSecurityContextHolder.clearContext();
+            }
 
             then(productService).should().delete(1L, UserRole.OWNER, productId);
         }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #25 

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 상품 목록 search/sort/paging 구현 및 Product 엔티티 생성 경로 점검 |
| 🔍 목적 | 가게별 상품 목록 조회에 검색/정렬/페이징 기능을 추가하고, Product 엔티티 생성 경로가 `create()`를 통해 일관되게 유지되는지 점검하기 위함 |
| 🛠️ 변경사항 | 상품 목록 조회 API에 `keyword`, `page`, `size`, `sort`를 반영하고, 서비스/레포지토리/테스트를 이에 맞게 정리 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | 가게별 상품 목록 조회 API에 `page`, `size`, `sort`, `keyword` 파라미터 반영 |
| 2️⃣ | 상품명 기준 keyword 검색 기능 추가 |
| 3️⃣ | 검색 결과에도 기존 hidden 상품 노출 권한 정책이 동일하게 적용되도록 서비스 로직 확장 |
| 4️⃣ | `size`는 `10/30/50`만 허용하고, 그 외 값은 `10`으로 보정하도록 처리 |
| 5️⃣ | `sort` 기본값을 `createdAt,desc`로 두고, 허용된 필드에 대해서만 정렬 적용 |
| 6️⃣ | Product Service/Controller 테스트를 새 목록 조회 시그니처에 맞게 수정하고 검색 케이스 추가 |
| 7️⃣ | Product 엔티티가 `create() + private builder` 구조로 외부 생성 경로가 제한되는지 컴파일 결과 기준으로 점검 |

---

## ✅ 테스트 체크리스트
- [x] 기본 상품 목록 조회 시 `createdAt desc` 기본 정렬 확인
- [x] `page`, `size` 파라미터 기준 페이징 동작 확인
- [x] `size` 비허용 값 입력 시 `10`으로 보정되는지 확인
- [x] `sort=price,asc` / `sort=productName,desc` 정렬 동작 확인
- [x] `keyword` 기반 상품명 검색 동작 확인
- [x] 비로그인 사용자 기준 hidden 상품이 검색/목록 결과에서 제외되는지 확인
- [x] Product Service 단위 테스트 통과
- [x] Product Controller 단위 테스트 통과
- [x] `./gradlew test` 전체 통과
- [x] Postman으로 search/sort/paging 주요 요청/응답 정상 동작 확인

---

## 📸 포스트맨 캡처 사진

### 1. 기본 상품 목록 조회
<img width="1237" height="903" alt="비로그인조회" src="https://github.com/user-attachments/assets/60774272-a650-4010-beb0-fa0f9889c031" />

### 2. `page=0&size=10`
<img width="1242" height="898" alt="페이징0이랑10" src="https://github.com/user-attachments/assets/cade550e-22ef-4ac6-b092-2d364fa1f964" />

### 3. `page=1&size=10`
<img width="1241" height="844" alt="페이징1이랑10" src="https://github.com/user-attachments/assets/18b192fe-3145-408d-8c7c-af38b05ef7a4" />

> 당시 상품은 10개밖에 등록되지 않아, 페이지 1에서는 어떠한 상품도 보이지 않는 것이 정상 응답

### 4. `sort=price,asc`
<img width="1244" height="890" alt="가격낮은순" src="https://github.com/user-attachments/assets/e9b03c36-da85-41e4-a277-6ccc52f28e1f" />

### 5. `sort=productName,desc`
<img width="1246" height="890" alt="가나다순인데역순" src="https://github.com/user-attachments/assets/0e5863e5-9ddf-429b-a4cb-e5a851258ea3" />

### 6. `keyword=콤보`
<img width="1247" height="900" alt="키워드검색" src="https://github.com/user-attachments/assets/8dd4bd50-f99d-4e4e-8f7f-703277a01cae" />


---

## 🙋‍♀️ 리뷰어 참고사항
- 본 PR은 Product CRUD 후속 범위로, **가게별 상품 목록의 search/sort/paging 구현**에 초점을 맞춤
- 현재 검색 범위: **전역 상품 검색이 아니라 특정 가게 내부 상품 목록**
- 현재 검색 대상: `productName`
- hidden 상품은 기존과 동일하게 일반 사용자/비로그인에게는 노출되지 않고, `MANAGER`, `MASTER`, 또는 해당 가게의 `OWNER`에게만 노출됨
- Product 엔티티 생성 방식을 `create() + private builder` 구조로 리팩터링했으며, 이번 PR에서는 해당 생성 경로가 의도대로 컴파일되는지 확인하는 수준으로 점검함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상품 목록 조회에 페이지네이션 기능 추가로 대량의 상품을 효율적으로 탐색 가능
  * 키워드 검색 기능으로 원하는 상품을 빠르게 찾을 수 있음
  * 커스터마이징 가능한 정렬 옵션으로 다양한 상품 정렬 방식 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->