### PR TITLE
refactor: Address 문자열 정규화 책임을 DTO로 이동

### DIFF
--- a/src/main/java/com/sparta/delivery/address/domain/entity/Address.java
+++ b/src/main/java/com/sparta/delivery/address/domain/entity/Address.java
@@ -55,10 +55,10 @@ public class Address extends BaseEntity {
             boolean isDefault
     ) {
         this.userId = requireUserId(userId);
-        this.alias = normalizeOptional(alias);
+        this.alias = alias;
         this.address = requireAddress(address);
-        this.detail = normalizeOptional(detail);
-        this.zipCode = normalizeOptional(zipCode);
+        this.detail = detail;
+        this.zipCode = zipCode;
         this.isDefault = isDefault;
     }
 
@@ -81,10 +81,10 @@ public class Address extends BaseEntity {
     }
 
     public void update(String alias, String address, String detail, String zipCode) {
-        this.alias = normalizeOptional(alias);
+        this.alias = alias;
         this.address = requireAddress(address);
-        this.detail = normalizeOptional(detail);
-        this.zipCode = normalizeOptional(zipCode);
+        this.detail = detail;
+        this.zipCode = zipCode;
     }
 
     public void markAsDefault() {
@@ -99,7 +99,7 @@ public class Address extends BaseEntity {
         if (value == null || value.isBlank()) {
             throw new InvalidAddressException();
         }
-        return value.trim();
+        return value;
     }
 
     private static Long requireUserId(Long userId) {
@@ -107,14 +107,5 @@ public class Address extends BaseEntity {
             throw new InvalidUserIdException();
         }
         return userId;
-    }
-
-    private static String normalizeOptional(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        String trimmed = value.trim();
-        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/java/com/sparta/delivery/address/presentation/dto/AddressCreateRequest.java
+++ b/src/main/java/com/sparta/delivery/address/presentation/dto/AddressCreateRequest.java
@@ -19,4 +19,26 @@ public record AddressCreateRequest(
 
         boolean isDefault
 ) {
+    public AddressCreateRequest {
+        alias = normalizeOptional(alias);
+        address = normalizeRequired(address);
+        detail = normalizeOptional(detail);
+        zipCode = normalizeOptional(zipCode);
+    }
+
+    private static String normalizeRequired(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
 }

--- a/src/main/java/com/sparta/delivery/address/presentation/dto/AddressUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/address/presentation/dto/AddressUpdateRequest.java
@@ -17,4 +17,26 @@ public record AddressUpdateRequest(
         @Size(max = 10, message = "우편번호는 10자 이하여야 합니다.")
         String zipCode
 ) {
+    public AddressUpdateRequest {
+        alias = normalizeOptional(alias);
+        address = normalizeRequired(address);
+        detail = normalizeOptional(detail);
+        zipCode = normalizeOptional(zipCode);
+    }
+
+    private static String normalizeRequired(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
 }

--- a/src/test/java/com/sparta/delivery/address/application/AddressServiceTest.java
+++ b/src/test/java/com/sparta/delivery/address/application/AddressServiceTest.java
@@ -45,10 +45,10 @@ class AddressServiceTest {
             // given
             Long userId = 1L;
             AddressCreateRequest request = new AddressCreateRequest(
-                    "집",
-                    "서울시 강남구",
-                    "101호",
-                    "12345",
+                    "  집  ",
+                    "  서울시 강남구  ",
+                    " 101호 ",
+                    " 12345 ",
                     false
             );
 
@@ -63,6 +63,35 @@ class AddressServiceTest {
             assertThat(response.isDefault()).isTrue();
             assertThat(response.alias()).isEqualTo("집");
             assertThat(response.address()).isEqualTo("서울시 강남구");
+            assertThat(response.detail()).isEqualTo("101호");
+            assertThat(response.zipCode()).isEqualTo("12345");
+        }
+
+        @Test
+        @DisplayName("선택 문자열 필드는 DTO에서 trim 및 blank to null 처리된다")
+        void normalizeOptionalFields() {
+            // given
+            Long userId = 1L;
+            AddressCreateRequest request = new AddressCreateRequest(
+                    "   ",
+                    "  서울시 강남구  ",
+                    "   ",
+                    "   ",
+                    false
+            );
+
+            given(addressRepository.existsByUserId(userId)).willReturn(false);
+            given(addressRepository.save(any(Address.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            AddressResponse response = addressService.create(userId, request);
+
+            // then
+            assertThat(response.alias()).isNull();
+            assertThat(response.address()).isEqualTo("서울시 강남구");
+            assertThat(response.detail()).isNull();
+            assertThat(response.zipCode()).isNull();
         }
 
         @Test
@@ -133,10 +162,10 @@ class AddressServiceTest {
             );
             setAddressId(address, addressId);
             AddressUpdateRequest request = new AddressUpdateRequest(
-                    "회사",
-                    "서울시 서초구",
-                    "202호",
-                    "54321"
+                    "  회사  ",
+                    "  서울시 서초구  ",
+                    " 202호 ",
+                    " 54321 "
             );
 
             given(addressRepository.findById(addressId)).willReturn(Optional.of(address));


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #66 

## ✨ 기능 요약
Address 도메인의 문자열 정규화 책임을 엔티티에서 Request DTO로 이동해
입력값 정리와 도메인 유효성 검증의 책임을 분리.


## 📝 상세 내역
- 문자열 정규화를 DTO에서 수행하도록 변경.
- 필수 문자열은 `trim`, 선택 문자열은 `trim` 후 blank 값을 `null`로 정리하도록 반영.
- `Address` 엔티티에서는 문자열 정규화 로직을 제거하고 핵심 유효성 검증만 수행하도록 정리.

---

## 🙋‍♀️ 리뷰어 참고사항
- `order` 도메인과 동일하게 `입력값 정리 = DTO`, `도메인 유효성 = 엔티티` 기준으로 맞추려는 방향입니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 주소 입력 필드의 공백 처리가 개선되었습니다. 사용자가 입력한 주소, 별칭, 상세주소, 우편번호의 앞뒤 공백이 자동으로 제거됩니다.
  * 선택사항 필드(별칭, 상세주소, 우편번호)에 공백만 입력된 경우 자동으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->