### PR TITLE
feat: 주문 상태 변경 API 

### DIFF
--- a/src/main/java/com/sparta/delivery/order/application/OrderService.java
+++ b/src/main/java/com/sparta/delivery/order/application/OrderService.java
@@ -6,6 +6,7 @@ import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.order.domain.entity.Order;
 import com.sparta.delivery.order.domain.entity.OrderItem;
 import com.sparta.delivery.order.domain.entity.OrderStatus;
+import com.sparta.delivery.order.domain.exception.InvalidOrderStatusException;
 import com.sparta.delivery.order.domain.exception.MinOrderAmountNotMetException;
 import com.sparta.delivery.order.domain.exception.OrderForbiddenException;
 import com.sparta.delivery.order.domain.exception.OrderNotFoundException;
@@ -15,13 +16,14 @@ import com.sparta.delivery.order.domain.exception.StoreNotFoundException;
 import com.sparta.delivery.order.domain.exception.StoreNotOrderableException;
 import com.sparta.delivery.order.domain.repository.OrderRepository;
 import com.sparta.delivery.order.presentation.dto.OrderCreateRequest;
-import com.sparta.delivery.order.presentation.dto.OrderItemCreateRequest;
 import com.sparta.delivery.order.presentation.dto.OrderDetailResponse;
+import com.sparta.delivery.order.presentation.dto.OrderItemCreateRequest;
 import com.sparta.delivery.order.presentation.dto.OrderListResponse;
 import com.sparta.delivery.product.domain.entity.Product;
 import com.sparta.delivery.product.domain.repository.ProductRepository;
 import com.sparta.delivery.store.domain.entity.Store;
 import com.sparta.delivery.store.domain.repository.StoreRepository;
+import com.sparta.delivery.user.domain.entity.UserRole;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -57,26 +59,48 @@ public class OrderService {
         return OrderDetailResponse.from(savedOrder);
     }
 
