### PR TITLE
refactor: Review 도메인 검증/예외 처리 및 단위 테스트 추가

### DIFF
--- a/src/main/java/com/sparta/delivery/review/domain/entity/Review.java
+++ b/src/main/java/com/sparta/delivery/review/domain/entity/Review.java
@@ -11,20 +11,25 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.sparta.delivery.common.model.BaseEntity;
+import com.sparta.delivery.review.domain.exception.InvalidContentException;
+import com.sparta.delivery.review.domain.exception.InvalidRatingException;
 
 @Entity
 @Table(name = "p_review", uniqueConstraints = {@UniqueConstraint(name = "uk_review_order_id", columnNames = "order_id")}, indexes = {@Index(name = "idx_review_store_id", columnList = "store_id")})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class Review extends BaseEntity {
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Review(UUID orderId, UUID storeId, Long userId, Integer rating, String content) {
         this.orderId = orderId;
         this.storeId = storeId;
@@ -33,30 +38,79 @@ public class Review extends BaseEntity {
         this.content = content;
     }
 
+    public static Review create(
+            UUID orderId,
+            UUID storeId,
+            Long userId,
+            Integer rating,
+            String content
+    ) {
+        String normalizedContent = normalizeOptional(content);
+        validate(rating, content);
+        return Review.builder()
+                .orderId(orderId)
+                .storeId(storeId)
+                .userId(userId)
+                .rating(rating)
+                .content(normalizedContent)
+                .build();
+    }
+
+    private static void validate(Integer rating, String content) {
+        validateRating(rating);
+        validateContent(content);
+    }
+
+    private static void validateRating(Integer rating) {
+        if (rating == null || rating < 1 || rating > 5) {
+            throw new InvalidRatingException();
+        }
+    }
+
+    private static void validateContent(String content) {
+        String value = normalizeOptional(content);
+
+        if (value != null && value.length() > 500) {
+            throw new InvalidContentException();
+        }
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
     @Id
-    @Column(name = "review_id", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID reviewId;
 
-    @Column(name = "order_id", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     private UUID orderId;
 
-    @Column(name = "store_id", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     private UUID storeId;
 
-    @Column(name = "user_id", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     private Long userId;
 
-    @Column(name = "rating", nullable = false)
+    @Column(nullable = false)
     private Integer rating;
 
-    @Column(name = "content")
+    @Column(length=500)
     private String content;
 
     public void update(Integer rating, String content) {
-        this.rating = rating;
-        this.content = content;
-    }
 
+        String normalizedContent = normalizeOptional(content);
+        validate(rating, content);
+        this.rating = rating;
+        this.content = normalizedContent;
+
+    }
 
 }

--- a/src/main/java/com/sparta/delivery/review/domain/exception/InvalidContentException.java
+++ b/src/main/java/com/sparta/delivery/review/domain/exception/InvalidContentException.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.review.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidContentException extends BaseException {
+
+        public InvalidContentException() {
+        super(ReviewErrorCode.INVALID_CONTENT);
+    }
+}

--- a/src/main/java/com/sparta/delivery/review/domain/exception/InvalidRatingException.java
+++ b/src/main/java/com/sparta/delivery/review/domain/exception/InvalidRatingException.java
@@ -1,0 +1,8 @@
+package com.sparta.delivery.review.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class InvalidRatingException extends BaseException {
+
+        public InvalidRatingException() { super(ReviewErrorCode.INVALID_RATING); }
+}

--- a/src/main/java/com/sparta/delivery/review/domain/exception/ReviewErrorCode.java
+++ b/src/main/java/com/sparta/delivery/review/domain/exception/ReviewErrorCode.java
@@ -1,0 +1,20 @@
+package com.sparta.delivery.review.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import com.sparta.delivery.common.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewErrorCode implements ErrorCode {
+
+    INVALID_RATING(HttpStatus.BAD_REQUEST, "REVIEW-001", "평점은 1~5 사이 정수만 가능합니다."),
+    INVALID_CONTENT(HttpStatus.BAD_REQUEST, "REVIEW-002", "리뷰글은 500자 이하로 작성해야합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivery/review/domain/exception/ReviewErrorCode.java
+++ b/src/main/java/com/sparta/delivery/review/domain/exception/ReviewErrorCode.java
@@ -14,7 +14,7 @@ public enum ReviewErrorCode implements ErrorCode {
     INVALID_RATING(HttpStatus.BAD_REQUEST, "REVIEW-001", "평점은 1~5 사이 정수만 가능합니다."),
     INVALID_CONTENT(HttpStatus.BAD_REQUEST, "REVIEW-002", "리뷰글은 500자 이하로 작성해야합니다.");
 
-    private final HttpStatus httpStatus;
+    private final HttpStatus status;
     private final String code;
     private final String message;
 }

--- a/src/test/java/com/sparta/delivery/review/domain/entity/ReviewTest.java
+++ b/src/test/java/com/sparta/delivery/review/domain/entity/ReviewTest.java
@@ -1,0 +1,140 @@
+package com.sparta.delivery.review.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.sparta.delivery.review.domain.exception.InvalidContentException;
+import com.sparta.delivery.review.domain.exception.InvalidRatingException;
+import com.sparta.delivery.review.domain.exception.ReviewErrorCode;
+
+class ReviewTest {
+
+    @Test
+    @DisplayName("create: 정상 입력이면 Review를 생성한다")
+    void create_success() {
+        UUID orderId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        Long userId = 1L;
+
+        Review review = Review.create(orderId, storeId, userId, 5, "  맛있어요  ");
+
+        assertThat(review.getOrderId()).isEqualTo(orderId);
+        assertThat(review.getStoreId()).isEqualTo(storeId);
+        assertThat(review.getUserId()).isEqualTo(userId);
+        assertThat(review.getRating()).isEqualTo(5);
+        assertThat(review.getContent()).isEqualTo("맛있어요");
+    }
+
+    @Test
+    @DisplayName("create: content가 null이면 null로 저장된다")
+    void create_success_whenContentNull() {
+        Review review = Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 4, null);
+
+        assertThat(review.getContent()).isNull();
+    }
+
+    @Test
+    @DisplayName("create: content가 공백이면 null로 정규화된다")
+    void create_success_whenContentBlank() {
+        Review review = Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 4, "   ");
+
+        assertThat(review.getContent()).isNull();
+    }
+
+    @Test
+    @DisplayName("create: rating이 null이면 예외가 발생한다")
+    void create_fail_whenRatingNull() {
+        Throwable thrown = catchThrowable(
+                () -> Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, null, "good")
+        );
+
+        assertThat(thrown).isInstanceOf(InvalidRatingException.class);
+        InvalidRatingException exception = (InvalidRatingException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ReviewErrorCode.INVALID_RATING.getCode());
+    }
+
+    @Test
+    @DisplayName("create: rating이 1 미만이면 예외가 발생한다")
+    void create_fail_whenRatingLessThanOne() {
+        Throwable thrown = catchThrowable(
+                () -> Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 0, "good")
+        );
+
+        assertThat(thrown).isInstanceOf(InvalidRatingException.class);
+    }
+
+    @Test
+    @DisplayName("create: rating이 5 초과면 예외가 발생한다")
+    void create_fail_whenRatingGreaterThanFive() {
+        Throwable thrown = catchThrowable(
+                () -> Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 6, "good")
+        );
+
+        assertThat(thrown).isInstanceOf(InvalidRatingException.class);
+    }
+
+    @Test
+    @DisplayName("create: content가 500자를 초과하면 예외가 발생한다")
+    void create_fail_whenContentTooLong() {
+        String longContent = "a".repeat(501);
+
+        Throwable thrown = catchThrowable(
+                () -> Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 5, longContent)
+        );
+
+        assertThat(thrown).isInstanceOf(InvalidContentException.class);
+        InvalidContentException exception = (InvalidContentException) thrown;
+        assertThat(exception.getCode()).isEqualTo(ReviewErrorCode.INVALID_CONTENT.getCode());
+    }
+
+    @Test
+    @DisplayName("update: 정상 입력이면 rating/content가 갱신된다")
+    void update_success() {
+        Review review = Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 3, "good");
+
+        review.update(5, "  excellent  ");
+
+        assertThat(review.getRating()).isEqualTo(5);
+        assertThat(review.getContent()).isEqualTo("excellent");
+    }
+
+    @Test
+    @DisplayName("update: content가 공백이면 null로 정규화된다")
+    void update_success_whenContentBlank() {
+        Review review = Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 3, "good");
+
+        review.update(4, "   ");
+
+        assertThat(review.getRating()).isEqualTo(4);
+        assertThat(review.getContent()).isNull();
+    }
+
+    @Test
+    @DisplayName("update: 유효하지 않은 rating이면 값이 변경되지 않는다")
+    void update_fail_whenInvalidRating_thenStateUnchanged() {
+        Review review = Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 3, "good");
+
+        Throwable thrown = catchThrowable(() -> review.update(0, "new content"));
+
+        assertThat(thrown).isInstanceOf(InvalidRatingException.class);
+        assertThat(review.getRating()).isEqualTo(3);
+        assertThat(review.getContent()).isEqualTo("good");
+    }
+
+    @Test
+    @DisplayName("update: 유효하지 않은 content면 값이 변경되지 않는다")
+    void update_fail_whenInvalidContent_thenStateUnchanged() {
+        Review review = Review.create(UUID.randomUUID(), UUID.randomUUID(), 1L, 3, "good");
+
+        Throwable thrown = catchThrowable(() -> review.update(5, "a".repeat(501)));
+
+        assertThat(thrown).isInstanceOf(InvalidContentException.class);
+        assertThat(review.getRating()).isEqualTo(3);
+        assertThat(review.getContent()).isEqualTo("good");
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #58 

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Review 도메인 검증/예외 체계 및 단위 테스트 추가 |
| 🔍 목적 | 리뷰 생성/수정 시 평점/내용 유효성을 도메인에서 강제하고 예외 응답 규격을 통일하기 위함 |
| 🛠️ 변경사항 | Review 검증 로직 추가, ReviewErrorCode/커스텀 예외 추가, ErrorCode 구현 정합성 수정, Review 단위 테스트 추가 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `Review.create` 정적 팩토리 추가, `create/update` 공통 검증(`validate`) 적용 |
| 2️⃣ | 평점(1~5), 내용(500자 이하) 검증 및 내용 정규화(`trim`, 공백 -> `null`) 반영 |
| 3️⃣ | `ReviewErrorCode`, `InvalidRatingException`, `InvalidContentException` 추가 및 `status` 필드로 `ErrorCode#getStatus()` 계약 일치 |
| 4️⃣ | `ReviewTest` 추가: 생성/수정 정상 흐름, 경계값/예외, 실패 시 상태 불변 검증 |

---

## ✅ 테스트 체크리스트
- [x] 기능 정상 작동 확인 (Review 도메인 생성/수정 검증)
- [x] 예외/엣지 케이스 확인 (rating/content 경계값)
- [ ] UI/UX 흐름 확인 (해당 없음)
- [x] 테스트 코드 작성 완료
- [ ] API 연동 확인 (요청/응답 정상 동작)
- [x] `./gradlew test --tests com.sparta.delivery.review.domain.entity.ReviewTest` 통과

---

## 🙋‍♀️ 리뷰어 참고사항
- 변경 파일
  - `src/main/java/com/sparta/delivery/review/domain/entity/Review.java`
  - `src/main/java/com/sparta/delivery/review/domain/exception/ReviewErrorCode.java`
  - `src/main/java/com/sparta/delivery/review/domain/exception/InvalidRatingException.java`
  - `src/main/java/com/sparta/delivery/review/domain/exception/InvalidContentException.java`
  - `src/test/java/com/sparta/delivery/review/domain/entity/ReviewTest.java`
- 리뷰 포인트
  - 내용 정규화 정책(공백 -> `null`)이 비즈니스 요구와 맞는지
  - `update` 실패 시 상태 불변 검증이 의도와 맞는지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **새로운 기능**
  * 리뷰 작성 시 평점 유효성 검사 (1~5 범위) 추가
  * 리뷰 내용 길이 제한 (최대 500자) 적용
  * 유효하지 않은 입력에 대한 개선된 오류 메시지 제공
  * 리뷰 수정 시 동일한 유효성 검사 적용

* **테스트**
  * 리뷰 생성 및 수정 동작 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->