### PR TITLE
feat: CI/CD 및 배포 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,5 @@ REDIS_PASSWORD=changeme
 # JWT
 JWT_SECRET=your-256-bit-secret-key-here
 
-# Gemini AI
-GEMINI_API_KEY=your-gemini-api-key
+# OpenAI API
+OPENAI_API_KEY=your-openai-api-key

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,96 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image_name: ${{ steps.image.outputs.image_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon
+
+      - name: Compute image name
+        id: image
+        run: |
+          IMAGE_NAME=$(echo "ghcr.io/${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image_name }}:latest
+            ${{ steps.image.outputs.image_name }}:sha-${{ github.sha }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Copy deploy files to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: ${{ secrets.EC2_PORT }}
+          source: docker-compose.prod.yml,scripts/deploy.sh
+          target: ${{ secrets.EC2_APP_DIR }}
+          strip_components: 0
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: ${{ secrets.EC2_PORT }}
+          script: |
+            mkdir -p "${{ secrets.EC2_APP_DIR }}/scripts"
+            chmod +x "${{ secrets.EC2_APP_DIR }}/scripts/deploy.sh"
+            cd "${{ secrets.EC2_APP_DIR }}"
+            APP_DIR="${{ secrets.EC2_APP_DIR }}" \
+            APP_IMAGE="${{ needs.build-and-push.outputs.image_name }}:latest" \
+            GHCR_USERNAME="${{ secrets.GHCR_USERNAME }}" \
+            GHCR_TOKEN="${{ secrets.GHCR_TOKEN }}" \
+            ./scripts/deploy.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Compile test classes
+        run: ./gradlew testClasses --no-daemon
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM eclipse-temurin:17-jdk-jammy AS builder
+
+WORKDIR /app
+
+COPY gradlew gradlew
+COPY gradle gradle
+COPY build.gradle settings.gradle ./
+COPY src src
+
+RUN chmod +x gradlew
+RUN ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:17-jre-jammy
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENV SPRING_PROFILES_ACTIVE=prod
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,67 @@
+services:
+  app:
+    image: ${APP_IMAGE}
+    container_name: delivery-app
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ${POSTGRES_DB}
+      DB_USERNAME: ${POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    networks:
+      - backend
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: delivery-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+
+  redis:
+    image: redis:7-alpine
+    container_name: delivery-redis
+    restart: unless-stopped
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} ping | grep PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+
+volumes:
+  postgres_data:
+  redis_data:
+
+networks:
+  backend:
+    driver: bridge

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -140,7 +140,7 @@ backend:
     REDIS_HOST: redis
     REDIS_PASSWORD: ${REDIS_PASSWORD}
     JWT_SECRET: ${JWT_SECRET}
-    GEMINI_API_KEY: ${GEMINI_API_KEY}
+    OPENAI_API_KEY: ${OPENAI_API_KEY}
 ```
 
 ---
@@ -154,7 +154,7 @@ backend:
  ├── EC2_SSH_KEY, EC2_HOST           ← Actions가 SSH 접속 시 사용
  ├── DB_PASSWORD, REDIS_PASSWORD      ← .env로 EC2에 전달
  ├── JWT_SECRET                       ← 동일
- └── GEMINI_API_KEY                   ← 동일
+ └── OPENAI_API_KEY                   ← 동일
         │
         ▼ (Actions가 SSH로 .env 업로드 또는 환경변수 주입)
 [EC2]
@@ -170,7 +170,7 @@ POSTGRES_USER=delivery
 POSTGRES_PASSWORD=changeme
 REDIS_PASSWORD=changeme
 JWT_SECRET=your-256-bit-secret-key-here
-GEMINI_API_KEY=your-gemini-api-key
+OPENAI_API_KEY=your-openai-api-key
 ```
 
 `.env`는 Git 커밋 금지.

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -96,7 +96,7 @@
 
 ### 민감 정보 (운영 환경변수)
 
-`DB_PASSWORD`, `JWT_SECRET`, `GEMINI_API_KEY`, `REDIS_PASSWORD`는 **환경 변수로만** 주입.
+`DB_PASSWORD`, `JWT_SECRET`, `OPENAI_API_KEY`, `REDIS_PASSWORD`는 **환경 변수로만** 주입.
 - 코드/Git 하드코딩 금지
 - 구체적 전달 경로(GitHub Secrets → EC2)는 [배포 파이프라인 #Secrets 관리](./deployment.md#4-secrets-관리) 참고
 
@@ -133,7 +133,7 @@ Backend(Spring Boot) 컨테이너는 운영 배포 시 추가 예정 — [배포
 
 - **연결 위치**: 코드 상 `ai/infrastructure/external/gemini/GeminiClient` ([패키지·계층 구조 가이드](../architecture/package-structure.md) 참고)
 - **네트워크**: EC2 → 인터넷 → Gemini API (아웃바운드 허용)
-- **키 관리**: `GEMINI_API_KEY` 환경변수
+- **키 관리**: `OPENAI_API_KEY` 환경변수
 - **운영 동작**(timeout / 에러 처리 / 입력 한도 등): [배포 파이프라인 #외부 API 운영 동작](./deployment.md#6-외부-api-운영-동작) 참고
 
 ---

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+
+if [[ -z "${APP_IMAGE:-}" ]]; then
+  echo "APP_IMAGE 환경변수가 필요합니다."
+  exit 1
+fi
+
+cd "${APP_DIR}"
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Compose 파일을 찾을 수 없습니다: ${COMPOSE_FILE}"
+  exit 1
+fi
+
+if [[ ! -f ".env" ]]; then
+  echo "${APP_DIR} 경로에 .env 파일이 없습니다. 서버에 운영용 .env 파일을 먼저 생성해주세요."
+  exit 1
+fi
+
+if [[ -n "${GHCR_USERNAME:-}" && -n "${GHCR_TOKEN:-}" ]]; then
+  echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+fi
+
+export APP_IMAGE
+
+docker compose -f "${COMPOSE_FILE}" pull app
+docker compose -f "${COMPOSE_FILE}" up -d postgres redis
+docker compose -f "${COMPOSE_FILE}" up -d app
+
+for _ in {1..30}; do
+  if curl -fsS http://127.0.0.1:8080/actuator/health >/dev/null; then
+    echo "애플리케이션이 정상적으로 실행 중입니다."
+    docker compose -f "${COMPOSE_FILE}" ps
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "애플리케이션 헬스체크에 실패했습니다."
+docker compose -f "${COMPOSE_FILE}" ps
+exit 1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,7 @@ jwt:
 
 ai:
   gemini:
-    api-key: ${GEMINI_API_KEY:dummy-key}
+    api-key: ${OPENAI_API_KEY:dummy-key}
     max-input-length: 500
 
 ---

--- a/src/test/java/com/sparta/delivery/DeliveryApplicationTests.java
+++ b/src/test/java/com/sparta/delivery/DeliveryApplicationTests.java
@@ -2,8 +2,10 @@ package com.sparta.delivery;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DeliveryApplicationTests {
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:delivery;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: 1234


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #62 

## ✨ 기능 요약
GitHub Actions 기반 CI/CD 워크플로우와 EC2 운영 배포를 위한 Docker / Compose / 배포 스크립트 구성을 추가

## 📝 상세 내역
- ci.yml을 추가해 `dev`, `main` 브랜치의 push / pull_request 시 `testClasses`, `test`가 실행되도록 구성.
- cd.yml을 추가해 `main` 브랜치 push 시 Docker 이미지 빌드, GHCR 푸시, EC2 배포 스크립트 실행 흐름을 구성.
- 운영용 `Dockerfile`을 추가해 Java 17 기반 Spring Boot 애플리케이션 이미지를 멀티스테이지 빌드하도록 구성.
- `docker-compose.prod.yml`을 추가해 `app`, `postgres`, `redis` 컨테이너를 운영 환경 기준으로 구성.
- `scripts/deploy.sh`를 추가해 EC2에서 최신 앱 이미지를 pull하고 compose 재기동 및 `/actuator/health` 헬스체크를 수행하도록 구성
- 운영 배포 구조는 `호스트 Nginx + 내부 Docker 네트워크(app/postgres/redis)` 기준으로 맞춤.
- 테스트용 Redis 설정 추가

---

## 🙋‍♀️ 리뷰어 참고사항
- 이번 PR은 배포 자동화와 운영 환경 구성을 위한 인프라성 설정 추가가 중심.
- 현재 CD는 `main` 브랜치 push 기준으로 동작하도록 구성.
- GitHub Secrets(`EC2_HOST`, `EC2_USERNAME`, `EC2_SSH_KEY`, `EC2_APP_DIR`, `GHCR_USERNAME`, `GHCR_TOKEN` 등) 설정이 선행되어야 실제 배포가 가능.
- 운영 서버에는 별도로 Docker, Docker Compose plugin, Nginx, `.env` 파일이 준비되어 있어야함.
- 앱 컨테이너는 `127.0.0.1:8080`으로만 열고, 외부 트래픽은 Nginx가 받아 reverse proxy 하도록 구성.
- 우선 이번에는 `dev`에 먼저 반영하고 실제 배포는 추후 `main` 반영 시점에 진행할 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 제공자로 OpenAI API 키 통합

* **Chores**
  * CI 파이프라인 및 CD 배포 자동화 추가
  * 컨테이너 이미지 빌드 및 배포 워크플로우 추가
  * 프로덕션용 Docker 이미지 및 Compose 구성 추가
  * 배포 스크립트로 환경 기반 자동 배포 지원

* **문서**
  * 배포·인프라 문서에서 API 키 참조 업데이트

* **Tests**
  * 테스트용 프로파일 및 인메모리 DB/Redis 테스트 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->