### PR TITLE
feat: logout 추가, 단위 테스트 보강 

### DIFF
--- a/src/main/java/com/sparta/delivery/auth/application/AuthService.java
+++ b/src/main/java/com/sparta/delivery/auth/application/AuthService.java
@@ -56,4 +56,18 @@ public class AuthService {
                 jwtProvider.getExpirationMs()
         );
     }
+
+    /**
+     * 로그아웃.
+     *
+     * 현재 tokenVersion 단위 무효화 구조라 "이 디바이스만 로그아웃" 은 불가능 — 호출 시 해당 유저의
+     * 모든 기존 JWT 가 즉시 무효화된다. 디바이스별 분리는 추후 RefreshToken 도입 시 재설계.
+     *
+     * 실제 무효화는 UserService.forceLogout 에 위임 (도메인 흐름 유지).
+     */
+    public void logout(Long userId) {
+        userService.forceLogout(userId);
+        log.info("로그아웃: userId={}", userId);
+    }
+
 }

--- a/src/main/java/com/sparta/delivery/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/delivery/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -130,11 +130,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         objectMapper.writeValue(response.getWriter(), ApiResponse.error(ec));
     }
 
+    /**
+     * 필터 스킵 대상 — "토큰 없이 호출되는 게 정상" 인 엔드포인트만 화이트리스트.
+     *
+     * 주의: /api/v1/auth/** 전체를 스킵하면 안 됨. /auth/logout 은 인증된 요청이어야 하므로
+     * 필터를 타고 SecurityContext 에 principal 이 채워져야 한다. 따라서 /auth 하위는
+     * 무인증 경로(login 등)만 명시적으로 enumerate.
+     */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return path.startsWith("/api/v1/auth/")
-                || (path.equals("/api/v1/users/signup") && "POST".equalsIgnoreCase(request.getMethod()))
+        boolean isAuthLogin = "/api/v1/auth/login".equals(path)
+                && "POST".equalsIgnoreCase(request.getMethod());
+        boolean isSignup = "/api/v1/users/signup".equals(path)
+                && "POST".equalsIgnoreCase(request.getMethod());
+        return isAuthLogin
+                || isSignup
                 || path.startsWith("/swagger-ui")
                 || path.startsWith("/v3/api-docs")
                 || path.startsWith("/actuator/health")

--- a/src/main/java/com/sparta/delivery/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/delivery/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -139,7 +139,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
+        String path = request.getServletPath();
         boolean isAuthLogin = "/api/v1/auth/login".equals(path)
                 && "POST".equalsIgnoreCase(request.getMethod());
         boolean isSignup = "/api/v1/users/signup".equals(path)

--- a/src/main/java/com/sparta/delivery/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/sparta/delivery/auth/presentation/controller/AuthController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.sparta.delivery.common.config.security.UserPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 /**
  * 인증 API.
@@ -31,6 +33,15 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
         return ResponseEntity.ok(ApiResponse.success(authService.login(request)));
+    }
+
+    @Operation(summary = "로그아웃 — 해당 유저의 모든 기존 JWT 무효화 ")
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        authService.logout(principal.getId());
+        return ResponseEntity.ok(ApiResponse.ok());
     }
 
 }

--- a/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
@@ -42,8 +42,9 @@ public class SecurityConfig {
                                 "/actuator/health",
                                 "/actuator/info"
                         ).permitAll()
-                        // 인증/회원가입 (auth 도메인이 실제 경로 확정 시 갱신)
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        // /auth 하위는 무인증 경로만 명시. /auth/logout 등 인증 필요한 경로는
+                        // anyRequest().authenticated() 에 흡수시킨다.
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/signup")
                         .permitAll()
                         // 상품 조회

--- a/src/main/java/com/sparta/delivery/user/application/UserService.java
+++ b/src/main/java/com/sparta/delivery/user/application/UserService.java
@@ -2,10 +2,7 @@ package com.sparta.delivery.user.application;
 
 import com.sparta.delivery.user.domain.entity.User;
 import com.sparta.delivery.user.domain.entity.UserRole;
-import com.sparta.delivery.user.domain.exception.DuplicateEmailException;
-import com.sparta.delivery.user.domain.exception.ForbiddenRoleChangeException;
-import com.sparta.delivery.user.domain.exception.InvalidPasswordException;
-import com.sparta.delivery.user.domain.exception.UserNotFoundException;
+import com.sparta.delivery.user.domain.exception.*;
 import com.sparta.delivery.user.domain.repository.UserRepository;
 import com.sparta.delivery.user.presentation.dto.*;
 import lombok.RequiredArgsConstructor;
@@ -74,13 +71,30 @@ public class UserService {
         );
     }
 
-    /** 비밀번호 변경 */
+    /**
+     * 비밀번호 변경.
+     *
+     * 검증 순서:
+     *  1. 현재 비번 일치 여부 — 본인 확인
+     *  2. 새 비번이 기존과 동일한지 — 비번 회전 효과 무력화 방지
+     *
+     * 두 번째 검증은 raw 끼리 비교가 아니라 passwordEncoder.matches(new, oldHash) 로 수행.
+     * BCrypt 는 salt 때문에 같은 raw 라도 encode() 결과가 매번 달라 직접 비교가 의미 없음.
+     */
     @Transactional
     public void changePassword(Long userId, PasswordChangeRequest request) {
         User user = findUser(userId);
+
+        // 1. 현재 비번 검증
         if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
             throw new InvalidPasswordException();
         }
