### PR TITLE
feat: 주문 생성, 조회, 취소 API 

### DIFF
--- a/src/main/java/com/sparta/delivery/address/application/AddressService.java
+++ b/src/main/java/com/sparta/delivery/address/application/AddressService.java
@@ -44,6 +44,10 @@ public class AddressService {
                 .toList();
     }
 
+    public Address findOwnedAddress(Long userId, UUID addressId) {
+        return getOwnedAddress(userId, addressId);
+    }
+
     public AddressResponse getAddress(Long userId, UUID addressId) {
         return AddressResponse.from(getOwnedAddress(userId, addressId));
     }

--- a/src/main/java/com/sparta/delivery/address/domain/entity/Address.java
+++ b/src/main/java/com/sparta/delivery/address/domain/entity/Address.java
@@ -45,7 +45,7 @@ public class Address extends BaseEntity {
     @Column(nullable = false)
     private boolean isDefault;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Address(
             Long userId,
             String alias,

--- a/src/main/java/com/sparta/delivery/common/response/PageResponse.java
+++ b/src/main/java/com/sparta/delivery/common/response/PageResponse.java
@@ -1,0 +1,25 @@
+package com.sparta.delivery.common.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last
+) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/application/OrderService.java
+++ b/src/main/java/com/sparta/delivery/order/application/OrderService.java
@@ -16,7 +16,8 @@ import com.sparta.delivery.order.domain.exception.StoreNotOrderableException;
 import com.sparta.delivery.order.domain.repository.OrderRepository;
 import com.sparta.delivery.order.presentation.dto.OrderCreateRequest;
 import com.sparta.delivery.order.presentation.dto.OrderItemCreateRequest;
-import com.sparta.delivery.order.presentation.dto.OrderResponse;
+import com.sparta.delivery.order.presentation.dto.OrderDetailResponse;
+import com.sparta.delivery.order.presentation.dto.OrderListResponse;
 import com.sparta.delivery.product.domain.entity.Product;
 import com.sparta.delivery.product.domain.repository.ProductRepository;
 import com.sparta.delivery.store.domain.entity.Store;
@@ -46,29 +47,29 @@ public class OrderService {
     private final ProductRepository productRepository;
 
     @Transactional
-    public OrderResponse create(Long userId, OrderCreateRequest request) {
+    public OrderDetailResponse create(Long userId, OrderCreateRequest request) {
         Address address = addressService.findOwnedAddress(userId, request.addressId());
         Store store = getOrderableStore(request.storeId());
         Order order = createOrder(userId, request, address, store);
         Order savedOrder = orderRepository.save(order);
         log.info("주문 생성 완료 - userId={}, orderId={}, totalPrice={}",
                 userId, savedOrder.getOrderId(), savedOrder.getTotalPrice());
-        return OrderResponse.from(savedOrder);
+        return OrderDetailResponse.from(savedOrder);
     }
 
-    public PageResponse<OrderResponse> getMyOrders(
+    public PageResponse<OrderListResponse> getMyOrders(
             Long userId,
             UUID storeId,
             OrderStatus status,
             Pageable pageable
     ) {
-        Page<OrderResponse> page = findMyOrders(userId, storeId, status, pageable)
-                .map(OrderResponse::from);
+        Page<OrderListResponse> page = findMyOrders(userId, storeId, status, pageable)
+                .map(OrderListResponse::from);
         return PageResponse.from(page);
     }
 
-    public OrderResponse getMyOrder(Long userId, UUID orderId) {
-        return OrderResponse.from(getOwnedOrder(userId, orderId));
+    public OrderDetailResponse getMyOrder(Long userId, UUID orderId) {
+        return OrderDetailResponse.from(getOwnedOrder(userId, orderId));
     }
 
     @Transactional

--- a/src/main/java/com/sparta/delivery/order/application/OrderService.java
+++ b/src/main/java/com/sparta/delivery/order/application/OrderService.java
@@ -1,0 +1,194 @@
+package com.sparta.delivery.order.application;
+
+import com.sparta.delivery.address.application.AddressService;
+import com.sparta.delivery.address.domain.entity.Address;
+import com.sparta.delivery.common.response.PageResponse;
+import com.sparta.delivery.order.domain.entity.Order;
+import com.sparta.delivery.order.domain.entity.OrderItem;
+import com.sparta.delivery.order.domain.entity.OrderStatus;
+import com.sparta.delivery.order.domain.exception.MinOrderAmountNotMetException;
+import com.sparta.delivery.order.domain.exception.OrderForbiddenException;
+import com.sparta.delivery.order.domain.exception.OrderNotFoundException;
+import com.sparta.delivery.order.domain.exception.ProductNotFoundException;
+import com.sparta.delivery.order.domain.exception.ProductNotOrderableException;
+import com.sparta.delivery.order.domain.exception.StoreNotFoundException;
+import com.sparta.delivery.order.domain.exception.StoreNotOrderableException;
+import com.sparta.delivery.order.domain.repository.OrderRepository;
+import com.sparta.delivery.order.presentation.dto.OrderCreateRequest;
+import com.sparta.delivery.order.presentation.dto.OrderItemCreateRequest;
+import com.sparta.delivery.order.presentation.dto.OrderResponse;
+import com.sparta.delivery.product.domain.entity.Product;
+import com.sparta.delivery.product.domain.repository.ProductRepository;
+import com.sparta.delivery.store.domain.entity.Store;
+import com.sparta.delivery.store.domain.repository.StoreRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private static final List<Integer> ALLOWED_PAGE_SIZES = List.of(10, 30, 50);
+
+    private final OrderRepository orderRepository;
+    private final AddressService addressService;
+    private final StoreRepository storeRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public OrderResponse create(Long userId, OrderCreateRequest request) {
+        Address address = addressService.findOwnedAddress(userId, request.addressId());
+        Store store = getOrderableStore(request.storeId());
+        Order order = createOrder(userId, request, address, store);
+        Order savedOrder = orderRepository.save(order);
+        log.info("주문 생성 완료 - userId={}, orderId={}, totalPrice={}",
+                userId, savedOrder.getOrderId(), savedOrder.getTotalPrice());
+        return OrderResponse.from(savedOrder);
+    }
+
+    public PageResponse<OrderResponse> getMyOrders(
+            Long userId,
+            UUID storeId,
+            OrderStatus status,
+            Pageable pageable
+    ) {
+        Page<OrderResponse> page = findMyOrders(userId, storeId, status, pageable)
+                .map(OrderResponse::from);
+        return PageResponse.from(page);
+    }
+
+    public OrderResponse getMyOrder(Long userId, UUID orderId) {
+        return OrderResponse.from(getOwnedOrder(userId, orderId));
+    }
+
+    @Transactional
+    public void cancel(Long userId, UUID orderId) {
+        Order order = getOwnedOrder(userId, orderId);
+        order.cancel();
+        log.info("주문 취소 완료 - userId={}, orderId={}", userId, orderId);
+    }
+
+    private Order createOrder(Long userId, OrderCreateRequest request, Address address, Store store) {
+        // 주문 총액은 외부 입력값이 아니라 주문 항목 합계로 계산되도록 엔티티에 맡긴다.
+        List<OrderItem> items = createOrderItems(store.getStoreId(), request.items());
+        Order order = Order.create(
+                store.getStoreId(),
+                address.getAddressId(),
+                userId,
+                buildDeliveryAddressSnapshot(address),
+                items
+        );
+        validateMinOrderAmount(order, store);
+        return order;
+    }
+
+    private Page<Order> findMyOrders(
+            Long userId,
+            UUID storeId,
+            OrderStatus status,
+            Pageable pageable
+    ) {
+        Pageable normalizedPageable = normalizePageable(pageable);
+        if (storeId != null && status != null) {
+            return orderRepository.findAllByUserIdAndStoreIdAndStatus(
+                    userId,
+                    storeId,
+                    status,
+                    normalizedPageable
+            );
+        }
+        if (storeId != null) {
+            return orderRepository.findAllByUserIdAndStoreId(userId, storeId, normalizedPageable);
+        }
+        if (status != null) {
+            return orderRepository.findAllByUserIdAndStatus(userId, status, normalizedPageable);
+        }
+        return orderRepository.findAllByUserId(userId, normalizedPageable);
+    }
+
+    private Pageable normalizePageable(Pageable pageable) {
+        // size(10/30/50)와 기본 정렬(createdAt DESC)을 보정한다.
+        int size = ALLOWED_PAGE_SIZES.contains(pageable.getPageSize()) ? pageable.getPageSize() : 10;
+        Sort sort = pageable.getSort().isSorted()
+                ? pageable.getSort()
+                : Sort.by(Sort.Direction.DESC, "createdAt");
+        return PageRequest.of(pageable.getPageNumber(), size, sort);
+    }
+
+    private Store getOrderableStore(UUID storeId) {
+        Store store = storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)
+                .orElseThrow(StoreNotFoundException::new);
+        if (!Boolean.TRUE.equals(store.getIsOpen()) || !Boolean.TRUE.equals(store.getIsActive())) {
+            throw new StoreNotOrderableException();
+        }
+        return store;
+    }
+
+    private List<OrderItem> createOrderItems(UUID storeId, List<OrderItemCreateRequest> requests) {
+        return requests.stream()
+                .map(request -> createOrderItem(storeId, request))
+                .toList();
+    }
+
+    private OrderItem createOrderItem(UUID storeId, OrderItemCreateRequest request) {
+        Product product = productRepository.findByProductId(request.productId())
+                .orElseThrow(ProductNotFoundException::new);
+
+        validateOrderableProduct(storeId, product);
+
+        return OrderItem.create(
+                product.getProductId(),
+                request.quantity(),
+                product.getPrice(),
+                product.getProductName()
+        );
+    }
+
+    private void validateOrderableProduct(UUID storeId, Product product) {
+        if (!product.getStoreId().equals(storeId)
+                || product.isHidden()
+                || product.isSoldOut()) {
+            throw new ProductNotOrderableException();
+        }
+    }
+
+    private String buildDeliveryAddressSnapshot(Address address) {
+        StringBuilder snapshot = new StringBuilder();
+
+        if (address.getZipCode() != null) {
+            snapshot.append("[").append(address.getZipCode()).append("] ");
+        }
+        snapshot.append(address.getAddress());
+        if (address.getDetail() != null) {
+            snapshot.append(" ").append(address.getDetail());
+        }
+
+        // 주문 당시 배송지 문자열을 스냅샷으로 보관해 이후 주소 변경과 분리한다.
+        return snapshot.toString();
+    }
+
+    private void validateMinOrderAmount(Order order, Store store) {
+        if (order.getTotalPrice() < store.getMinOrderAmount()) {
+            throw new MinOrderAmountNotMetException();
+        }
+    }
+
+    private Order getOwnedOrder(Long userId, UUID orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(OrderNotFoundException::new);
+        if (!order.getUserId().equals(userId)) {
+            throw new OrderForbiddenException();
+        }
+        return order;
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/Order.java
@@ -69,7 +69,7 @@ public class Order extends BaseEntity {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> items = new ArrayList<>();
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Order(
             UUID storeId,
             UUID addressId,

--- a/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/sparta/delivery/order/domain/entity/OrderItem.java
@@ -62,7 +62,7 @@ public class OrderItem {
     @Column(updatable = false)
     private Long createdBy;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private OrderItem(
             UUID productId,
             Integer quantity,

--- a/src/main/java/com/sparta/delivery/order/domain/exception/MinOrderAmountNotMetException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/MinOrderAmountNotMetException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class MinOrderAmountNotMetException extends BaseException {
+
+    public MinOrderAmountNotMetException() {
+        super(OrderErrorCode.MIN_ORDER_AMOUNT_NOT_MET);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/OrderErrorCode.java
@@ -19,7 +19,13 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_ORDER_ITEM_QUANTITY(HttpStatus.BAD_REQUEST, "ORDER-008", "주문 수량은 1개 이상이어야 합니다."),
     INVALID_ORDER_ITEM_UNIT_PRICE(HttpStatus.BAD_REQUEST, "ORDER-009", "주문 단가는 0보다 커야 합니다."),
     INVALID_PRODUCT_NAME_SNAPSHOT(HttpStatus.BAD_REQUEST, "ORDER-010", "상품명 스냅샷은 필수입니다."),
-    INVALID_ORDER_ITEM(HttpStatus.BAD_REQUEST, "ORDER-011", "주문 항목이 올바르지 않습니다.");
+    INVALID_ORDER_ITEM(HttpStatus.BAD_REQUEST, "ORDER-011", "주문 항목이 올바르지 않습니다."),
+    ORDER_FORBIDDEN(HttpStatus.FORBIDDEN, "ORDER-012", "본인 주문만 접근할 수 있습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER-013", "가게를 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER-014", "상품을 찾을 수 없습니다."),
+    STORE_NOT_ORDERABLE(HttpStatus.BAD_REQUEST, "ORDER-015", "주문 가능한 가게가 아닙니다."),
+    PRODUCT_NOT_ORDERABLE(HttpStatus.BAD_REQUEST, "ORDER-016", "주문 가능한 상품이 아닙니다."),
+    MIN_ORDER_AMOUNT_NOT_MET(HttpStatus.BAD_REQUEST, "ORDER-017", "최소 주문 금액을 충족하지 않았습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/delivery/order/domain/exception/OrderForbiddenException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/OrderForbiddenException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class OrderForbiddenException extends BaseException {
+
+    public OrderForbiddenException() {
+        super(OrderErrorCode.ORDER_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/ProductNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/ProductNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class ProductNotFoundException extends BaseException {
+
+    public ProductNotFoundException() {
+        super(OrderErrorCode.PRODUCT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/ProductNotOrderableException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/ProductNotOrderableException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class ProductNotOrderableException extends BaseException {
+
+    public ProductNotOrderableException() {
+        super(OrderErrorCode.PRODUCT_NOT_ORDERABLE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/StoreNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/StoreNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class StoreNotFoundException extends BaseException {
+
+    public StoreNotFoundException() {
+        super(OrderErrorCode.STORE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/exception/StoreNotOrderableException.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/StoreNotOrderableException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class StoreNotOrderableException extends BaseException {
+
+    public StoreNotOrderableException() {
+        super(OrderErrorCode.STORE_NOT_ORDERABLE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/delivery/order/domain/repository/OrderRepository.java
@@ -1,14 +1,25 @@
 package com.sparta.delivery.order.domain.repository;
 
 import com.sparta.delivery.order.domain.entity.Order;
+import com.sparta.delivery.order.domain.entity.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
 
-    List<Order> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+    Page<Order> findAllByUserId(Long userId, Pageable pageable);
 
-    List<Order> findAllByStoreIdOrderByCreatedAtDesc(UUID storeId);
+    Page<Order> findAllByUserIdAndStoreId(Long userId, UUID storeId, Pageable pageable);
+
+    Page<Order> findAllByUserIdAndStatus(Long userId, OrderStatus status, Pageable pageable);
+
+    Page<Order> findAllByUserIdAndStoreIdAndStatus(
+            Long userId,
+            UUID storeId,
+            OrderStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/sparta/delivery/order/presentation/OrderController.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/OrderController.java
@@ -1,0 +1,87 @@
+package com.sparta.delivery.order.presentation;
+
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.common.response.PageResponse;
+import com.sparta.delivery.order.application.OrderService;
+import com.sparta.delivery.order.domain.entity.OrderStatus;
+import com.sparta.delivery.order.presentation.dto.OrderCreateRequest;
+import com.sparta.delivery.order.presentation.dto.OrderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+@Tag(name = "Order", description = "주문 API")
+@PreAuthorize("hasRole('CUSTOMER')")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @Operation(summary = "주문 생성")
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderResponse>> create(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody OrderCreateRequest request
+    ) {
+        OrderResponse response = orderService.create(principal.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
+    }
+
+    @Operation(summary = "내 주문 목록 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<OrderResponse>>> getMyOrders(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(required = false) UUID storeId,
+            @RequestParam(required = false) OrderStatus status,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        PageResponse<OrderResponse> response = orderService.getMyOrders(
+                principal.getId(),
+                storeId,
+                status,
+                pageable
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "내 주문 상세 조회")
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderResponse>> getMyOrder(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID orderId
+    ) {
+        OrderResponse response = orderService.getMyOrder(principal.getId(), orderId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "주문 취소")
+    @PatchMapping("/{orderId}/cancel")
+    public ResponseEntity<ApiResponse<Void>> cancel(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID orderId
+    ) {
+        orderService.cancel(principal.getId(), orderId);
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/presentation/OrderController.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/OrderController.java
@@ -6,7 +6,8 @@ import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.order.application.OrderService;
 import com.sparta.delivery.order.domain.entity.OrderStatus;
 import com.sparta.delivery.order.presentation.dto.OrderCreateRequest;
-import com.sparta.delivery.order.presentation.dto.OrderResponse;
+import com.sparta.delivery.order.presentation.dto.OrderDetailResponse;
+import com.sparta.delivery.order.presentation.dto.OrderListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -39,24 +40,24 @@ public class OrderController {
 
     @Operation(summary = "주문 생성")
     @PostMapping
-    public ResponseEntity<ApiResponse<OrderResponse>> create(
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> create(
             @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody OrderCreateRequest request
     ) {
-        OrderResponse response = orderService.create(principal.getId(), request);
+        OrderDetailResponse response = orderService.create(principal.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
     }
 
     @Operation(summary = "내 주문 목록 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<OrderResponse>>> getMyOrders(
+    public ResponseEntity<ApiResponse<PageResponse<OrderListResponse>>> getMyOrders(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam(required = false) UUID storeId,
             @RequestParam(required = false) OrderStatus status,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        PageResponse<OrderResponse> response = orderService.getMyOrders(
+        PageResponse<OrderListResponse> response = orderService.getMyOrders(
                 principal.getId(),
                 storeId,
                 status,
@@ -67,11 +68,11 @@ public class OrderController {
 
     @Operation(summary = "내 주문 상세 조회")
     @GetMapping("/{orderId}")
-    public ResponseEntity<ApiResponse<OrderResponse>> getMyOrder(
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getMyOrder(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable UUID orderId
     ) {
-        OrderResponse response = orderService.getMyOrder(principal.getId(), orderId);
+        OrderDetailResponse response = orderService.getMyOrder(principal.getId(), orderId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/sparta/delivery/order/presentation/dto/OrderCreateRequest.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/dto/OrderCreateRequest.java
@@ -1,0 +1,24 @@
+package com.sparta.delivery.order.presentation.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderCreateRequest(
+        @NotNull(message = "가게 ID는 필수입니다.")
+        UUID storeId,
+
+        @NotNull(message = "배송지 ID는 필수입니다.")
+        UUID addressId,
+
+        @Valid
+        @NotEmpty(message = "주문 항목은 1개 이상이어야 합니다.")
+        List<OrderItemCreateRequest> items
+) {
+
+    public OrderCreateRequest {
+        items = (items == null) ? null : List.copyOf(items);
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/presentation/dto/OrderDetailResponse.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/dto/OrderDetailResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-public record OrderResponse(
+public record OrderDetailResponse(
         UUID orderId,
         UUID storeId,
         UUID addressId,
@@ -23,8 +23,8 @@ public record OrderResponse(
         LocalDateTime updatedAt
 ) {
 
-    public static OrderResponse from(Order order) {
-        return new OrderResponse(
+    public static OrderDetailResponse from(Order order) {
+        return new OrderDetailResponse(
                 order.getOrderId(),
                 order.getStoreId(),
                 order.getAddressId(),

--- a/src/main/java/com/sparta/delivery/order/presentation/dto/OrderItemCreateRequest.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/dto/OrderItemCreateRequest.java
@@ -1,0 +1,15 @@
+package com.sparta.delivery.order.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record OrderItemCreateRequest(
+        @NotNull(message = "상품 ID는 필수입니다.")
+        UUID productId,
+
+        @NotNull(message = "주문 수량은 필수입니다.")
+        @Min(value = 1, message = "주문 수량은 1개 이상이어야 합니다.")
+        Integer quantity
+) {
+}

--- a/src/main/java/com/sparta/delivery/order/presentation/dto/OrderItemResponse.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/dto/OrderItemResponse.java
@@ -1,0 +1,28 @@
+package com.sparta.delivery.order.presentation.dto;
+
+import com.sparta.delivery.order.domain.entity.OrderItem;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderItemResponse(
+        UUID orderItemId,
+        UUID productId,
+        Integer quantity,
+        Integer unitPrice,
+        Integer lineTotalPrice,
+        String productNameSnapshot,
+        LocalDateTime createdAt
+) {
+
+    public static OrderItemResponse from(OrderItem orderItem) {
+        return new OrderItemResponse(
+                orderItem.getOrderItemId(),
+                orderItem.getProductId(),
+                orderItem.getQuantity(),
+                orderItem.getUnitPrice(),
+                orderItem.getLineTotalPrice(),
+                orderItem.getProductNameSnapshot(),
+                orderItem.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/presentation/dto/OrderListResponse.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/dto/OrderListResponse.java
@@ -1,0 +1,41 @@
+package com.sparta.delivery.order.presentation.dto;
+
+import com.sparta.delivery.order.domain.entity.Order;
+import com.sparta.delivery.order.domain.entity.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderListResponse(
+        UUID orderId,
+        UUID storeId,
+        UUID addressId,
+        Long userId,
+        Integer totalPrice,
+        OrderStatus status,
+        String deliveryAddressSnapshot,
+        LocalDateTime cancelDeadlineAt,
+        LocalDateTime rejectedAt,
+        LocalDateTime completedAt,
+        LocalDateTime canceledAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static OrderListResponse from(Order order) {
+        return new OrderListResponse(
+                order.getOrderId(),
+                order.getStoreId(),
+                order.getAddressId(),
+                order.getUserId(),
+                order.getTotalPrice(),
+                order.getStatus(),
+                order.getDeliveryAddressSnapshot(),
+                order.getCancelDeadlineAt(),
+                order.getRejectedAt(),
+                order.getCompletedAt(),
+                order.getCanceledAt(),
+                order.getCreatedAt(),
+                order.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/order/presentation/dto/OrderResponse.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/dto/OrderResponse.java
@@ -1,0 +1,46 @@
+package com.sparta.delivery.order.presentation.dto;
+
+import com.sparta.delivery.order.domain.entity.Order;
+import com.sparta.delivery.order.domain.entity.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderResponse(
+        UUID orderId,
+        UUID storeId,
+        UUID addressId,
+        Long userId,
+        Integer totalPrice,
+        OrderStatus status,
+        String deliveryAddressSnapshot,
+        LocalDateTime cancelDeadlineAt,
+        LocalDateTime rejectedAt,
+        LocalDateTime completedAt,
+        LocalDateTime canceledAt,
+        List<OrderItemResponse> items,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static OrderResponse from(Order order) {
+        return new OrderResponse(
+                order.getOrderId(),
+                order.getStoreId(),
+                order.getAddressId(),
+                order.getUserId(),
+                order.getTotalPrice(),
+                order.getStatus(),
+                order.getDeliveryAddressSnapshot(),
+                order.getCancelDeadlineAt(),
+                order.getRejectedAt(),
+                order.getCompletedAt(),
+                order.getCanceledAt(),
+                order.getItems().stream()
+                        .map(OrderItemResponse::from)
+                        .toList(),
+                order.getCreatedAt(),
+                order.getUpdatedAt()
+        );
+    }
+}

--- a/src/test/java/com/sparta/delivery/order/application/OrderServiceTest.java
+++ b/src/test/java/com/sparta/delivery/order/application/OrderServiceTest.java
@@ -1,0 +1,326 @@
+package com.sparta.delivery.order.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.sparta.delivery.address.application.AddressService;
+import com.sparta.delivery.address.domain.entity.Address;
+import com.sparta.delivery.common.response.PageResponse;
+import com.sparta.delivery.order.domain.entity.Order;
+import com.sparta.delivery.order.domain.entity.OrderItem;
+import com.sparta.delivery.order.domain.entity.OrderStatus;
+import com.sparta.delivery.order.domain.exception.MinOrderAmountNotMetException;
+import com.sparta.delivery.order.domain.exception.OrderForbiddenException;
+import com.sparta.delivery.order.domain.exception.ProductNotOrderableException;
+import com.sparta.delivery.order.domain.repository.OrderRepository;
+import com.sparta.delivery.order.presentation.dto.OrderCreateRequest;
+import com.sparta.delivery.order.presentation.dto.OrderItemCreateRequest;
+import com.sparta.delivery.product.domain.entity.Product;
+import com.sparta.delivery.product.domain.repository.ProductRepository;
+import com.sparta.delivery.store.domain.entity.Store;
+import com.sparta.delivery.store.domain.repository.StoreRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private AddressService addressService;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Nested
+    @DisplayName("주문 생성")
+    class Create {
+
+        @Test
+        @DisplayName("본인 주소와 주문 가능한 상품으로 주문을 생성할 수 있다")
+        void success() {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            UUID productId = UUID.randomUUID();
+
+            Address address = createAddress(userId, addressId);
+            Store store = createStore(storeId, 10000, true, true);
+            Product product = createProduct(productId, storeId, "후라이드 치킨", 18000);
+            OrderCreateRequest request = new OrderCreateRequest(
+                    storeId,
+                    addressId,
+                    List.of(new OrderItemCreateRequest(productId, 1))
+            );
+
+            given(addressService.findOwnedAddress(userId, addressId)).willReturn(address);
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(store));
+            given(productRepository.findByProductId(productId)).willReturn(Optional.of(product));
+            given(orderRepository.save(any(Order.class))).willAnswer(invocation -> {
+                Order order = invocation.getArgument(0);
+                ReflectionTestUtils.setField(order, "orderId", UUID.randomUUID());
+                ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now());
+                return order;
+            });
+
+            // when
+            var response = orderService.create(userId, request);
+
+            // then
+            assertThat(response.storeId()).isEqualTo(storeId);
+            assertThat(response.addressId()).isEqualTo(addressId);
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.totalPrice()).isEqualTo(18000);
+            assertThat(response.status()).isEqualTo(OrderStatus.PENDING);
+            assertThat(response.deliveryAddressSnapshot()).isEqualTo("[12345] 서울시 강남구 101호");
+            assertThat(response.items()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("최소 주문 금액을 충족하지 않으면 주문을 생성할 수 없다")
+        void minOrderAmountNotMet() {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            UUID productId = UUID.randomUUID();
+
+            Address address = createAddress(userId, addressId);
+            Store store = createStore(storeId, 20000, true, true);
+            Product product = createProduct(productId, storeId, "후라이드 치킨", 18000);
+            OrderCreateRequest request = new OrderCreateRequest(
+                    storeId,
+                    addressId,
+                    List.of(new OrderItemCreateRequest(productId, 1))
+            );
+
+            given(addressService.findOwnedAddress(userId, addressId)).willReturn(address);
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(store));
+            given(productRepository.findByProductId(productId)).willReturn(Optional.of(product));
+
+            // when // then
+            assertThatThrownBy(() -> orderService.create(userId, request))
+                    .isInstanceOf(MinOrderAmountNotMetException.class);
+            verify(orderRepository, never()).save(any(Order.class));
+        }
+
+        @Test
+        @DisplayName("주문 불가능한 상품이면 주문을 생성할 수 없다")
+        void productNotOrderable() {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            UUID productId = UUID.randomUUID();
+
+            Address address = createAddress(userId, addressId);
+            Store store = createStore(storeId, 10000, true, true);
+            Product product = createProduct(productId, storeId, "후라이드 치킨", 18000);
+            product.changeHidden(true);
+            OrderCreateRequest request = new OrderCreateRequest(
+                    storeId,
+                    addressId,
+                    List.of(new OrderItemCreateRequest(productId, 1))
+            );
+
+            given(addressService.findOwnedAddress(userId, addressId)).willReturn(address);
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(store));
+            given(productRepository.findByProductId(productId)).willReturn(Optional.of(product));
+
+            // when // then
+            assertThatThrownBy(() -> orderService.create(userId, request))
+                    .isInstanceOf(ProductNotOrderableException.class);
+            verify(orderRepository, never()).save(any(Order.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("내 주문 목록 조회")
+    class GetMyOrders {
+
+        @Test
+        @DisplayName("허용되지 않은 페이지 크기는 10으로 보정된다")
+        void invalidPageSize() {
+            // given
+            Long userId = 1L;
+            UUID orderId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            Order order = createOrder(orderId, userId, storeId, UUID.randomUUID(), 18000);
+            Pageable pageable = PageRequest.of(0, 7);
+
+            given(orderRepository.findAllByUserId(eq(userId), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(order), PageRequest.of(0, 10), 1));
+
+            // when
+            PageResponse<?> response = orderService.getMyOrders(userId, null, null, pageable);
+
+            // then
+            ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+            verify(orderRepository).findAllByUserId(eq(userId), pageableCaptor.capture());
+            assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(10);
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.size()).isEqualTo(10);
+        }
+    }
+
+    @Nested
+    @DisplayName("내 주문 상세 조회")
+    class GetMyOrder {
+
+        @Test
+        @DisplayName("본인 주문을 상세 조회할 수 있다")
+        void success() {
+            // given
+            Long userId = 1L;
+            UUID orderId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            UUID addressId = UUID.randomUUID();
+            Order order = createOrder(orderId, userId, storeId, addressId, 18000);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when
+            var response = orderService.getMyOrder(userId, orderId);
+
+            // then
+            assertThat(response.orderId()).isEqualTo(orderId);
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.totalPrice()).isEqualTo(18000);
+            assertThat(response.items()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("본인 주문이 아니면 상세 조회할 수 없다")
+        void forbidden() {
+            // given
+            Long userId = 1L;
+            UUID orderId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, UUID.randomUUID(), UUID.randomUUID(), 18000);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when // then
+            assertThatThrownBy(() -> orderService.getMyOrder(userId, orderId))
+                    .isInstanceOf(OrderForbiddenException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 취소")
+    class Cancel {
+
+        @Test
+        @DisplayName("본인 주문을 취소할 수 있다")
+        void success() {
+            // given
+            Long userId = 1L;
+            UUID orderId = UUID.randomUUID();
+            Order order = createOrder(orderId, userId, UUID.randomUUID(), UUID.randomUUID(), 18000);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when
+            orderService.cancel(userId, orderId);
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+            assertThat(order.getCanceledAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("본인 주문이 아니면 취소할 수 없다")
+        void forbidden() {
+            // given
+            Long userId = 1L;
+            UUID orderId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, UUID.randomUUID(), UUID.randomUUID(), 18000);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when // then
+            assertThatThrownBy(() -> orderService.cancel(userId, orderId))
+                    .isInstanceOf(OrderForbiddenException.class);
+        }
+    }
+
+    private Address createAddress(Long userId, UUID addressId) {
+        Address address = Address.create(userId, "집", "서울시 강남구", "101호", "12345", true);
+        ReflectionTestUtils.setField(address, "addressId", addressId);
+        return address;
+    }
+
+    private Store createStore(UUID storeId, Integer minOrderAmount, boolean isOpen, boolean isActive) {
+        Store store = Store.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                1L,
+                "치킨집",
+                null,
+                "서울시 강남구",
+                null,
+                null,
+                minOrderAmount,
+                isOpen,
+                isActive,
+                null,
+                0
+        );
+        ReflectionTestUtils.setField(store, "storeId", storeId);
+        return store;
+    }
+
+    private Product createProduct(UUID productId, UUID storeId, String productName, Integer price) {
+        Product product = Product.create(
+                storeId,
+                productName,
+                null,
+                null,
+                price,
+                1
+        );
+        ReflectionTestUtils.setField(product, "productId", productId);
+        return product;
+    }
+
+    private Order createOrder(UUID orderId, Long userId, UUID storeId, UUID addressId, Integer unitPrice) {
+        OrderItem orderItem = OrderItem.create(UUID.randomUUID(), 1, unitPrice, "후라이드 치킨");
+        Order order = Order.create(
+                storeId,
+                addressId,
+                userId,
+                "[12345] 서울시 강남구 101호",
+                List.of(orderItem)
+        );
+        ReflectionTestUtils.setField(order, "orderId", orderId);
+        ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now());
+        return order;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #47 

## ✨ 기능 요약
고객 기준 주문 생성, 목록 조회, 상세 조회, 취소 API를 구현하고
주문 생성 시 필요한 주소/가게/상품 검증과 페이징 응답 구조를 반영.

## 📝 상세 내역
- `OrderController`, `OrderService`, 주문 Request/Response DTO를 추가해 고객 주문 CRUD(생성/목록/상세/취소) 흐름을 구현.
- 주문 생성 시 본인 배송지 확인, 주문 가능한 가게/상품 검증, 최소 주문 금액 검증, 배송지 스냅샷 생성 로직을 반영.
- 주문 목록 조회는 `storeId`, `status` 조건과 `Pageable + PageResponse`를 사용하도록 구현.
- `OrderService`가 `AddressRepository` 대신 `AddressService`를 통해 주소를 조회하도록 구현.
- `OrderServiceTest`를 추가해 생성/조회/취소 핵심 시나리오를 검증.

---

## ✅ 테스트 체크리스트
<!-- 테스트 할 내용이 있다면 작성해주세요
- [x] 기능 정상 작동 확인
- [x] 예외/엣지 케이스 확인
- [x] UI/UX 흐름 확인 (필요 시 캡처 또는 영상 첨부)
- [x] 테스트 코드 작성 완료
-->

---

- 이번 PR은 우선 `CUSTOMER` 기준 주문 생성/조회/취소 범위만 포함.
- 주문 상태 변경, 주문 삭제, OWNER/MANAGER/MASTER 조회 권한은 다음 이슈에서 진행 예정.
- `address`는 docs 방향에 맞춰 service 경유로 연결했고 `store`/`product`는 관련 service가 아직 없어 현재는 repository를 직접 사용.
- 목록 조회 size는 docs 기준에 맞춰 `10/30/50` 외 값은 `10`으로 보정하고 기본 정렬은 `createdAt DESC`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 고객용 주문 생성, 조회, 취소 API 엔드포인트 추가
  * 주문 목록 조회 시 가게 및 상태 필터링과 페이지네이션 지원
  * 최소 주문 금액 및 상품 주문 가능 여부 검증 강화
  * 주문 상세 정보 및 목록 조회 응답 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->