### PR TITLE
feat: LLM 관리 API 및 호출 로그 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/ai/application/LlmCallService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmCallService.java
@@ -1,0 +1,55 @@
+package com.sparta.delivery.ai.application;
+
+import com.sparta.delivery.ai.domain.entity.LlmCall;
+import com.sparta.delivery.ai.domain.exception.AiForbiddenException;
+import com.sparta.delivery.ai.domain.exception.LlmCallNotFoundException;
+import com.sparta.delivery.ai.domain.repository.LlmCallRepository;
+import com.sparta.delivery.ai.presentation.dto.response.LlmCallListResponse;
+import com.sparta.delivery.ai.presentation.dto.response.LlmCallResponse;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LlmCallService {
+
+    private final LlmCallRepository llmCallRepository;
+
+    public LlmCallResponse getLlmCall(UserRole actorRole, UUID callId) {
+        validateLlmCallPermission(actorRole);
+        LlmCall call = getLlmCallOrThrow(callId);
+
+        return LlmCallResponse.from(call);
+    }
+
+    public List<LlmCallListResponse> getLlmCalls(UserRole actorRole) {
+        validateLlmCallPermission(actorRole);
+        return llmCallRepository.findAll(Sort.by(
+                        Sort.Order.desc("createdAt")
+                ))
+                .stream()
+                .map(LlmCallListResponse::from)
+                .toList();
+    }
+
+    private LlmCall getLlmCallOrThrow(UUID callId) {
+        return llmCallRepository.findByCallId(callId)
+                .orElseThrow(LlmCallNotFoundException::new);
+    }
+
+    private void validateLlmCallPermission(UserRole actorRole) {
+        if (actorRole == UserRole.MANAGER || actorRole == UserRole.MASTER) {
+            return;
+        }
+        throw new AiForbiddenException();
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/application/LlmService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmService.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.ai.application;
 
 import com.sparta.delivery.ai.domain.entity.Llm;
+import com.sparta.delivery.ai.domain.exception.CannotDeleteActiveLlmException;
 import com.sparta.delivery.ai.domain.exception.DuplicateLlmNameException;
 import com.sparta.delivery.ai.domain.exception.LlmForbiddenException;
 import com.sparta.delivery.ai.domain.exception.LlmNotFoundException;
@@ -11,9 +12,11 @@ import com.sparta.delivery.ai.presentation.dto.response.LlmResponse;
 import com.sparta.delivery.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -41,16 +44,45 @@ public class LlmService {
         return LlmResponse.from(savedLlm);
     }
 
+    public LlmResponse getLlm(UserRole actorRole, UUID llmId) {
+        validateLlmPermission(actorRole);
+        Llm llm = getLlmOrThrow(llmId);
+
+        return LlmResponse.from(llm);
+    }
+
+    public List<LlmResponse> getLlms(UserRole actorRole) {
+        validateLlmPermission(actorRole);
+        return llmRepository.findAll(Sort.by(
+                Sort.Order.desc("isActive"),
+                Sort.Order.desc("updatedAt")
+        )).stream()
+                .map(LlmResponse::from)
+                .toList();
+    }
+
     @Transactional
     public LlmResponse changeLlmName(Long actorId, UserRole actorRole, UUID llmId, LlmUpdateRequest request) {
         validateLlmPermission(actorRole);
-
         Llm llm = getLlmOrThrow(llmId);
-
         validateDuplicateLlmNameOnUpdate(llm, request.llmName());
-
         llm.updateName(request.llmName());
         log.info("LLM 이름 변경 완료 - actorId={}, llmId={}, provider={}, llmName={}",
+                actorId, llm.getLlmId(), llm.getProvider(), llm.getLlmName());
+
+        return LlmResponse.from(llm);
+    }
+
+    @Transactional
+    public LlmResponse delete(Long actorId, UserRole actorRole, UUID llmId) {
+        validateLlmPermission(actorRole);
+        Llm llm = getLlmOrThrow(llmId);
+        if (llm.isActive()) {
+            throw new CannotDeleteActiveLlmException();
+        }
+
+        llm.softDelete(actorId);
+        log.info("LLM 삭제 완료 - actorId={}, llmId={}, provider={}, llmName={}",
                 actorId, llm.getLlmId(), llm.getProvider(), llm.getLlmName());
 
         return LlmResponse.from(llm);

--- a/src/main/java/com/sparta/delivery/ai/application/LlmService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmService.java
@@ -3,7 +3,7 @@ package com.sparta.delivery.ai.application;
 import com.sparta.delivery.ai.domain.entity.Llm;
 import com.sparta.delivery.ai.domain.exception.CannotDeleteActiveLlmException;
 import com.sparta.delivery.ai.domain.exception.DuplicateLlmNameException;
-import com.sparta.delivery.ai.domain.exception.LlmForbiddenException;
+import com.sparta.delivery.ai.domain.exception.AiForbiddenException;
 import com.sparta.delivery.ai.domain.exception.LlmNotFoundException;
 import com.sparta.delivery.ai.domain.repository.LlmRepository;
 import com.sparta.delivery.ai.presentation.dto.request.LlmCreateRequest;
@@ -97,7 +97,7 @@ public class LlmService {
         if (actorRole == UserRole.MANAGER || actorRole == UserRole.MASTER) {
             return;
         }
-        throw new LlmForbiddenException();
+        throw new AiForbiddenException();
     }
 
     private void validateDuplicateLlmName(String llmName) {

--- a/src/main/java/com/sparta/delivery/ai/application/LlmService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmService.java
@@ -1,0 +1,83 @@
+package com.sparta.delivery.ai.application;
+
+import com.sparta.delivery.ai.domain.entity.Llm;
+import com.sparta.delivery.ai.domain.exception.DuplicateLlmNameException;
+import com.sparta.delivery.ai.domain.exception.LlmForbiddenException;
+import com.sparta.delivery.ai.domain.exception.LlmNotFoundException;
+import com.sparta.delivery.ai.domain.repository.LlmRepository;
+import com.sparta.delivery.ai.presentation.dto.request.LlmCreateRequest;
+import com.sparta.delivery.ai.presentation.dto.request.LlmUpdateRequest;
+import com.sparta.delivery.ai.presentation.dto.response.LlmResponse;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LlmService {
+
+    private final LlmRepository llmRepository;
+
+    @Transactional
+    public LlmResponse create(Long actorId, UserRole actorRole, LlmCreateRequest request) {
+        validateLlmPermission(actorRole);
+        validateDuplicateLlmName(request.llmName());
+        Llm llm = Llm.create(
+                request.llmName(),
+                request.provider(),
+                false
+        );
+        Llm savedLlm = llmRepository.save(llm);
+
+        log.info("LLM 생성 완료 - actorId={}, llmId={}, provider={}, llmName={}",
+                actorId, savedLlm.getLlmId(), savedLlm.getProvider(), savedLlm.getLlmName());
+
+        return LlmResponse.from(savedLlm);
+    }
+
+    @Transactional
+    public LlmResponse changeLlmName(Long actorId, UserRole actorRole, UUID llmId, LlmUpdateRequest request) {
+        validateLlmPermission(actorRole);
+
+        Llm llm = getLlmOrThrow(llmId);
+
+        validateDuplicateLlmNameOnUpdate(llm, request.llmName());
+
+        llm.updateName(request.llmName());
+        log.info("LLM 이름 변경 완료 - actorId={}, llmId={}, provider={}, llmName={}",
+                actorId, llm.getLlmId(), llm.getProvider(), llm.getLlmName());
+
+        return LlmResponse.from(llm);
+    }
+
+    private Llm getLlmOrThrow(UUID llmId) {
+        return llmRepository.findByLlmId(llmId)
+                .orElseThrow(LlmNotFoundException::new);
+    }
+
+    private void validateLlmPermission(UserRole actorRole) {
+        if (actorRole == UserRole.MANAGER || actorRole == UserRole.MASTER) {
+            return;
+        }
+        throw new LlmForbiddenException();
+    }
+
+    private void validateDuplicateLlmName(String llmName) {
+        if (llmRepository.existsIncludingDeletedByLlmName(llmName)) {
+            throw new DuplicateLlmNameException();
+        }
+    }
+
+    private void validateDuplicateLlmNameOnUpdate(Llm llm, String llmName) {
+        boolean nameChanged = !llm.getLlmName().equals(llmName);
+        if (nameChanged && llmRepository.existsIncludingDeletedByLlmName(llmName)) {
+            throw new DuplicateLlmNameException();
+        }
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.ai.domain.entity;
 
 
 import com.sparta.delivery.ai.domain.exception.InvalidLlmNameException;
+import com.sparta.delivery.ai.domain.exception.InvalidLlmProviderException;
 import com.sparta.delivery.common.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -51,6 +52,7 @@ public class Llm extends BaseEntity {
             boolean isActive
     ) {
         validateLlmName(llmName);
+        validateProvider(provider);
 
         return Llm.builder()
                 .llmName(llmName)
@@ -72,10 +74,16 @@ public class Llm extends BaseEntity {
         this.isActive = false;
     }
 
-    // max length 100
+    // not null, non-blank, and max length 100
     private static void validateLlmName(String llmName) {
-        if (llmName != null && llmName.length() > 100) {
+        if (llmName == null || llmName.isBlank() || llmName.length() > 100) {
             throw new InvalidLlmNameException();
+        }
+    }
+
+    private static void validateProvider(LlmProvider provider) {
+        if (provider == null) {
+            throw new InvalidLlmProviderException();
         }
     }
 }

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
@@ -34,7 +34,7 @@ public class Llm extends BaseEntity {
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Llm(
             String llmName,
             LlmProvider provider,

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
@@ -1,5 +1,8 @@
 package com.sparta.delivery.ai.domain.entity;
 
+import com.sparta.delivery.ai.domain.exception.InvalidCreatedByException;
+import com.sparta.delivery.ai.domain.exception.InvalidInputSnapshotException;
+import com.sparta.delivery.ai.domain.exception.InvalidProviderStatusCodeException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -74,6 +77,10 @@ public class LlmCall {
             String generatedText,
             Long createdBy
     ) {
+        validateInputSnapshot(inputSnapshot);
+        validateProviderStatusCode(providerStatusCode);
+        validateCreatedBy(createdBy);
+
         return LlmCall.builder()
                 .llmId(llmId)
                 .productId(productId)
@@ -84,6 +91,24 @@ public class LlmCall {
                 .createdAt(LocalDateTime.now())
                 .createdBy(createdBy)
                 .build();
+    }
+
+    private static void validateInputSnapshot(String inputSnapshot) {
+        if (inputSnapshot == null || inputSnapshot.isBlank()) {
+            throw new InvalidInputSnapshotException();
+        }
+    }
+
+    private static void validateProviderStatusCode(String providerStatusCode) {
+        if (providerStatusCode != null && providerStatusCode.length() > 50) {
+            throw new InvalidProviderStatusCodeException();
+        }
+    }
+
+    private static void validateCreatedBy(Long createdBy) {
+        if (createdBy == null) {
+            throw new InvalidCreatedByException();
+        }
     }
 
 }

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
@@ -44,7 +44,7 @@ public class LlmCall {
     @Column(name = "created_by", nullable = false)
     private Long createdBy;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private LlmCall(
             UUID llmId,
             UUID productId,

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
@@ -10,11 +10,18 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AiErrorCode implements ErrorCode {
     INVALID_LLM_NAME(HttpStatus.BAD_REQUEST, "AI-001", "모델 이름은 100자를 넘을 수 없습니다."),
+    INVALID_LLM_PROVIDER(HttpStatus.BAD_REQUEST, "AI-002", "유효하지 않은 LLM provider입니다."),
+    INVALID_INPUT_SNAPSHOT(HttpStatus.BAD_REQUEST, "AI-003", "inputSnapshot은 비어 있을 수 없습니다."),
+    INVALID_PROVIDER_STATUS_CODE(HttpStatus.BAD_REQUEST, "AI-004", "providerStatusCode는 50자를 넘을 수 없습니다."),
+    INVALID_CREATED_BY(HttpStatus.BAD_REQUEST, "AI-005", "createdBy는 필수입니다."),
 
-    LLM_FORBIDDEN(HttpStatus.FORBIDDEN, "AI-101", "모델 정보에 접근할 수 없습니다."),
-    DUPLICATE_LLM_NAME(HttpStatus.CONFLICT, "AI-102", "이미 존재하는 모델입니다."),
-    LLM_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-103", "모델을 찾을 수 없습니다."),
-    CANNOT_DELETE_ACTIVE_LLM(HttpStatus.BAD_REQUEST, "AI-104", "활성 모델은 삭제할 수 없습니다.");
+    AI_FORBIDDEN(HttpStatus.FORBIDDEN, "AI-101", "모델 정보에 접근할 수 없습니다."),
+
+    DUPLICATE_LLM_NAME(HttpStatus.CONFLICT, "AI-201", "이미 존재하는 모델입니다."),
+    LLM_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-202", "모델을 찾을 수 없습니다."),
+    CANNOT_DELETE_ACTIVE_LLM(HttpStatus.BAD_REQUEST, "AI-203", "활성 모델은 삭제할 수 없습니다."),
+
+    LLM_CALL_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-301", "LLM 호출 로그를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
@@ -9,7 +9,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AiErrorCode implements ErrorCode {
-    INVALID_LLM_NAME(HttpStatus.BAD_REQUEST, "AI-001", "모델 이름은 100자를 넘을 수 없습니다.");
+    INVALID_LLM_NAME(HttpStatus.BAD_REQUEST, "AI-001", "모델 이름은 100자를 넘을 수 없습니다."),
+
+    LLM_FORBIDDEN(HttpStatus.FORBIDDEN, "AI-101", "모델 정보에 접근할 수 없습니다."),
+    DUPLICATE_LLM_NAME(HttpStatus.CONFLICT, "AI-102", "이미 존재하는 모델입니다."),
+    LLM_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-103", "모델을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/AiErrorCode.java
@@ -13,7 +13,8 @@ public enum AiErrorCode implements ErrorCode {
 
     LLM_FORBIDDEN(HttpStatus.FORBIDDEN, "AI-101", "모델 정보에 접근할 수 없습니다."),
     DUPLICATE_LLM_NAME(HttpStatus.CONFLICT, "AI-102", "이미 존재하는 모델입니다."),
-    LLM_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-103", "모델을 찾을 수 없습니다.");
+    LLM_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-103", "모델을 찾을 수 없습니다."),
+    CANNOT_DELETE_ACTIVE_LLM(HttpStatus.BAD_REQUEST, "AI-104", "활성 모델은 삭제할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/AiForbiddenException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/AiForbiddenException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class AiForbiddenException extends BaseException {
+    public AiForbiddenException() {
+        super(AiErrorCode.AI_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/CannotDeleteActiveLlmException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/CannotDeleteActiveLlmException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class CannotDeleteActiveLlmException extends BaseException {
+    public CannotDeleteActiveLlmException() {
+        super(AiErrorCode.CANNOT_DELETE_ACTIVE_LLM);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/DuplicateLlmNameException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/DuplicateLlmNameException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class DuplicateLlmNameException extends BaseException {
+    public DuplicateLlmNameException() {
+        super(AiErrorCode.DUPLICATE_LLM_NAME);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidCreatedByException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidCreatedByException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidCreatedByException extends BaseException {
+    public InvalidCreatedByException() {
+        super(AiErrorCode.INVALID_CREATED_BY);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidInputSnapshotException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidInputSnapshotException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidInputSnapshotException extends BaseException {
+    public InvalidInputSnapshotException() {
+        super(AiErrorCode.INVALID_INPUT_SNAPSHOT);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidLlmProviderException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidLlmProviderException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidLlmProviderException extends BaseException {
+    public InvalidLlmProviderException() {
+        super(AiErrorCode.INVALID_LLM_PROVIDER);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidProviderStatusCodeException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/InvalidProviderStatusCodeException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidProviderStatusCodeException extends BaseException {
+    public InvalidProviderStatusCodeException() {
+        super(AiErrorCode.INVALID_PROVIDER_STATUS_CODE);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/LlmCallNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/LlmCallNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class LlmCallNotFoundException extends BaseException {
+    public LlmCallNotFoundException() {
+        super(AiErrorCode.LLM_CALL_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/LlmForbiddenException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/LlmForbiddenException.java
@@ -1,9 +1,0 @@
-package com.sparta.delivery.ai.domain.exception;
-
-import com.sparta.delivery.common.exception.BaseException;
-
-public class LlmForbiddenException extends BaseException {
-    public LlmForbiddenException() {
-        super(AiErrorCode.LLM_FORBIDDEN);
-    }
-}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/LlmForbiddenException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/LlmForbiddenException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class LlmForbiddenException extends BaseException {
+    public LlmForbiddenException() {
+        super(AiErrorCode.LLM_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/exception/LlmNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/exception/LlmNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.ai.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class LlmNotFoundException extends BaseException {
+    public LlmNotFoundException() {
+        super(AiErrorCode.LLM_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/domain/repository/LlmCallRepository.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/repository/LlmCallRepository.java
@@ -1,9 +1,10 @@
 package com.sparta.delivery.ai.domain.repository;
 
 import com.sparta.delivery.ai.domain.entity.LlmCall;
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LlmCallRepository extends JpaRepository<LlmCall, UUID> {
 

--- a/src/main/java/com/sparta/delivery/ai/domain/repository/LlmRepository.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/repository/LlmRepository.java
@@ -1,9 +1,12 @@
 package com.sparta.delivery.ai.domain.repository;
 
 import com.sparta.delivery.ai.domain.entity.Llm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LlmRepository extends JpaRepository<Llm, UUID> {
 
@@ -11,5 +14,13 @@ public interface LlmRepository extends JpaRepository<Llm, UUID> {
 
     Optional<Llm> findByIsActiveTrue();
 
-    boolean existsByLlmName(String llmName);
+    @Query(
+            value = """
+                SELECT CASE WHEN COUNT(*) > 0 THEN true ELSE false END
+                FROM p_llms
+                WHERE llm_name = :llmName
+                """,
+            nativeQuery = true
+    )
+    boolean existsIncludingDeletedByLlmName(@Param("llmName") String llmName);
 }

--- a/src/main/java/com/sparta/delivery/ai/presentation/LlmCallController.java
+++ b/src/main/java/com/sparta/delivery/ai/presentation/LlmCallController.java
@@ -1,0 +1,54 @@
+package com.sparta.delivery.ai.presentation;
+
+import com.sparta.delivery.ai.application.LlmCallService;
+import com.sparta.delivery.ai.presentation.dto.response.LlmCallListResponse;
+import com.sparta.delivery.ai.presentation.dto.response.LlmCallResponse;
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@Tag(name = "LlmCall", description = "LLM 호출 로그 API")
+@RequestMapping("/api/v1/llm-calls")
+@PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+@RequiredArgsConstructor
+public class LlmCallController {
+
+    private final LlmCallService llmCallService;
+
+    @Operation(summary = "LLM 호출 로그 단건 조회")
+    @GetMapping("/{callId}")
+    public ResponseEntity<ApiResponse<LlmCallResponse>> getLlmCall(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID callId
+            ) {
+        LlmCallResponse response = llmCallService.getLlmCall(
+                UserRole.valueOf(principal.getRole()),
+                callId
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "LLM 호출 로그 목록 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<LlmCallListResponse>>> getLlmCalls(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<LlmCallListResponse> response = llmCallService.getLlmCalls(UserRole.valueOf(principal.getRole()));
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/presentation/LlmController.java
+++ b/src/main/java/com/sparta/delivery/ai/presentation/LlmController.java
@@ -1,0 +1,106 @@
+package com.sparta.delivery.ai.presentation;
+
+import com.sparta.delivery.ai.application.LlmService;
+import com.sparta.delivery.ai.presentation.dto.request.LlmCreateRequest;
+import com.sparta.delivery.ai.presentation.dto.request.LlmUpdateRequest;
+import com.sparta.delivery.ai.presentation.dto.response.LlmResponse;
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+@RestController
+@Tag(name = "Llm", description = "LLM API")
+@RequestMapping("/api/v1/llms")
+@RequiredArgsConstructor
+public class LlmController {
+
+    private final LlmService llmService;
+
+    @Operation(summary = "LLM 등록")
+    @PostMapping
+    public ResponseEntity<ApiResponse<LlmResponse>> createLlm(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody @Valid LlmCreateRequest request
+    ) {
+        LlmResponse response = llmService.create(
+                principal.getId(),
+                UserRole.valueOf(principal.getRole()),
+                request
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(response));
+    }
+
+    @Operation(summary = "LLM 단건 조회")
+    @GetMapping("/{llmId}")
+    public ResponseEntity<ApiResponse<LlmResponse>> getLlm(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID llmId
+            ) {
+        LlmResponse response = llmService.getLlm(
+                UserRole.valueOf(principal.getRole()),
+                llmId
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "LLM 목록 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<LlmResponse>>> getLlms(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        List<LlmResponse> response = llmService.getLlms(
+                UserRole.valueOf(principal.getRole())
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "LLM 이름 변경")
+    @PatchMapping("/{llmId}")
+    public ResponseEntity<ApiResponse<LlmResponse>> changeLlmName(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID llmId,
+            @RequestBody @Valid LlmUpdateRequest request
+            ) {
+        LlmResponse response = llmService.changeLlmName(
+                principal.getId(),
+                UserRole.valueOf(principal.getRole()),
+                llmId,
+                request
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "LLM 삭제")
+    @DeleteMapping("/{llmId}")
+    public ResponseEntity<ApiResponse<LlmResponse>> delete(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID llmId
+    ) {
+        LlmResponse response = llmService.delete(
+                principal.getId(),
+                UserRole.valueOf(principal.getRole()),
+                llmId
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/presentation/dto/request/LlmCreateRequest.java
+++ b/src/main/java/com/sparta/delivery/ai/presentation/dto/request/LlmCreateRequest.java
@@ -1,0 +1,16 @@
+package com.sparta.delivery.ai.presentation.dto.request;
+
+import com.sparta.delivery.ai.domain.entity.LlmProvider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record LlmCreateRequest(
+        @NotBlank
+        @Size(max = 100)
+        String llmName,
+
+        @NotNull
+        LlmProvider provider
+) {
+}

--- a/src/main/java/com/sparta/delivery/ai/presentation/dto/request/LlmUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/ai/presentation/dto/request/LlmUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.ai.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LlmUpdateRequest(
+        @NotBlank
+        @Size(max = 100)
+        String llmName
+) {
+}

--- a/src/main/java/com/sparta/delivery/ai/presentation/dto/response/LlmCallListResponse.java
+++ b/src/main/java/com/sparta/delivery/ai/presentation/dto/response/LlmCallListResponse.java
@@ -1,0 +1,24 @@
+package com.sparta.delivery.ai.presentation.dto.response;
+
+import com.sparta.delivery.ai.domain.entity.LlmCall;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LlmCallListResponse(
+        UUID callId,
+        UUID productId,
+        UUID llmId,
+        String providerStatusCode,
+        LocalDateTime createdAt
+) {
+    public static LlmCallListResponse from(LlmCall llmCall) {
+        return new LlmCallListResponse(
+                llmCall.getCallId(),
+                llmCall.getProductId(),
+                llmCall.getLlmId(),
+                llmCall.getProviderStatusCode(),
+                llmCall.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/presentation/dto/response/LlmCallResponse.java
+++ b/src/main/java/com/sparta/delivery/ai/presentation/dto/response/LlmCallResponse.java
@@ -1,0 +1,32 @@
+package com.sparta.delivery.ai.presentation.dto.response;
+
+import com.sparta.delivery.ai.domain.entity.LlmCall;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LlmCallResponse(
+        UUID callId,
+        UUID productId,
+        UUID llmId,
+        String inputSnapshot,
+        String providerStatusCode,
+        String rawResponse,
+        String generatedText,
+        LocalDateTime createdAt,
+        Long createdBy
+) {
+    public static LlmCallResponse from(LlmCall llmCall) {
+        return new LlmCallResponse(
+                llmCall.getCallId(),
+                llmCall.getProductId(),
+                llmCall.getLlmId(),
+                llmCall.getInputSnapshot(),
+                llmCall.getProviderStatusCode(),
+                llmCall.getRawResponse(),
+                llmCall.getGeneratedText(),
+                llmCall.getCreatedAt(),
+                llmCall.getCreatedBy()
+        );
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/presentation/dto/response/LlmResponse.java
+++ b/src/main/java/com/sparta/delivery/ai/presentation/dto/response/LlmResponse.java
@@ -2,7 +2,6 @@ package com.sparta.delivery.ai.presentation.dto.response;
 
 import com.sparta.delivery.ai.domain.entity.Llm;
 import com.sparta.delivery.ai.domain.entity.LlmProvider;
-import org.springframework.scheduling.quartz.ResourceLoaderClassLoadHelper;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/main/java/com/sparta/delivery/ai/presentation/dto/response/LlmResponse.java
+++ b/src/main/java/com/sparta/delivery/ai/presentation/dto/response/LlmResponse.java
@@ -1,0 +1,28 @@
+package com.sparta.delivery.ai.presentation.dto.response;
+
+import com.sparta.delivery.ai.domain.entity.Llm;
+import com.sparta.delivery.ai.domain.entity.LlmProvider;
+import org.springframework.scheduling.quartz.ResourceLoaderClassLoadHelper;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LlmResponse(
+        UUID llmId,
+        String llmName,
+        LlmProvider provider,
+        boolean isActive,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static LlmResponse from(Llm llm) {
+        return new LlmResponse(
+                llm.getLlmId(),
+                llm.getLlmName(),
+                llm.getProvider(),
+                llm.isActive(),
+                llm.getCreatedAt(),
+                llm.getUpdatedAt()
+        );
+    }
+}

--- a/src/test/java/com/sparta/delivery/ai/application/LlmCallServiceTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/LlmCallServiceTest.java
@@ -1,0 +1,128 @@
+package com.sparta.delivery.ai.application;
+
+import com.sparta.delivery.ai.domain.entity.LlmCall;
+import com.sparta.delivery.ai.domain.exception.AiForbiddenException;
+import com.sparta.delivery.ai.domain.exception.LlmCallNotFoundException;
+import com.sparta.delivery.ai.domain.repository.LlmCallRepository;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class LlmCallServiceTest {
+
+    @Mock
+    private LlmCallRepository llmCallRepository;
+
+    @InjectMocks
+    private LlmCallService llmCallService;
+
+    @Nested
+    @DisplayName("LLM 호출 로그 단건 조회")
+    class ReadOne {
+
+        @Test
+        @DisplayName("단건 조회에 성공한다")
+        void getLlmCall_success() {
+            // given
+            UUID callId = UUID.randomUUID();
+            LlmCall llmCall = createLlmCall(callId);
+            given(llmCallRepository.findByCallId(callId)).willReturn(Optional.of(llmCall));
+
+            // when
+            var response = llmCallService.getLlmCall(UserRole.MANAGER, callId);
+
+            // then
+            assertThat(response.callId()).isEqualTo(callId);
+            assertThat(response.inputSnapshot()).isEqualTo("{\"productName\":\"Americano\"}");
+            assertThat(response.providerStatusCode()).isEqualTo("200");
+        }
+
+        @Test
+        @DisplayName("존재하지 않으면 예외가 발생한다")
+        void getLlmCall_fail_notFound() {
+            // given
+            UUID callId = UUID.randomUUID();
+            given(llmCallRepository.findByCallId(callId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> llmCallService.getLlmCall(UserRole.MANAGER, callId))
+                    .isInstanceOf(LlmCallNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("권한이 없으면 조회할 수 없다")
+        void getLlmCall_fail_forbidden() {
+            // when & then
+            assertThatThrownBy(() -> llmCallService.getLlmCall(UserRole.CUSTOMER, UUID.randomUUID()))
+                    .isInstanceOf(AiForbiddenException.class);
+            then(llmCallRepository).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("LLM 호출 로그 목록 조회")
+    class ReadMany {
+
+        @Test
+        @DisplayName("생성일 내림차순 정렬로 목록 조회에 성공한다")
+        void getLlmCalls_success() {
+            // given
+            LlmCall recent = createLlmCall(UUID.randomUUID());
+            LlmCall old = createLlmCall(UUID.randomUUID());
+            given(llmCallRepository.findAll(eq(Sort.by(
+                    Sort.Order.desc("createdAt")
+            )))).willReturn(List.of(recent, old));
+
+            // when
+            var responses = llmCallService.getLlmCalls(UserRole.MANAGER);
+
+            // then
+            assertThat(responses).hasSize(2);
+            assertThat(responses.get(0).callId()).isEqualTo(recent.getCallId());
+            assertThat(responses.get(1).callId()).isEqualTo(old.getCallId());
+        }
+
+        @Test
+        @DisplayName("권한이 없으면 목록 조회할 수 없다")
+        void getLlmCalls_fail_forbidden() {
+            // when & then
+            assertThatThrownBy(() -> llmCallService.getLlmCalls(UserRole.CUSTOMER))
+                    .isInstanceOf(AiForbiddenException.class);
+            then(llmCallRepository).shouldHaveNoInteractions();
+        }
+    }
+
+    private LlmCall createLlmCall(UUID callId) {
+        LlmCall llmCall = LlmCall.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "{\"productName\":\"Americano\"}",
+                "200",
+                "{\"result\":\"ok\"}",
+                "generated description",
+                1L
+        );
+        ReflectionTestUtils.setField(llmCall, "callId", callId);
+        ReflectionTestUtils.setField(llmCall, "createdAt", LocalDateTime.now());
+        return llmCall;
+    }
+}

--- a/src/test/java/com/sparta/delivery/ai/application/LlmServiceTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/LlmServiceTest.java
@@ -1,0 +1,233 @@
+package com.sparta.delivery.ai.application;
+
+import com.sparta.delivery.ai.domain.entity.Llm;
+import com.sparta.delivery.ai.domain.entity.LlmProvider;
+import com.sparta.delivery.ai.domain.exception.AiForbiddenException;
+import com.sparta.delivery.ai.domain.exception.CannotDeleteActiveLlmException;
+import com.sparta.delivery.ai.domain.exception.DuplicateLlmNameException;
+import com.sparta.delivery.ai.domain.exception.LlmNotFoundException;
+import com.sparta.delivery.ai.domain.repository.LlmRepository;
+import com.sparta.delivery.ai.presentation.dto.request.LlmCreateRequest;
+import com.sparta.delivery.ai.presentation.dto.request.LlmUpdateRequest;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class LlmServiceTest {
+
+    @Mock
+    private LlmRepository llmRepository;
+
+    @InjectMocks
+    private LlmService llmService;
+
+    @Nested
+    @DisplayName("LLM 생성")
+    class Create {
+
+        @Test
+        @DisplayName("MANAGER는 LLM을 생성할 수 있다")
+        void create_success() {
+            // given
+            Long actorId = 1L;
+            LlmCreateRequest request = new LlmCreateRequest("gpt-4.1-mini", LlmProvider.OPENAI);
+            given(llmRepository.existsIncludingDeletedByLlmName("gpt-4.1-mini")).willReturn(false);
+            given(llmRepository.save(any(Llm.class))).willAnswer(invocation -> {
+                Llm llm = invocation.getArgument(0);
+                ReflectionTestUtils.setField(llm, "llmId", UUID.randomUUID());
+                ReflectionTestUtils.setField(llm, "createdAt", LocalDateTime.now());
+                ReflectionTestUtils.setField(llm, "updatedAt", LocalDateTime.now());
+                return llm;
+            });
+
+            // when
+            var response = llmService.create(actorId, UserRole.MANAGER, request);
+
+            // then
+            assertThat(response.llmName()).isEqualTo("gpt-4.1-mini");
+            assertThat(response.provider()).isEqualTo(LlmProvider.OPENAI);
+            assertThat(response.isActive()).isFalse();
+            then(llmRepository).should().save(any(Llm.class));
+        }
+
+        @Test
+        @DisplayName("중복된 LLM 이름이면 생성할 수 없다")
+        void create_fail_duplicateName() {
+            // given
+            LlmCreateRequest request = new LlmCreateRequest("gpt-4.1-mini", LlmProvider.OPENAI);
+            given(llmRepository.existsIncludingDeletedByLlmName("gpt-4.1-mini")).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> llmService.create(1L, UserRole.MANAGER, request))
+                    .isInstanceOf(DuplicateLlmNameException.class);
+            then(llmRepository).should(never()).save(any(Llm.class));
+        }
+
+        @Test
+        @DisplayName("권한이 없으면 생성할 수 없다")
+        void create_fail_forbidden() {
+            // given
+            LlmCreateRequest request = new LlmCreateRequest("gpt-4.1-mini", LlmProvider.OPENAI);
+
+            // when & then
+            assertThatThrownBy(() -> llmService.create(1L, UserRole.CUSTOMER, request))
+                    .isInstanceOf(AiForbiddenException.class);
+            then(llmRepository).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("LLM 조회")
+    class Read {
+
+        @Test
+        @DisplayName("단건 조회에 성공한다")
+        void getLlm_success() {
+            // given
+            UUID llmId = UUID.randomUUID();
+            Llm llm = createLlm(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, true);
+            given(llmRepository.findByLlmId(llmId)).willReturn(Optional.of(llm));
+
+            // when
+            var response = llmService.getLlm(UserRole.MANAGER, llmId);
+
+            // then
+            assertThat(response.llmId()).isEqualTo(llmId);
+            assertThat(response.llmName()).isEqualTo("gpt-4.1-mini");
+            assertThat(response.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않으면 예외가 발생한다")
+        void getLlm_fail_notFound() {
+            // given
+            UUID llmId = UUID.randomUUID();
+            given(llmRepository.findByLlmId(llmId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> llmService.getLlm(UserRole.MANAGER, llmId))
+                    .isInstanceOf(LlmNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("목록 조회는 활성순, 수정일순 정렬로 조회한다")
+        void getLlms_success() {
+            // given
+            Llm active = createLlm(UUID.randomUUID(), "gpt-4.1", LlmProvider.OPENAI, true);
+            Llm inactive = createLlm(UUID.randomUUID(), "gpt-4.1-mini", LlmProvider.OPENAI, false);
+            given(llmRepository.findAll(eq(Sort.by(
+                    Sort.Order.desc("isActive"),
+                    Sort.Order.desc("updatedAt")
+            )))).willReturn(List.of(active, inactive));
+
+            // when
+            var responses = llmService.getLlms(UserRole.MANAGER);
+
+            // then
+            assertThat(responses).hasSize(2);
+            assertThat(responses.get(0).isActive()).isTrue();
+            assertThat(responses.get(1).isActive()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("LLM 이름 변경")
+    class Update {
+
+        @Test
+        @DisplayName("이름을 변경할 수 있다")
+        void changeLlmName_success() {
+            // given
+            UUID llmId = UUID.randomUUID();
+            Llm llm = createLlm(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, false);
+            given(llmRepository.findByLlmId(llmId)).willReturn(Optional.of(llm));
+            given(llmRepository.existsIncludingDeletedByLlmName("gpt-4.1")).willReturn(false);
+
+            // when
+            var response = llmService.changeLlmName(1L, UserRole.MANAGER, llmId, new LlmUpdateRequest("gpt-4.1"));
+
+            // then
+            assertThat(response.llmName()).isEqualTo("gpt-4.1");
+        }
+
+        @Test
+        @DisplayName("변경한 이름이 중복되면 예외가 발생한다")
+        void changeLlmName_fail_duplicateName() {
+            // given
+            UUID llmId = UUID.randomUUID();
+            Llm llm = createLlm(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, false);
+            given(llmRepository.findByLlmId(llmId)).willReturn(Optional.of(llm));
+            given(llmRepository.existsIncludingDeletedByLlmName("gpt-4.1")).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> llmService.changeLlmName(1L, UserRole.MANAGER, llmId, new LlmUpdateRequest("gpt-4.1")))
+                    .isInstanceOf(DuplicateLlmNameException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("LLM 삭제")
+    class Delete {
+
+        @Test
+        @DisplayName("비활성 LLM은 soft delete할 수 있다")
+        void delete_success() {
+            // given
+            UUID llmId = UUID.randomUUID();
+            Long actorId = 1L;
+            Llm llm = createLlm(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, false);
+            given(llmRepository.findByLlmId(llmId)).willReturn(Optional.of(llm));
+
+            // when
+            var response = llmService.delete(actorId, UserRole.MANAGER, llmId);
+
+            // then
+            assertThat(response.llmId()).isEqualTo(llmId);
+            assertThat(llm.isDeleted()).isTrue();
+            assertThat(llm.getDeletedBy()).isEqualTo(actorId);
+        }
+
+        @Test
+        @DisplayName("활성 LLM은 삭제할 수 없다")
+        void delete_fail_activeLlm() {
+            // given
+            UUID llmId = UUID.randomUUID();
+            Llm llm = createLlm(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, true);
+            given(llmRepository.findByLlmId(llmId)).willReturn(Optional.of(llm));
+
+            // when & then
+            assertThatThrownBy(() -> llmService.delete(1L, UserRole.MANAGER, llmId))
+                    .isInstanceOf(CannotDeleteActiveLlmException.class);
+            assertThat(llm.isDeleted()).isFalse();
+        }
+    }
+
+    private Llm createLlm(UUID llmId, String llmName, LlmProvider provider, boolean isActive) {
+        Llm llm = Llm.create(llmName, provider, isActive);
+        ReflectionTestUtils.setField(llm, "llmId", llmId);
+        ReflectionTestUtils.setField(llm, "createdAt", LocalDateTime.now().minusDays(1));
+        ReflectionTestUtils.setField(llm, "updatedAt", LocalDateTime.now());
+        return llm;
+    }
+}

--- a/src/test/java/com/sparta/delivery/ai/domain/entity/LlmCallTest.java
+++ b/src/test/java/com/sparta/delivery/ai/domain/entity/LlmCallTest.java
@@ -1,5 +1,9 @@
 package com.sparta.delivery.ai.domain.entity;
 
+import com.sparta.delivery.ai.domain.exception.AiErrorCode;
+import com.sparta.delivery.ai.domain.exception.InvalidCreatedByException;
+import com.sparta.delivery.ai.domain.exception.InvalidInputSnapshotException;
+import com.sparta.delivery.ai.domain.exception.InvalidProviderStatusCodeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -7,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 class LlmCallTest {
 
@@ -47,5 +52,65 @@ class LlmCallTest {
         assertThat(llmCall.getCreatedBy()).isEqualTo(createdBy);
         assertThat(llmCall.getCreatedAt()).isNotNull();
         assertThat(llmCall.getCreatedAt()).isBetween(before, after);
+    }
+
+    @Test
+    @DisplayName("create should throw when inputSnapshot is blank")
+    void create_shouldThrow_whenInputSnapshotIsBlank() {
+        // when
+        Throwable thrown = catchThrowable(() -> LlmCall.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "   ",
+                "200",
+                "{}",
+                "generated",
+                1L
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidInputSnapshotException.class);
+        InvalidInputSnapshotException exception = (InvalidInputSnapshotException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_INPUT_SNAPSHOT.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when providerStatusCode length exceeds 50")
+    void create_shouldThrow_whenProviderStatusCodeLengthExceeds50() {
+        // when
+        Throwable thrown = catchThrowable(() -> LlmCall.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "{\"productName\":\"Americano\"}",
+                "1".repeat(51),
+                "{}",
+                "generated",
+                1L
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidProviderStatusCodeException.class);
+        InvalidProviderStatusCodeException exception = (InvalidProviderStatusCodeException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_PROVIDER_STATUS_CODE.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when createdBy is null")
+    void create_shouldThrow_whenCreatedByIsNull() {
+        // when
+        Throwable thrown = catchThrowable(() -> LlmCall.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "{\"productName\":\"Americano\"}",
+                "200",
+                "{}",
+                "generated",
+                null
+        ));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidCreatedByException.class);
+        InvalidCreatedByException exception = (InvalidCreatedByException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_CREATED_BY.getCode());
     }
 }

--- a/src/test/java/com/sparta/delivery/ai/domain/entity/LlmTest.java
+++ b/src/test/java/com/sparta/delivery/ai/domain/entity/LlmTest.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.ai.domain.entity;
 
 import com.sparta.delivery.ai.domain.exception.AiErrorCode;
 import com.sparta.delivery.ai.domain.exception.InvalidLlmNameException;
+import com.sparta.delivery.ai.domain.exception.InvalidLlmProviderException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +43,30 @@ class LlmTest {
         assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
         InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
         assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when llmName is blank")
+    void create_shouldThrow_whenLlmNameIsBlank() {
+        // when
+        Throwable thrown = catchThrowable(() -> Llm.create("   ", LlmProvider.OPENAI, false));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidLlmNameException.class);
+        InvalidLlmNameException exception = (InvalidLlmNameException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_NAME.getCode());
+    }
+
+    @Test
+    @DisplayName("create should throw when provider is null")
+    void create_shouldThrow_whenProviderIsNull() {
+        // when
+        Throwable thrown = catchThrowable(() -> Llm.create("gpt-4.1-mini", null, false));
+
+        // then
+        assertThat(thrown).isInstanceOf(InvalidLlmProviderException.class);
+        InvalidLlmProviderException exception = (InvalidLlmProviderException) thrown;
+        assertThat(exception.getCode()).isEqualTo(AiErrorCode.INVALID_LLM_PROVIDER.getCode());
     }
 
     @Test

--- a/src/test/java/com/sparta/delivery/ai/presentation/LlmCallControllerTest.java
+++ b/src/test/java/com/sparta/delivery/ai/presentation/LlmCallControllerTest.java
@@ -1,0 +1,134 @@
+package com.sparta.delivery.ai.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sparta.delivery.ai.application.LlmCallService;
+import com.sparta.delivery.ai.presentation.dto.response.LlmCallListResponse;
+import com.sparta.delivery.ai.presentation.dto.response.LlmCallResponse;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtProvider;
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.user.application.UserService;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LlmCallController.class)
+class LlmCallControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LlmCallService llmCallService;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Nested
+    @DisplayName("LLM 호출 로그 API")
+    class LlmCallApi {
+
+        @Test
+        @DisplayName("MANAGER 권한이면 호출 로그 단건을 조회한다")
+        void getLlmCall_success() throws Exception {
+            UUID callId = UUID.randomUUID();
+            LlmCallResponse response = new LlmCallResponse(
+                    callId,
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    "{\"productName\":\"Americano\"}",
+                    "200",
+                    "{\"result\":\"ok\"}",
+                    "generated description",
+                    LocalDateTime.now(),
+                    1L
+            );
+
+            given(llmCallService.getLlmCall(UserRole.MANAGER, callId)).willReturn(response);
+
+            mockMvc.perform(get("/api/v1/llm-calls/{callId}", callId)
+                            .with(authentication(authenticationToken(UserRole.MANAGER))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.callId").value(callId.toString()))
+                    .andExpect(jsonPath("$.data.providerStatusCode").value("200"));
+
+            then(llmCallService).should().getLlmCall(UserRole.MANAGER, callId);
+        }
+
+        @Test
+        @DisplayName("MANAGER 권한이면 호출 로그 목록을 조회한다")
+        void getLlmCalls_success() throws Exception {
+            LlmCallListResponse response = new LlmCallListResponse(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    "200",
+                    LocalDateTime.now()
+            );
+
+            given(llmCallService.getLlmCalls(UserRole.MANAGER)).willReturn(List.of(response));
+
+            mockMvc.perform(get("/api/v1/llm-calls")
+                            .with(authentication(authenticationToken(UserRole.MANAGER))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data[0].providerStatusCode").value("200"));
+
+            then(llmCallService).should().getLlmCalls(UserRole.MANAGER);
+        }
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken(UserRole role) {
+        TestUserPrincipal principal = new TestUserPrincipal(1L, "user@test.com", role.name());
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+        );
+    }
+
+    private record TestUserPrincipal(
+            Long id,
+            String username,
+            String role
+    ) implements UserPrincipal {
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public String getUsername() {
+            return username;
+        }
+
+        @Override
+        public String getRole() {
+            return role;
+        }
+    }
+}

--- a/src/test/java/com/sparta/delivery/ai/presentation/LlmControllerTest.java
+++ b/src/test/java/com/sparta/delivery/ai/presentation/LlmControllerTest.java
@@ -1,0 +1,220 @@
+package com.sparta.delivery.ai.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.delivery.ai.application.LlmService;
+import com.sparta.delivery.ai.domain.entity.LlmProvider;
+import com.sparta.delivery.ai.presentation.dto.request.LlmCreateRequest;
+import com.sparta.delivery.ai.presentation.dto.request.LlmUpdateRequest;
+import com.sparta.delivery.ai.presentation.dto.response.LlmResponse;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.delivery.auth.infrastructure.jwt.JwtProvider;
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.user.application.UserService;
+import com.sparta.delivery.user.domain.entity.UserRole;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LlmController.class)
+class LlmControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private LlmService llmService;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Nested
+    @DisplayName("LLM 관리 API")
+    class LlmApi {
+
+        @Test
+        @DisplayName("MANAGER 권한이면 LLM을 생성한다")
+        void createLlm_success() throws Exception {
+            UUID llmId = UUID.randomUUID();
+            LlmCreateRequest request = new LlmCreateRequest("gpt-4.1-mini", LlmProvider.OPENAI);
+            LlmResponse response = llmResponse(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, false);
+
+            given(llmService.create(eq(1L), eq(UserRole.MANAGER), eq(request)))
+                    .willReturn(response);
+
+            mockMvc.perform(post("/api/v1/llms")
+                            .with(csrf())
+                            .with(authentication(authenticationToken(UserRole.MANAGER)))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.llmId").value(llmId.toString()))
+                    .andExpect(jsonPath("$.data.llmName").value("gpt-4.1-mini"));
+
+            then(llmService).should().create(eq(1L), eq(UserRole.MANAGER), any(LlmCreateRequest.class));
+        }
+
+        @Test
+        @DisplayName("llmName이 비어 있으면 400을 반환한다")
+        void createLlm_fail_whenLlmNameBlank() throws Exception {
+            LlmCreateRequest request = new LlmCreateRequest("", LlmProvider.OPENAI);
+
+            mockMvc.perform(post("/api/v1/llms")
+                            .with(csrf())
+                            .with(authentication(authenticationToken(UserRole.MANAGER)))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+
+            then(llmService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("MANAGER 권한이면 LLM 단건을 조회한다")
+        void getLlm_success() throws Exception {
+            UUID llmId = UUID.randomUUID();
+            LlmResponse response = llmResponse(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, false);
+
+            given(llmService.getLlm(UserRole.MANAGER, llmId)).willReturn(response);
+
+            mockMvc.perform(get("/api/v1/llms/{llmId}", llmId)
+                            .with(authentication(authenticationToken(UserRole.MANAGER))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.llmId").value(llmId.toString()))
+                    .andExpect(jsonPath("$.data.llmName").value("gpt-4.1-mini"));
+
+            then(llmService).should().getLlm(UserRole.MANAGER, llmId);
+        }
+
+        @Test
+        @DisplayName("MANAGER 권한이면 LLM 목록을 조회한다")
+        void getLlms_success() throws Exception {
+            LlmResponse response = llmResponse(UUID.randomUUID(), "gpt-4.1-mini", LlmProvider.OPENAI, false);
+
+            given(llmService.getLlms(UserRole.MANAGER)).willReturn(List.of(response));
+
+            mockMvc.perform(get("/api/v1/llms")
+                            .with(authentication(authenticationToken(UserRole.MANAGER))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data[0].llmName").value("gpt-4.1-mini"));
+
+            then(llmService).should().getLlms(UserRole.MANAGER);
+        }
+
+        @Test
+        @DisplayName("MANAGER 권한이면 LLM 이름을 변경한다")
+        void changeLlmName_success() throws Exception {
+            UUID llmId = UUID.randomUUID();
+            LlmUpdateRequest request = new LlmUpdateRequest("gpt-4.1");
+            LlmResponse response = llmResponse(llmId, "gpt-4.1", LlmProvider.OPENAI, false);
+
+            given(llmService.changeLlmName(eq(1L), eq(UserRole.MANAGER), eq(llmId), eq(request)))
+                    .willReturn(response);
+
+            mockMvc.perform(patch("/api/v1/llms/{llmId}", llmId)
+                            .with(csrf())
+                            .with(authentication(authenticationToken(UserRole.MANAGER)))
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.llmName").value("gpt-4.1"));
+
+            then(llmService).should().changeLlmName(eq(1L), eq(UserRole.MANAGER), eq(llmId), any(LlmUpdateRequest.class));
+        }
+
+        @Test
+        @DisplayName("MANAGER 권한이면 LLM을 삭제한다")
+        void deleteLlm_success() throws Exception {
+            UUID llmId = UUID.randomUUID();
+            LlmResponse response = llmResponse(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, false);
+
+            given(llmService.delete(1L, UserRole.MANAGER, llmId)).willReturn(response);
+
+            mockMvc.perform(delete("/api/v1/llms/{llmId}", llmId)
+                            .with(csrf())
+                            .with(authentication(authenticationToken(UserRole.MANAGER))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.llmId").value(llmId.toString()));
+
+            then(llmService).should().delete(1L, UserRole.MANAGER, llmId);
+        }
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken(UserRole role) {
+        TestUserPrincipal principal = new TestUserPrincipal(1L, "user@test.com", role.name());
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+        );
+    }
+
+    private LlmResponse llmResponse(UUID llmId, String llmName, LlmProvider provider, boolean isActive) {
+        return new LlmResponse(
+                llmId,
+                llmName,
+                provider,
+                isActive,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    private record TestUserPrincipal(
+            Long id,
+            String username,
+            String role
+    ) implements UserPrincipal {
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public String getUsername() {
+            return username;
+        }
+
+        @Override
+        public String getRole() {
+            return role;
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Relates to #29

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | AI LLM 관리 API 및 LLM 호출 로그 조회 API 1차 구현 |
| 🔍 목적 | AI 도메인의 1차 범위로 LLM 설정 관리 기능과 LLM 호출 로그 조회 기능을 먼저 분리 구현하기 위함 |
| 🛠️ 변경사항 | `Llm` CRUD API와 `LlmCall` 조회 API를 추가하고, 관련 엔티티/DTO/서비스/컨트롤러/예외/테스트를 정리 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `Llm` 엔티티/리포지토리/서비스/컨트롤러 구현 |
| 2️⃣ | LLM 생성, 단건 조회, 목록 조회, 이름 변경, soft delete API 추가 |
| 3️⃣ | 활성 LLM 삭제 금지 정책 반영 |
| 4️⃣ | `LlmCall` 조회 전용 서비스/컨트롤러 구현 |
| 5️⃣ | LLM 호출 로그 목록/상세 응답 DTO 분리 (`LlmCallListResponse`, `LlmCallResponse`) |
| 6️⃣ | `LlmCall`은 외부 생성 API 없이 조회만 제공하도록 범위 제한 |
| 7️⃣ | AI 공용 권한 예외(`AiForbiddenException`) 및 LLM/LLMCall 전용 예외 코드 정리 |
| 8️⃣ | `Llm`, `LlmCall` 엔티티 생성 경로를 `create() + private builder`로 제한 |
| 9️⃣ | `Llm`/`LlmCall` 엔티티 검증 로직 보강 (`llmName`, `provider`, `inputSnapshot`, `providerStatusCode`, `createdBy`) |
| 🔟 | 엔티티/서비스/컨트롤러 테스트 추가 및 AI 테스트 전체 통과 확인 |

---

## ✅ 테스트 체크리스트
- [x] LLM 생성 성공 케이스 확인
- [x] LLM 단건 조회 / 목록 조회 정상 동작 확인
- [x] LLM 이름 변경 정상 동작 확인
- [x] 비활성 LLM soft delete 정상 동작 확인
- [x] 활성 LLM 삭제 시 `400 Bad Request` 및 `AI-203` 확인
- [x] LLM 호출 로그 목록 조회 정상 동작 확인
- [x] LLM 호출 로그 단건 조회 정상 동작 확인
- [x] `./gradlew test --tests "com.sparta.delivery.ai.*"` 통과
- [x] Postman으로 LLM/LLMCall 주요 요청/응답 정상 동작 확인

---

## 📸 포스트맨 캡처 사진

### LLM 목록 조회
<img width="894" height="683" alt="LLM목록조회" src="https://github.com/user-attachments/assets/3e4c91e3-51ce-44d7-8ec6-bdf04a15c68f" />

### LLM 생성
<img width="895" height="511" alt="LLM생성" src="https://github.com/user-attachments/assets/4d578e62-3a9a-45f2-9f26-c44447f8b08c" />

### LLM 이름 변경
<img width="899" height="483" alt="LLM이름변경" src="https://github.com/user-attachments/assets/27cf48ab-cfb7-4bb0-9dad-a17253180ae3" />

### 활성 LLM 삭제 실패
<img width="896" height="375" alt="비활성모델만지우세여" src="https://github.com/user-attachments/assets/dbba445e-01f9-4bdd-9da7-01dd997ddd39" />

### LLM 호출 로그 목록 조회
<img width="902" height="641" alt="LLM호출로그목록조회" src="https://github.com/user-attachments/assets/a26ef9a8-cf7b-49a9-bc26-8f0af280a143" />

### LLM 호출 로그 단건 조회
<img width="904" height="573" alt="LLM호출로그단건조회" src="https://github.com/user-attachments/assets/3960b612-6df8-4ce4-9d95-2daf54078d1a" />


---

## 🙋‍♀️ 리뷰어 참고사항

### 메인 리뷰 지점
changed files 중 상당수는 예외 클래스 / 에러 코드 / 테스트 파일들로, **메인으로 봐주시면 좋은 파일은 아래와 같습니다...!**
  - `src/main/java/com/sparta/delivery/ai/application/LlmService.java`
  - `src/main/java/com/sparta/delivery/ai/application/LlmCallService.java`
  - `src/main/java/com/sparta/delivery/ai/presentation/LlmController.java`
  - `src/main/java/com/sparta/delivery/ai/presentation/LlmCallController.java`
  - `src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java`
  - `src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java`
  - `src/main/java/com/sparta/delivery/ai/presentation/dto/request/LlmCreateRequest.java`
  - `src/main/java/com/sparta/delivery/ai/presentation/dto/request/LlmUpdateRequest.java`

### 기타 참고사항
- 본 PR은 **LLM 관리 API + LLM 호출 로그 조회 API** 구현에 집중
- 외부 LLM 연동, 오케스트레이터, Product 생성 흐름과의 AI 연결은 이번 PR 범위에 포함하지 않음
- `LlmCall`은 **조회 전용**이며, 생성은 추후 오케스트레이터 내부 책임으로 설계 예정
- 예외/에러코드는 AI 도메인 번호 체계를 맞추기 위해 함께 정리함
  - AI-0xx: 도메인 예외
  - AI-1xx: AI 서비스 공통 예외
  - AI-2xx: LLM 서비스 전용 예외
  - AI-3xx: LLM 호출 로그 서비스 전용 예외

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * LLM 관리 REST API 추가 (생성, 조회, 이름 변경, 삭제)
  * LLM 호출 로그 조회 REST API 추가
  * MANAGER/MASTER 역할 기반 접근 제어 적용

* **Bug Fixes**
  * 중복 LLM 이름 검증 강화
  * 활성 LLM 삭제 방지 기능 추가
  * 입력값 유효성 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->