-    public PageResponse<OrderListResponse> getMyOrders(
-            Long userId,
+    public PageResponse<OrderListResponse> getOrders(
+            Long actorId,
+            UserRole actorRole,
             UUID storeId,
             OrderStatus status,
             Pageable pageable
     ) {
-        Page<OrderListResponse> page = findMyOrders(userId, storeId, status, pageable)
+        Page<OrderListResponse> page = findOrders(actorId, actorRole, storeId, status, pageable)
                 .map(OrderListResponse::from);
         return PageResponse.from(page);
     }
 
-    public OrderDetailResponse getMyOrder(Long userId, UUID orderId) {
-        return OrderDetailResponse.from(getOwnedOrder(userId, orderId));
+    public OrderDetailResponse getOrder(Long actorId, UserRole actorRole, UUID orderId) {
+        return OrderDetailResponse.from(getAccessibleOrder(actorId, actorRole, orderId));
     }
 
     @Transactional
-    public void cancel(Long userId, UUID orderId) {
-        Order order = getOwnedOrder(userId, orderId);
+    public void cancel(Long actorId, UserRole actorRole, UUID orderId) {
+        Order order = getCancelableOrder(actorId, actorRole, orderId);
         order.cancel();
-        log.info("주문 취소 완료 - userId={}, orderId={}", userId, orderId);
+        log.info("주문 취소 완료 - actorId={}, orderId={}", actorId, orderId);
+    }
+
+    @Transactional
+    public OrderDetailResponse updateStatus(
+            Long actorId,
+            UserRole actorRole,
+            UUID orderId,
+            OrderStatus targetStatus
+    ) {
+        Order order = getManageableOrder(actorId, actorRole, orderId);
+        changeOrderStatus(order, targetStatus);
+        log.info("주문 상태 변경 완료 - actorId={}, orderId={}, status={}",
+                actorId, orderId, order.getStatus());
+        return OrderDetailResponse.from(order);
+    }
+
+    @Transactional
+    public void delete(Long actorId, UserRole actorRole, UUID orderId) {
+        Order order = getDeletableOrder(actorRole, orderId);
+        order.softDelete(actorId);
+        log.info("주문 삭제 완료 - actorId={}, orderId={}", actorId, orderId);
     }
 
     private Order createOrder(Long userId, OrderCreateRequest request, Address address, Store store) {
@@ -93,28 +117,86 @@ public class OrderService {
         return order;
     }
 
-    private Page<Order> findMyOrders(
-            Long userId,
+    private Page<Order> findOrders(
+            Long actorId,
+            UserRole actorRole,
             UUID storeId,
             OrderStatus status,
             Pageable pageable
     ) {
         Pageable normalizedPageable = normalizePageable(pageable);
+        // 조회 가능 범위는 역할별로 다르므로 CUSTOMER / OWNER / ADMIN 계열로 분기한다.
+        return switch (actorRole) {
+            case CUSTOMER -> findCustomerOrders(actorId, storeId, status, normalizedPageable);
+            case OWNER -> findOwnerOrders(actorId, storeId, status, normalizedPageable);
+            case MANAGER, MASTER -> findAdminOrders(storeId, status, normalizedPageable);
+        };
+    }
+
+    private Page<Order> findCustomerOrders(
+            Long userId,
+            UUID storeId,
+            OrderStatus status,
+            Pageable pageable
+    ) {
         if (storeId != null && status != null) {
             return orderRepository.findAllByUserIdAndStoreIdAndStatus(
                     userId,
                     storeId,
                     status,
-                    normalizedPageable
+                    pageable
             );
         }
         if (storeId != null) {
-            return orderRepository.findAllByUserIdAndStoreId(userId, storeId, normalizedPageable);
+            return orderRepository.findAllByUserIdAndStoreId(userId, storeId, pageable);
         }
         if (status != null) {
-            return orderRepository.findAllByUserIdAndStatus(userId, status, normalizedPageable);
+            return orderRepository.findAllByUserIdAndStatus(userId, status, pageable);
         }
-        return orderRepository.findAllByUserId(userId, normalizedPageable);
+        return orderRepository.findAllByUserId(userId, pageable);
+    }
+
+    private Page<Order> findOwnerOrders(
+            Long actorId,
+            UUID storeId,
+            OrderStatus status,
+            Pageable pageable
+    ) {
+        if (storeId != null) {
+            if (!isOwnedStore(actorId, storeId)) {
+                throw new OrderForbiddenException();
+            }
+            return findAdminOrders(storeId, status, pageable);
+        }
+
+        List<UUID> ownedStoreIds = findOwnedStoreIds(actorId);
+
+        if (ownedStoreIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        if (status != null) {
+            return orderRepository.findAllByStoreIdInAndStatus(ownedStoreIds, status, pageable);
+        }
+        return orderRepository.findAllByStoreIdIn(ownedStoreIds, pageable);
+    }
+
+    private List<UUID> findOwnedStoreIds(Long actorId) {
+        return storeRepository.findByUserIdAndDeletedAtIsNull(actorId).stream()
+                .map(Store::getStoreId)
+                .toList();
+    }
+
+    private Page<Order> findAdminOrders(UUID storeId, OrderStatus status, Pageable pageable) {
+        if (storeId != null && status != null) {
+            return orderRepository.findAllByStoreIdAndStatus(storeId, status, pageable);
+        }
+        if (storeId != null) {
+            return orderRepository.findAllByStoreId(storeId, pageable);
+        }
+        if (status != null) {
+            return orderRepository.findAllByStatus(status, pageable);
+        }
+        return orderRepository.findAll(pageable);
     }
 
     private Pageable normalizePageable(Pageable pageable) {
@@ -184,12 +266,81 @@ public class OrderService {
         }
     }
 
+    private void changeOrderStatus(Order order, OrderStatus targetStatus) {
+        switch (targetStatus) {
+            case ACCEPTED -> order.accept();
+            case COOKING -> order.startCooking();
+            case DELIVERING -> order.startDelivery();
+            case DELIVERED -> order.markDelivered();
+            case COMPLETED -> order.complete();
+            case REJECTED -> order.reject();
+            default -> throw new InvalidOrderStatusException();
+        }
+    }
+
+    private Order getAccessibleOrder(Long actorId, UserRole actorRole, UUID orderId) {
+        return switch (actorRole) {
+            case CUSTOMER -> getOwnedOrder(actorId, orderId);
+            case OWNER -> getOwnerOrder(actorId, orderId);
+            case MANAGER, MASTER -> getOrderOrThrow(orderId);
+        };
+    }
+
+    private Order getOwnerOrder(Long actorId, UUID orderId) {
+        Order order = getOrderOrThrow(orderId);
+        if (!isOwnedStore(actorId, order.getStoreId())) {
+            throw new OrderForbiddenException();
+        }
+        return order;
+    }
+
+    private Order getCancelableOrder(Long actorId, UserRole actorRole, UUID orderId) {
+        // 취소는 CUSTOMER 본인 주문과 MASTER 예외 권한만 허용한다.
+        return switch (actorRole) {
+            case CUSTOMER -> getOwnedOrder(actorId, orderId);
+            case MASTER -> getOrderOrThrow(orderId);
+            default -> throw new OrderForbiddenException();
+        };
+    }
+
+    private Order getDeletableOrder(UserRole actorRole, UUID orderId) {
+        if (actorRole != UserRole.MASTER) {
+            throw new OrderForbiddenException();
+        }
+        return getOrderOrThrow(orderId);
+    }
+
+    private Order getManageableOrder(Long actorId, UserRole actorRole, UUID orderId) {
+        Order order = getOrderOrThrow(orderId);
+
+        // 상태 변경은 OWNER(본인 가게) 또는 MANAGER / MASTER만 가능하다.
+        if (actorRole == UserRole.MANAGER || actorRole == UserRole.MASTER) {
+            return order;
+        }
+
+        if (actorRole == UserRole.OWNER && isOwnedStore(actorId, order.getStoreId())) {
+            return order;
+        }
+
+        throw new OrderForbiddenException();
+    }
+
     private Order getOwnedOrder(Long userId, UUID orderId) {
-        Order order = orderRepository.findById(orderId)
-                .orElseThrow(OrderNotFoundException::new);
+        Order order = getOrderOrThrow(orderId);
         if (!order.getUserId().equals(userId)) {
             throw new OrderForbiddenException();
         }
         return order;
+    }
+
+    private Order getOrderOrThrow(UUID orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(OrderNotFoundException::new);
+    }
+
+    private boolean isOwnedStore(Long actorId, UUID storeId) {
+        Store store = storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)
+                .orElseThrow(StoreNotFoundException::new);
+        return store.getUserId().equals(actorId);
     }
 }

--- a/src/main/java/com/sparta/delivery/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/sparta/delivery/order/domain/exception/OrderErrorCode.java
@@ -20,7 +20,7 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_ORDER_ITEM_UNIT_PRICE(HttpStatus.BAD_REQUEST, "ORDER-009", "주문 단가는 0보다 커야 합니다."),
     INVALID_PRODUCT_NAME_SNAPSHOT(HttpStatus.BAD_REQUEST, "ORDER-010", "상품명 스냅샷은 필수입니다."),
     INVALID_ORDER_ITEM(HttpStatus.BAD_REQUEST, "ORDER-011", "주문 항목이 올바르지 않습니다."),
-    ORDER_FORBIDDEN(HttpStatus.FORBIDDEN, "ORDER-012", "본인 주문만 접근할 수 있습니다."),
+    ORDER_FORBIDDEN(HttpStatus.FORBIDDEN, "ORDER-012", "주문에 접근할 수 없습니다."),
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER-013", "가게를 찾을 수 없습니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER-014", "상품을 찾을 수 없습니다."),
     STORE_NOT_ORDERABLE(HttpStatus.BAD_REQUEST, "ORDER-015", "주문 가능한 가게가 아닙니다."),

--- a/src/main/java/com/sparta/delivery/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/delivery/order/domain/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.order.domain.repository;
 
 import com.sparta.delivery.order.domain.entity.Order;
 import com.sparta.delivery.order.domain.entity.OrderStatus;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,14 @@ public interface OrderRepository extends JpaRepository<Order, UUID> {
             OrderStatus status,
             Pageable pageable
     );
+
+    Page<Order> findAllByStoreId(UUID storeId, Pageable pageable);
+
+    Page<Order> findAllByStatus(OrderStatus status, Pageable pageable);
+
+    Page<Order> findAllByStoreIdAndStatus(UUID storeId, OrderStatus status, Pageable pageable);
+
+    Page<Order> findAllByStoreIdIn(List<UUID> storeIds, Pageable pageable);
+
+    Page<Order> findAllByStoreIdInAndStatus(List<UUID> storeIds, OrderStatus status, Pageable pageable);
 }

--- a/src/main/java/com/sparta/delivery/order/presentation/OrderController.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/OrderController.java
@@ -8,6 +8,8 @@ import com.sparta.delivery.order.domain.entity.OrderStatus;
 import com.sparta.delivery.order.presentation.dto.OrderCreateRequest;
 import com.sparta.delivery.order.presentation.dto.OrderDetailResponse;
 import com.sparta.delivery.order.presentation.dto.OrderListResponse;
+import com.sparta.delivery.order.presentation.dto.OrderStatusUpdateRequest;
+import com.sparta.delivery.user.domain.entity.UserRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -20,6 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,12 +36,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
 @Tag(name = "Order", description = "주문 API")
-@PreAuthorize("hasRole('CUSTOMER')")
 public class OrderController {
 
     private final OrderService orderService;
 
     @Operation(summary = "주문 생성")
+    @PreAuthorize("hasRole('CUSTOMER')")
     @PostMapping
     public ResponseEntity<ApiResponse<OrderDetailResponse>> create(
             @AuthenticationPrincipal UserPrincipal principal,
@@ -48,17 +51,19 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
     }
 
-    @Operation(summary = "내 주문 목록 조회")
+    @Operation(summary = "주문 목록 조회")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<OrderListResponse>>> getMyOrders(
+    public ResponseEntity<ApiResponse<PageResponse<OrderListResponse>>> getOrders(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam(required = false) UUID storeId,
             @RequestParam(required = false) OrderStatus status,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        PageResponse<OrderListResponse> response = orderService.getMyOrders(
+        PageResponse<OrderListResponse> response = orderService.getOrders(
                 principal.getId(),
+                UserRole.valueOf(principal.getRole()),
                 storeId,
                 status,
                 pageable
@@ -66,23 +71,65 @@ public class OrderController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @Operation(summary = "내 주문 상세 조회")
+    @Operation(summary = "주문 상세 조회")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
     @GetMapping("/{orderId}")
-    public ResponseEntity<ApiResponse<OrderDetailResponse>> getMyOrder(
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrder(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable UUID orderId
     ) {
-        OrderDetailResponse response = orderService.getMyOrder(principal.getId(), orderId);
+        OrderDetailResponse response = orderService.getOrder(
+                principal.getId(),
+                UserRole.valueOf(principal.getRole()),
+                orderId
+        );
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "주문 취소")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'MASTER')")
     @PatchMapping("/{orderId}/cancel")
     public ResponseEntity<ApiResponse<Void>> cancel(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable UUID orderId
     ) {
-        orderService.cancel(principal.getId(), orderId);
+        orderService.cancel(
+                principal.getId(),
+                UserRole.valueOf(principal.getRole()),
+                orderId
+        );
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
+
+    @Operation(summary = "주문 상태 변경")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    @PatchMapping("/{orderId}/status")
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> updateStatus(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID orderId,
+            @Valid @RequestBody OrderStatusUpdateRequest request
+    ) {
+        OrderDetailResponse response = orderService.updateStatus(
+                principal.getId(),
+                UserRole.valueOf(principal.getRole()),
+                orderId,
+                request.status()
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "주문 삭제")
+    @PreAuthorize("hasRole('MASTER')")
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID orderId
+    ) {
+        orderService.delete(
+                principal.getId(),
+                UserRole.valueOf(principal.getRole()),
+                orderId
+        );
         return ResponseEntity.ok(ApiResponse.ok());
     }
 }

--- a/src/main/java/com/sparta/delivery/order/presentation/dto/OrderListResponse.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/dto/OrderListResponse.java
@@ -8,34 +8,18 @@ import java.util.UUID;
 public record OrderListResponse(
         UUID orderId,
         UUID storeId,
-        UUID addressId,
-        Long userId,
         Integer totalPrice,
         OrderStatus status,
-        String deliveryAddressSnapshot,
-        LocalDateTime cancelDeadlineAt,
-        LocalDateTime rejectedAt,
-        LocalDateTime completedAt,
-        LocalDateTime canceledAt,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime createdAt
 ) {
 
     public static OrderListResponse from(Order order) {
         return new OrderListResponse(
                 order.getOrderId(),
                 order.getStoreId(),
-                order.getAddressId(),
-                order.getUserId(),
                 order.getTotalPrice(),
                 order.getStatus(),
-                order.getDeliveryAddressSnapshot(),
-                order.getCancelDeadlineAt(),
-                order.getRejectedAt(),
-                order.getCompletedAt(),
-                order.getCanceledAt(),
-                order.getCreatedAt(),
-                order.getUpdatedAt()
+                order.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/sparta/delivery/order/presentation/dto/OrderStatusUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/order/presentation/dto/OrderStatusUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.order.presentation.dto;
+
+import com.sparta.delivery.order.domain.entity.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record OrderStatusUpdateRequest(
+        @NotNull(message = "변경할 주문 상태는 필수입니다.")
+        OrderStatus status
+) {
+}

--- a/src/test/java/com/sparta/delivery/order/application/OrderServiceTest.java
+++ b/src/test/java/com/sparta/delivery/order/application/OrderServiceTest.java
@@ -14,6 +14,7 @@ import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.order.domain.entity.Order;
 import com.sparta.delivery.order.domain.entity.OrderItem;
 import com.sparta.delivery.order.domain.entity.OrderStatus;
+import com.sparta.delivery.order.domain.exception.InvalidOrderStatusException;
 import com.sparta.delivery.order.domain.exception.MinOrderAmountNotMetException;
 import com.sparta.delivery.order.domain.exception.OrderForbiddenException;
 import com.sparta.delivery.order.domain.exception.ProductNotOrderableException;
@@ -24,6 +25,7 @@ import com.sparta.delivery.product.domain.entity.Product;
 import com.sparta.delivery.product.domain.repository.ProductRepository;
 import com.sparta.delivery.store.domain.entity.Store;
 import com.sparta.delivery.store.domain.repository.StoreRepository;
+import com.sparta.delivery.user.domain.entity.UserRole;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -163,8 +165,8 @@ class OrderServiceTest {
     }
 
     @Nested
-    @DisplayName("내 주문 목록 조회")
-    class GetMyOrders {
+    @DisplayName("주문 목록 조회")
+    class GetOrders {
 
         @Test
         @DisplayName("허용되지 않은 페이지 크기는 10으로 보정된다")
@@ -180,7 +182,7 @@ class OrderServiceTest {
                     .willReturn(new PageImpl<>(List.of(order), PageRequest.of(0, 10), 1));
 
             // when
-            PageResponse<?> response = orderService.getMyOrders(userId, null, null, pageable);
+            PageResponse<?> response = orderService.getOrders(userId, UserRole.CUSTOMER, null, null, pageable);
 
             // then
             ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
@@ -189,11 +191,51 @@ class OrderServiceTest {
             assertThat(response.content()).hasSize(1);
             assertThat(response.size()).isEqualTo(10);
         }
+
+        @Test
+        @DisplayName("사장은 본인 가게 주문 목록을 조회할 수 있다")
+        void ownerSuccess() {
+            // given
+            Long actorId = 1L;
+            UUID storeId = UUID.randomUUID();
+            Order order = createOrder(UUID.randomUUID(), 2L, storeId, UUID.randomUUID(), 18000);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(storeRepository.findByUserIdAndDeletedAtIsNull(actorId))
+                    .willReturn(List.of(createStore(storeId, actorId, 10000, true, true)));
+            given(orderRepository.findAllByStoreIdIn(eq(List.of(storeId)), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(order), pageable, 1));
+
+            // when
+            PageResponse<?> response = orderService.getOrders(actorId, UserRole.OWNER, null, null, pageable);
+
+            // then
+            assertThat(response.content()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("매니저는 전체 주문 목록을 조회할 수 있다")
+        void managerSuccess() {
+            // given
+            Long actorId = 99L;
+            UUID storeId = UUID.randomUUID();
+            Order order = createOrder(UUID.randomUUID(), 2L, storeId, UUID.randomUUID(), 18000);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(orderRepository.findAll(any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(order), pageable, 1));
+
+            // when
+            PageResponse<?> response = orderService.getOrders(actorId, UserRole.MANAGER, null, null, pageable);
+
+            // then
+            assertThat(response.content()).hasSize(1);
+        }
     }
 
     @Nested
-    @DisplayName("내 주문 상세 조회")
-    class GetMyOrder {
+    @DisplayName("주문 상세 조회")
+    class GetOrder {
 
         @Test
         @DisplayName("본인 주문을 상세 조회할 수 있다")
@@ -208,7 +250,7 @@ class OrderServiceTest {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when
-            var response = orderService.getMyOrder(userId, orderId);
+            var response = orderService.getOrder(userId, UserRole.CUSTOMER, orderId);
 
             // then
             assertThat(response.orderId()).isEqualTo(orderId);
@@ -228,8 +270,28 @@ class OrderServiceTest {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when // then
-            assertThatThrownBy(() -> orderService.getMyOrder(userId, orderId))
+            assertThatThrownBy(() -> orderService.getOrder(userId, UserRole.CUSTOMER, orderId))
                     .isInstanceOf(OrderForbiddenException.class);
+        }
+
+        @Test
+        @DisplayName("사장은 본인 가게 주문을 상세 조회할 수 있다")
+        void ownerSuccess() {
+            // given
+            Long actorId = 1L;
+            UUID orderId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, storeId, UUID.randomUUID(), 18000);
+            Store store = createStore(storeId, actorId, 10000, true, true);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(store));
+
+            // when
+            var response = orderService.getOrder(actorId, UserRole.OWNER, orderId);
+
+            // then
+            assertThat(response.orderId()).isEqualTo(orderId);
         }
     }
 
@@ -248,7 +310,7 @@ class OrderServiceTest {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when
-            orderService.cancel(userId, orderId);
+            orderService.cancel(userId, UserRole.CUSTOMER, orderId);
 
             // then
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
@@ -266,8 +328,142 @@ class OrderServiceTest {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when // then
-            assertThatThrownBy(() -> orderService.cancel(userId, orderId))
+            assertThatThrownBy(() -> orderService.cancel(userId, UserRole.CUSTOMER, orderId))
                     .isInstanceOf(OrderForbiddenException.class);
+        }
+
+        @Test
+        @DisplayName("마스터는 타인 주문도 취소할 수 있다")
+        void masterSuccess() {
+            // given
+            Long actorId = 99L;
+            UUID orderId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, UUID.randomUUID(), UUID.randomUUID(), 18000);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when
+            orderService.cancel(actorId, UserRole.MASTER, orderId);
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+            assertThat(order.getCanceledAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 상태 변경")
+    class UpdateStatus {
+
+        @Test
+        @DisplayName("본인 가게 사장은 주문 상태를 변경할 수 있다")
+        void ownerSuccess() {
+            // given
+            Long actorId = 1L;
+            UUID orderId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, storeId, UUID.randomUUID(), 18000);
+            Store store = createStore(storeId, actorId, 10000, true, true);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(store));
+
+            // when
+            var response = orderService.updateStatus(actorId, UserRole.OWNER, orderId, OrderStatus.ACCEPTED);
+
+            // then
+            assertThat(response.status()).isEqualTo(OrderStatus.ACCEPTED);
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.ACCEPTED);
+        }
+
+        @Test
+        @DisplayName("매니저는 주문 상태를 변경할 수 있다")
+        void managerSuccess() {
+            // given
+            Long actorId = 99L;
+            UUID orderId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, storeId, UUID.randomUUID(), 18000);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when
+            var response = orderService.updateStatus(actorId, UserRole.MANAGER, orderId, OrderStatus.ACCEPTED);
+
+            // then
+            assertThat(response.status()).isEqualTo(OrderStatus.ACCEPTED);
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.ACCEPTED);
+            verify(storeRepository, never()).findByStoreIdAndDeletedAtIsNull(any(UUID.class));
+        }
+
+        @Test
+        @DisplayName("본인 가게 주문이 아니면 상태를 변경할 수 없다")
+        void forbidden() {
+            // given
+            Long actorId = 1L;
+            UUID orderId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, storeId, UUID.randomUUID(), 18000);
+            Store store = createStore(storeId, 3L, 10000, true, true);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+            given(storeRepository.findByStoreIdAndDeletedAtIsNull(storeId)).willReturn(Optional.of(store));
+
+            // when // then
+            assertThatThrownBy(() -> orderService.updateStatus(actorId, UserRole.OWNER, orderId, OrderStatus.ACCEPTED))
+                    .isInstanceOf(OrderForbiddenException.class);
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 주문 상태로는 변경할 수 없다")
+        void invalidStatus() {
+            // given
+            Long actorId = 99L;
+            UUID orderId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, storeId, UUID.randomUUID(), 18000);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when // then
+            assertThatThrownBy(() -> orderService.updateStatus(actorId, UserRole.MANAGER, orderId, OrderStatus.PENDING))
+                    .isInstanceOf(InvalidOrderStatusException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 삭제")
+    class Delete {
+
+        @Test
+        @DisplayName("마스터는 주문을 삭제할 수 있다")
+        void success() {
+            // given
+            Long actorId = 99L;
+            UUID orderId = UUID.randomUUID();
+            Order order = createOrder(orderId, 2L, UUID.randomUUID(), UUID.randomUUID(), 18000);
+
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when
+            orderService.delete(actorId, UserRole.MASTER, orderId);
+
+            // then
+            assertThat(order.getDeletedAt()).isNotNull();
+            assertThat(order.getDeletedBy()).isEqualTo(actorId);
+        }
+
+        @Test
+        @DisplayName("마스터가 아니면 주문을 삭제할 수 없다")
+        void forbidden() {
+            // given
+            Long actorId = 1L;
+            UUID orderId = UUID.randomUUID();
+
+            // when // then
+            assertThatThrownBy(() -> orderService.delete(actorId, UserRole.CUSTOMER, orderId))
+                    .isInstanceOf(OrderForbiddenException.class);
+            verify(orderRepository, never()).findById(any(UUID.class));
         }
     }
 
@@ -278,10 +474,14 @@ class OrderServiceTest {
     }
 
     private Store createStore(UUID storeId, Integer minOrderAmount, boolean isOpen, boolean isActive) {
+        return createStore(storeId, 1L, minOrderAmount, isOpen, isActive);
+    }
+
+    private Store createStore(UUID storeId, Long ownerId, Integer minOrderAmount, boolean isOpen, boolean isActive) {
         Store store = Store.create(
                 UUID.randomUUID(),
                 UUID.randomUUID(),
-                1L,
+                ownerId,
                 "치킨집",
                 null,
                 "서울시 강남구",


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #54  

## ✨ 기능 요약
주문 상태 변경 API를 구현하고 주문 조회/취소/삭제 권한 범위를 문서 기준에 맞게 확장.


## 📝 상세 내역
- 주문 상태 변경 API와 dto를 추가.
- OWNER / MANAGER / MASTER 권한에 따른 상태 변경 로직 구현.
- 주문 목록 조회 / 상세 조회 권한을 `CUSTOMER / OWNER / MANAGER / MASTER` 기준으로 확장.
- 주문 취소 권한을 `CUSTOMER(본인) / MASTER` 기준으로 확장.
- 주문 삭제(소프트) API를 추가하고, 서비스 레벨에서도 `MASTER`만 삭제 가능.
- 주문 목록 응답은 `OrderListResponse` 내용을 간소화.
- `OrderServiceTest`에 상태 변경 / 권한 분기 / 삭제 시나리오를 추가.

---

## 🙋‍♀️ 리뷰어 참고사항
- 상태 전이는 `Order` 엔티티 메서드(`accept`, `startCooking`, `startDelivery`, `markDelivered`, `complete`, `reject`)를 사용
- OWNER는 본인 가게 주문에 대해서만 조회 및 상태 변경 가능.
- MANAGER / MASTER는 전체 주문 조회 가능하며 MASTER는 타인 주문 취소 및 주문 삭제가 가능.
- 목록 조회의 기본 정렬은 `createdAt DESC`이며, 페이지 크기는 `10 / 30 / 50` 외 값이 들어오면 `10`으로 보정.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 주문 상태 변경 기능 추가
  * 주문 삭제 기능 추가

* **Refactor**
  * 주문 조회 및 관리 API에 역할 기반 접근 제어 적용
  * 사용자 역할(고객/점주/매니저/마스터)에 따른 권한 기반 데이터 접근 구현
  * 주문 목록 응답 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->