+
+        // 2. 새 비번 == 기존 비번 차단
+        if (passwordEncoder.matches(request.newPassword(), user.getPassword())) {
+            throw new SamePasswordException();
+        }
+
         user.changePassword(passwordEncoder.encode(request.newPassword()));
     }
 

--- a/src/main/java/com/sparta/delivery/user/application/UserService.java
+++ b/src/main/java/com/sparta/delivery/user/application/UserService.java
@@ -98,6 +98,19 @@ public class UserService {
         findUser(userId).withdraw();
     }
 
+    /**
+     * 강제 로그아웃 — tokenVersion 증가로 해당 유저의 모든 기존 JWT 무효화.
+     *
+     * 사용처:
+     *  - 본인 로그아웃 (AuthController.logout)
+     *  - 추후 관리자에 의한 강제 로그아웃 / 보안 사고 대응 등에서도 재사용
+     *
+     * 탈퇴(withdraw) 와 달리 deleted_at 은 건드리지 않음 — 단순 토큰 폐기 용도.
+     */
+    @Transactional
+    public void forceLogout(Long userId) {
+        findUser(userId).incrementTokenVersion();
+    }
 
     /**
      * 역할 변경 (관리자 기능).

--- a/src/main/java/com/sparta/delivery/user/domain/exception/SamePasswordException.java
+++ b/src/main/java/com/sparta/delivery/user/domain/exception/SamePasswordException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.user.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class SamePasswordException extends BaseException {
+    public SamePasswordException() {
+        super(UserErrorCode.SAME_AS_OLD_PASSWORD);
+    }
+}

--- a/src/main/java/com/sparta/delivery/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/sparta/delivery/user/domain/exception/UserErrorCode.java
@@ -14,7 +14,8 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER-003", "비밀번호가 올바르지 않습니다."),
     FORBIDDEN_ROLE_CHANGE(HttpStatus.FORBIDDEN, "USER-004", "권한을 변경할 수 없습니다."),
     ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER-005", "이미 탈퇴한 사용자입니다."),
-    INVALID_ROLE(HttpStatus.BAD_REQUEST, "USER-006", "유효하지 않은 역할입니다. (CUSTOMER, OWNER, MANAGER, MASTER)");
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, "USER-006", "유효하지 않은 역할입니다. (CUSTOMER, OWNER, MANAGER, MASTER)"),
+    SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "USER-007", "새 비밀번호가 기존 비밀번호와 동일합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/com/sparta/delivery/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/sparta/delivery/auth/application/AuthServiceTest.java
@@ -122,4 +122,14 @@ class AuthServiceTest {
         verify(jwtProvider).generateToken(1L, "MANAGER", 5);
     }
 
+    @Test
+    @DisplayName("로그아웃 - userService.forceLogout 위임 호출")
+    void logout_delegates_to_userService() {
+        // when
+        authService.logout(1L);
+
+        // then : 위임만 검증. tokenVersion 증가 검증은 UserServiceTest 에서 담당.
+        verify(userService).forceLogout(1L);
+    }
+
 }

--- a/src/test/java/com/sparta/delivery/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/sparta/delivery/auth/application/AuthServiceTest.java
@@ -11,6 +11,7 @@ import com.sparta.delivery.user.presentation.dto.LoginRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/src/test/java/com/sparta/delivery/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/sparta/delivery/auth/application/AuthServiceTest.java
@@ -23,8 +23,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.*;
 
 /**
  * AuthService 단위 테스트.
@@ -130,6 +130,49 @@ class AuthServiceTest {
 
         // then : 위임만 검증. tokenVersion 증가 검증은 UserServiceTest 에서 담당.
         verify(userService).forceLogout(1L);
+    }
+
+    @Test
+    @DisplayName("로그인 호출 순서 - 비번 검증 → 토큰 발급 → lastLoginAt 갱신")
+    void login_call_order() {
+        // given
+        User user = createUser(1L, "alice@test.com", UserRole.CUSTOMER, "ENCODED", 0);
+        LoginRequest req = new LoginRequest("alice@test.com", "rawPw");
+        given(userService.findByEmail("alice@test.com")).willReturn(user);
+        given(passwordEncoder.matches("rawPw", "ENCODED")).willReturn(true);
+        given(jwtProvider.generateToken(1L, "CUSTOMER", 0)).willReturn("JWT");
+        given(jwtProvider.getExpirationMs()).willReturn(3600000L);
+
+        // when
+        authService.login(req);
+
+        // then : 비번 통과 전에 토큰이 발급되거나 lastLoginAt 이 갱신되는 회귀를 잡는다.
+        InOrder inOrder = inOrder(passwordEncoder, jwtProvider, userService);
+        inOrder.verify(passwordEncoder).matches("rawPw", "ENCODED");
+        inOrder.verify(jwtProvider).generateToken(1L, "CUSTOMER", 0);
+        inOrder.verify(userService).updateLastLoginAt(1L);
+    }
+
+    @Test
+    @DisplayName("로그아웃 - userService.forceLogout 정확히 1회 호출 + 다른 협력자 무호출")
+    void logout_called_once_only() {
+        // when
+        authService.logout(1L);
+
+        // then : 로그아웃은 토큰/비번 관련 협력자를 건드리지 않아야 한다.
+        verify(userService, times(1)).forceLogout(1L);
+        verifyNoInteractions(passwordEncoder, jwtProvider);
+    }
+
+    @Test
+    @DisplayName("로그아웃 - forceLogout 에서 예외 발생 시 그대로 전파 (catch 금지)")
+    void logout_propagates_exception() {
+        // given : 존재하지 않는 유저 → UserService 가 던지는 예외
+        willThrow(new UserNotFoundException()).given(userService).forceLogout(999L);
+
+        // when / then : AuthService 가 임의로 변환/삼키지 않음
+        assertThatThrownBy(() -> authService.logout(999L))
+                .isInstanceOf(UserNotFoundException.class);
     }
 
 }

--- a/src/test/java/com/sparta/delivery/user/application/UserServiceTest.java
+++ b/src/test/java/com/sparta/delivery/user/application/UserServiceTest.java
@@ -290,4 +290,35 @@ class UserServiceTest {
         }
     }
 
+    // 강제 로그아웃 (tokenVersion 증가)
+    @Nested
+    @DisplayName("강제 로그아웃 (forceLogout)")
+    class ForceLogout {
+
+        @Test
+        @DisplayName("정상 호출 - tokenVersion 1 증가")
+        void success() {
+            // given : tv=3 인 유저
+            User user = createUser(1L, "alice@test.com", UserRole.CUSTOMER, "ENCODED");
+            ReflectionTestUtils.setField(user, "tokenVersion", 3);
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+            // when
+            userService.forceLogout(1L);
+
+            // then : 동일 객체 상태로 확인 (도메인 메서드가 처리)
+            assertThat(user.getTokenVersion()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저 - UserNotFoundException")
+        void user_not_found() {
+            // given : findById 가 empty
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userService.forceLogout(999L))
+                    .isInstanceOf(UserNotFoundException.class);
+        }
+    }
 }

--- a/src/test/java/com/sparta/delivery/user/application/UserServiceTest.java
+++ b/src/test/java/com/sparta/delivery/user/application/UserServiceTest.java
@@ -2,10 +2,7 @@ package com.sparta.delivery.user.application;
 
 import com.sparta.delivery.user.domain.entity.User;
 import com.sparta.delivery.user.domain.entity.UserRole;
-import com.sparta.delivery.user.domain.exception.DuplicateEmailException;
-import com.sparta.delivery.user.domain.exception.ForbiddenRoleChangeException;
-import com.sparta.delivery.user.domain.exception.InvalidPasswordException;
-import com.sparta.delivery.user.domain.exception.UserNotFoundException;
+import com.sparta.delivery.user.domain.exception.*;
 import com.sparta.delivery.user.domain.repository.UserRepository;
 import com.sparta.delivery.user.presentation.dto.PasswordChangeRequest;
 import com.sparta.delivery.user.presentation.dto.RoleChangeRequest;
@@ -130,6 +127,26 @@ class UserServiceTest {
                      .isInstanceOf(InvalidPasswordException.class);
              verify(passwordEncoder, never()).encode(anyString());
          }
+
+         @Test
+         @DisplayName("새 비밀번호가 기존과 동일하면 SamePasswordException")
+         void same_as_old_password() {
+             // given : 동일 raw 비번으로 변경 시도. matches 가 두 번 호출되며 같은 인자에 같은 true.
+             User user = createUser(1L, "alice@test.com", UserRole.CUSTOMER, "OLD_ENCODED");
+             given(userRepository.findById(1L)).willReturn(Optional.of(user));
+             given(passwordEncoder.matches("Pass1234!", "OLD_ENCODED")).willReturn(true);
+
+             // when / then
+             assertThatThrownBy(() ->
+                     userService.changePassword(1L, new PasswordChangeRequest("Pass1234!", "Pass1234!")))
+                     .isInstanceOf(SamePasswordException.class);
+
+             // 인코딩/실제 변경 모두 일어나지 않음 — tokenVersion 불변
+             verify(passwordEncoder, never()).encode(anyString());
+             assertThat(user.getPassword()).isEqualTo("OLD_ENCODED");
+             assertThat(user.getTokenVersion()).isEqualTo(0);
+         }
+
      }
 
      // 탈퇴


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #  <!-- 이슈 번호 기재 -->

## ✨ 기능 요약

| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Auth/User 보안 보강 (로그아웃 + 비밀번호 변경 정책) |
| 🔍 목적 | 기존 토큰을 명시적으로 무효화할 수단 부재 + 비번 변경 시 동일 비번 허용으로 회전 효과 무력화 → 보안 위생 강화 |
| 🛠️ 변경사항 | `/auth/logout` 엔드포인트 신규 / `UserService.forceLogout` 추가 / `changePassword` 에 동일 비번 차단 / 관련 단위 테스트 보강 / SecurityConfig·JwtAuthenticationFilter 화이트리스트 정밀화 |

## 📝 상세 내역

| 번호 | 내용 |
|------|------|
| 1️⃣ | **로그아웃 구현** — `AuthController.logout` → `AuthService.logout` → `UserService.forceLogout(userId)` 위임 구조. 내부적으로 `User.incrementTokenVersion()` 호출 → JWT claim `tv` 와 DB 값 불일치로 기존 토큰 전부 무효화. (현재 구조상 "전 디바이스 로그아웃" 만 가능, 디바이스 단위 분리는 RT 도입 시 재설계 예정) |
| 2️⃣ | **인증 화이트리스트 정밀화** — `SecurityConfig` 의 `/api/v1/auth/**` permitAll 을 `POST /api/v1/auth/login` 으로 좁히고, `JwtAuthenticationFilter.shouldNotFilter` 도 동일하게 enumerate. `/auth/logout` 이 필터를 타고 `@AuthenticationPrincipal` 가 채워지도록 보장. |
| 3️⃣ | **비밀번호 변경 정책 강화** — `UserService.changePassword` 에 "새 비번 == 기존 비번" 차단 추가. `passwordEncoder.matches(newPw, oldHash)` 로 BCrypt salt 우회. 신규 예외 `SamePasswordException` (USER-007 / 400). |
| 4️⃣ | **단위 테스트 보강** — `UserServiceTest.ChangePassword` 동일 비번 케이스 / `UserServiceTest.ForceLogout` 정상·NotFound 케이스 / `AuthServiceTest` InOrder 호출 순서 검증·로그아웃 호출 횟수·예외 전파 케이스 추가. |

---

## ✅ 테스트 체크리스트
- [x] 로그인 → 토큰 발급 정상
- [x] 로그아웃 호출 → 동일 토큰으로 `/users/me` 재호출 시 401 (TOKEN_VERSION_MISMATCH)
- [x] 토큰 없이 `/auth/logout` 호출 시 401 (permitAll 회귀 방지)
- [x] 회원가입 (`POST /users/signup`) 무인증 200 — 회귀 없음
- [x] 비번 변경 시 새 비번 == 기존 비번이면 400 + USER-007
- [x] 비번 변경 정상 동작 시 `tokenVersion` +1
- [x] `./gradlew test` 전체 통과
- [x] 단위 테스트 작성 완료 (UserServiceTest, AuthServiceTest)

---

## 🙋‍♀️ 리뷰어 참고사항

### 변경된 외부 영향
- **다른 도메인 백엔드 코드는 영향 없음** — 다른 도메인은 `UserRole` enum 만 import. `User` 엔티티/`AuthService`/`JwtProvider`/`LoginResponse` 외부 import 0건 확인.
- **API 명세 추가**: `POST /api/v1/auth/logout` (인증 필요, 응답 200 + ApiResponse.ok)
- **에러 코드 추가**: `USER-007` (SAME_AS_OLD_PASSWORD, 400)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자가 로그아웃할 수 있는 기능 추가(기존 토큰 일괄 무효화).

* **개선사항**
  * 비밀번호 변경 시 기존 비밀번호와 동일한 신규 비밀번호 입력 차단 및 전용 오류 처리 추가.
  * 로그아웃 엔드포인트는 인증된 사용자만 접근 가능하도록 보안 강화.
  * 공개 접근은 로그인 엔드포인트로 제한.

* **테스트**
  * 로그아웃·비밀번호 변경 관련 단위 테스트 추가 및 검증 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->