### PR TITLE
feat: Region 검증 보완 및 페이지네이션 적용 

### DIFF
--- a/src/main/java/com/sparta/delivery/region/application/RegionService.java
+++ b/src/main/java/com/sparta/delivery/region/application/RegionService.java
@@ -1,5 +1,6 @@
 package com.sparta.delivery.region.application;
 
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.region.domain.entity.Region;
 import com.sparta.delivery.region.domain.exception.DuplicateRegionCodeException;
 import com.sparta.delivery.region.domain.exception.InvalidParentRegionException;
@@ -15,6 +16,8 @@ import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,15 +65,13 @@ public class RegionService {
     }
 
     /** keyword가 있으면 지역명으로 검색하고, 없으면 전체 지역 목록을 조회한다. */
-    public List<RegionResponse> searchRegions(String keyword) {
+    public PageResponse<RegionResponse> searchRegions(String keyword, Pageable pageable) {
         String normalizedKeyword = keyword == null ? null : keyword.trim();
-        List<Region> regions = (normalizedKeyword == null || normalizedKeyword.isBlank())
-                ? regionRepository.findAll()
-                : regionRepository.findByRegionNameContaining(normalizedKeyword);
+        Page<Region> page = (normalizedKeyword == null || normalizedKeyword.isBlank())
+                ? regionRepository.findAll(pageable)
+                : regionRepository.findByRegionNameContaining(normalizedKeyword, pageable);
 
-        return regions.stream()
-                .map(RegionResponse::from)
-                .toList();
+        return PageResponse.from(page.map(RegionResponse::from));
     }
 
     /** 최상위 지역 목록 조회 */

--- a/src/main/java/com/sparta/delivery/region/application/RegionService.java
+++ b/src/main/java/com/sparta/delivery/region/application/RegionService.java
@@ -11,6 +11,7 @@ import com.sparta.delivery.region.presentation.dto.RegionCreateRequest;
 import com.sparta.delivery.region.presentation.dto.RegionResponse;
 import com.sparta.delivery.region.presentation.dto.RegionUpdateRequest;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -97,6 +98,7 @@ public class RegionService {
             throw new InvalidParentRegionException();
         }
 
+        validateRegionHierarchyChange(region, request.parentId(), request.depth());
         validateParentAndDepth(request.parentId(), request.depth());
 
         region.update(
@@ -142,13 +144,22 @@ public class RegionService {
 
     /** 지역 코드 중복 검사 */
     private void validateDuplicateRegionCode(String regionCode) {
-        if (regionRepository.existsByRegionCode(regionCode)) {
+        if (regionRepository.existsByRegionCodeIncludingDeleted(regionCode)) {
             throw new DuplicateRegionCodeException();
         }
     }
 
     private String normalize(String value) {
         return value == null ? null : value.trim();
+    }
+
+    private void validateRegionHierarchyChange(Region region, UUID parentId, Integer depth) {
+        boolean hierarchyChanged = !Objects.equals(region.getParentId(), parentId)
+                || !region.getDepth().equals(depth);
+
+        if (hierarchyChanged && !regionRepository.findByParentId(region.getRegionId()).isEmpty()) {
+            throw new RegionHasChildrenException();
+        }
     }
 
     /** 부모 지역과 depth 규칙 검사 */

--- a/src/main/java/com/sparta/delivery/region/domain/repository/RegionRepository.java
+++ b/src/main/java/com/sparta/delivery/region/domain/repository/RegionRepository.java
@@ -5,10 +5,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RegionRepository extends JpaRepository<Region, UUID> {
 
     boolean existsByRegionCode(String regionCode);
+
+    @Query(
+            value = "select exists (select 1 from p_region where region_code = :regionCode)",
+            nativeQuery = true
+    )
+    boolean existsByRegionCodeIncludingDeleted(@Param("regionCode") String regionCode);
 
     Optional<Region> findByRegionId(UUID regionId);
 

--- a/src/main/java/com/sparta/delivery/region/domain/repository/RegionRepository.java
+++ b/src/main/java/com/sparta/delivery/region/domain/repository/RegionRepository.java
@@ -4,6 +4,8 @@ import com.sparta.delivery.region.domain.entity.Region;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,7 +24,7 @@ public interface RegionRepository extends JpaRepository<Region, UUID> {
 
     Optional<Region> findByRegionCode(String regionCode);
 
-    List<Region> findByRegionNameContaining(String keyword);
+    Page<Region> findByRegionNameContaining(String keyword, Pageable pageable);
 
     List<Region> findByParentId(UUID parentId);
 

--- a/src/main/java/com/sparta/delivery/region/presentation/RegionController.java
+++ b/src/main/java/com/sparta/delivery/region/presentation/RegionController.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.region.presentation;
 
 import com.sparta.delivery.common.config.security.UserPrincipal;
 import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.region.application.RegionService;
 import com.sparta.delivery.region.presentation.dto.RegionCreateRequest;
 import com.sparta.delivery.region.presentation.dto.RegionResponse;
@@ -12,6 +13,9 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -55,10 +59,12 @@ public class RegionController {
 
     @Operation(summary = "지역 목록 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<RegionResponse>>> searchRegions(
-            @RequestParam(required = false) String keyword
+    public ResponseEntity<ApiResponse<PageResponse<RegionResponse>>> searchRegions(
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
     ) {
-        return ResponseEntity.ok(ApiResponse.success(regionService.searchRegions(keyword)));
+        return ResponseEntity.ok(ApiResponse.success(regionService.searchRegions(keyword, pageable)));
     }
 
     @Operation(summary = "최상위 지역 목록 조회")

--- a/src/test/java/com/sparta/delivery/region/application/RegionServiceTest.java
+++ b/src/test/java/com/sparta/delivery/region/application/RegionServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.region.domain.entity.Region;
 import com.sparta.delivery.region.domain.exception.DuplicateRegionCodeException;
 import com.sparta.delivery.region.domain.exception.InvalidParentRegionException;
@@ -26,6 +27,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class RegionServiceTest {
@@ -52,7 +56,7 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.existsByRegionCode("1100000000")).willReturn(false);
+            given(regionRepository.existsByRegionCodeIncludingDeleted("1100000000")).willReturn(false);
             given(regionRepository.save(any(Region.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -66,7 +70,7 @@ class RegionServiceTest {
             assertThat(response.depth()).isEqualTo(1);
             assertThat(response.isActive()).isTrue();
 
-            then(regionRepository).should().existsByRegionCode("1100000000");
+            then(regionRepository).should().existsByRegionCodeIncludingDeleted("1100000000");
             then(regionRepository).should().save(any(Region.class));
         }
 
@@ -92,7 +96,7 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.existsByRegionCode("1111000000")).willReturn(false);
+            given(regionRepository.existsByRegionCodeIncludingDeleted("1111000000")).willReturn(false);
             given(regionRepository.findByRegionId(parentId)).willReturn(Optional.of(parent));
             given(regionRepository.save(any(Region.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
@@ -107,7 +111,7 @@ class RegionServiceTest {
             assertThat(response.depth()).isEqualTo(2);
             assertThat(response.isActive()).isTrue();
 
-            then(regionRepository).should().existsByRegionCode("1111000000");
+            then(regionRepository).should().existsByRegionCodeIncludingDeleted("1111000000");
             then(regionRepository).should().findByRegionId(parentId);
             then(regionRepository).should().save(any(Region.class));
         }
@@ -124,14 +128,14 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.existsByRegionCode("1100000000")).willReturn(true);
+            given(regionRepository.existsByRegionCodeIncludingDeleted("1100000000")).willReturn(true);
 
             // when & then
             assertThatThrownBy(() -> regionService.createRegion(request))
                     .isInstanceOf(DuplicateRegionCodeException.class)
                     .hasMessageContaining("지역 코드");
 
-            then(regionRepository).should().existsByRegionCode("1100000000");
+            then(regionRepository).should().existsByRegionCodeIncludingDeleted("1100000000");
             then(regionRepository).should(never()).save(any());
         }
 
@@ -147,14 +151,14 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.existsByRegionCode("1100000000")).willReturn(false);
+            given(regionRepository.existsByRegionCodeIncludingDeleted("1100000000")).willReturn(false);
 
             // when & then
             assertThatThrownBy(() -> regionService.createRegion(request))
                     .isInstanceOf(InvalidRegionDepthException.class)
                     .hasMessageContaining("depth");
 
-            then(regionRepository).should().existsByRegionCode("1100000000");
+            then(regionRepository).should().existsByRegionCodeIncludingDeleted("1100000000");
             then(regionRepository).should(never()).save(any());
         }
 
@@ -172,7 +176,7 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.existsByRegionCode("1111000000")).willReturn(false);
+            given(regionRepository.existsByRegionCodeIncludingDeleted("1111000000")).willReturn(false);
             given(regionRepository.findByRegionId(parentId)).willReturn(Optional.empty());
 
             // when & then
@@ -180,7 +184,7 @@ class RegionServiceTest {
                     .isInstanceOf(InvalidParentRegionException.class)
                     .hasMessageContaining("상위");
 
-            then(regionRepository).should().existsByRegionCode("1111000000");
+            then(regionRepository).should().existsByRegionCodeIncludingDeleted("1111000000");
             then(regionRepository).should().findByRegionId(parentId);
             then(regionRepository).should(never()).save(any());
         }
@@ -207,7 +211,7 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.existsByRegionCode("1111000000")).willReturn(false);
+            given(regionRepository.existsByRegionCodeIncludingDeleted("1111000000")).willReturn(false);
             given(regionRepository.findByRegionId(parentId)).willReturn(Optional.of(parent));
 
             // when & then
@@ -215,7 +219,7 @@ class RegionServiceTest {
                     .isInstanceOf(InvalidRegionDepthException.class)
                     .hasMessageContaining("depth");
 
-            then(regionRepository).should().existsByRegionCode("1111000000");
+            then(regionRepository).should().existsByRegionCodeIncludingDeleted("1111000000");
             then(regionRepository).should().findByRegionId(parentId);
             then(regionRepository).should(never()).save(any());
         }
@@ -287,18 +291,22 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.findAll()).willReturn(List.of(seoul, busan));
+            Pageable pageable = PageRequest.of(0, 10);
+            given(regionRepository.findAll(pageable))
+                    .willReturn(new PageImpl<>(List.of(seoul, busan), pageable, 2));
 
             // when
-            var responses = regionService.searchRegions(null);
+            PageResponse<?> responses = regionService.searchRegions(null, pageable);
 
             // then
-            assertThat(responses).hasSize(2);
-            assertThat(responses)
+            assertThat(responses.content()).hasSize(2);
+            assertThat(responses.content())
                     .extracting("regionName")
                     .containsExactly("서울특별시", "부산광역시");
+            assertThat(responses.page()).isEqualTo(0);
+            assertThat(responses.size()).isEqualTo(10);
 
-            then(regionRepository).should().findAll();
+            then(regionRepository).should().findAll(pageable);
         }
 
         @Test
@@ -315,18 +323,19 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.findByRegionNameContaining("종로"))
-                    .willReturn(List.of(jongno));
+            Pageable pageable = PageRequest.of(0, 10);
+            given(regionRepository.findByRegionNameContaining("종로", pageable))
+                    .willReturn(new PageImpl<>(List.of(jongno), pageable, 1));
 
             // when
-            var responses = regionService.searchRegions("종로");
+            var responses = regionService.searchRegions("종로", pageable);
 
             // then
-            assertThat(responses).hasSize(1);
-            assertThat(responses.get(0).regionName()).isEqualTo("종로구");
-            assertThat(responses.get(0).parentId()).isEqualTo(parentId);
+            assertThat(responses.content()).hasSize(1);
+            assertThat(responses.content().get(0).regionName()).isEqualTo("종로구");
+            assertThat(responses.content().get(0).parentId()).isEqualTo(parentId);
 
-            then(regionRepository).should().findByRegionNameContaining("종로");
+            then(regionRepository).should().findByRegionNameContaining("종로", pageable);
         }
 
         @Test
@@ -341,17 +350,18 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.findByRegionNameContaining("종로"))
-                    .willReturn(List.of(jongno));
+            Pageable pageable = PageRequest.of(0, 10);
+            given(regionRepository.findByRegionNameContaining("종로", pageable))
+                    .willReturn(new PageImpl<>(List.of(jongno), pageable, 1));
 
             // when
-            var responses = regionService.searchRegions(" 종로 ");
+            var responses = regionService.searchRegions(" 종로 ", pageable);
 
             // then
-            assertThat(responses).hasSize(1);
-            assertThat(responses.get(0).regionName()).isEqualTo("종로구");
+            assertThat(responses.content()).hasSize(1);
+            assertThat(responses.content().get(0).regionName()).isEqualTo("종로구");
 
-            then(regionRepository).should().findByRegionNameContaining("종로");
+            then(regionRepository).should().findByRegionNameContaining("종로", pageable);
         }
 
         @Test

--- a/src/test/java/com/sparta/delivery/region/presentation/RegionControllerTest.java
+++ b/src/test/java/com/sparta/delivery/region/presentation/RegionControllerTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationEntryPoint;
 import com.sparta.delivery.auth.infrastructure.jwt.JwtProvider;
 import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.region.application.RegionService;
 import com.sparta.delivery.region.presentation.dto.RegionCreateRequest;
 import com.sparta.delivery.region.presentation.dto.RegionResponse;
@@ -33,6 +34,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 @WebMvcTest(RegionController.class)
 class RegionControllerTest {
@@ -137,7 +140,8 @@ class RegionControllerTest {
                     true
             );
 
-            given(regionService.searchRegions("서울")).willReturn(List.of(response));
+            given(regionService.searchRegions("서울", PageRequest.of(0, 10, Sort.Direction.DESC, "createdAt")))
+                    .willReturn(new PageResponse<>(List.of(response), 0, 10, 1, 1, true));
 
             // when & then
             mockMvc.perform(get("/api/v1/regions")
@@ -145,10 +149,15 @@ class RegionControllerTest {
                             .with(authentication(managerAuthentication())))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data[0].regionCode").value("1100000000"))
-                    .andExpect(jsonPath("$.data[0].regionName").value("서울특별시"));
+                    .andExpect(jsonPath("$.data.content[0].regionCode").value("1100000000"))
+                    .andExpect(jsonPath("$.data.content[0].regionName").value("서울특별시"))
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(10));
 
-            then(regionService).should().searchRegions("서울");
+            then(regionService).should().searchRegions(
+                    "서울",
+                    PageRequest.of(0, 10, Sort.Direction.DESC, "createdAt")
+            );
         }
 
         @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #72

## ✨ 기능 요약
Region 도메인의 검증 로직을 보완하고, 지역 목록 조회를 페이지네이션 방식으로 개선했습니다.

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | soft delete된 지역까지 포함하도록 `regionCode` 중복 검사 기준을 보완했습니다. |
| 2️⃣ | `RegionRepository`에 deleted 데이터 포함 중복 검사 메서드를 추가하고, 서비스 중복 검사 로직에 반영했습니다. |
| 3️⃣ | 자식 지역이 존재하는 경우 `parentId` 또는 `depth` 변경을 제한하는 계층 검증 로직을 추가했습니다. |
| 4️⃣ | 지역 목록 조회를 `Pageable + PageResponse` 기반 페이지네이션 구조로 전환했습니다. |
| 5️⃣ | `keyword` 지역명 검색도 페이지 응답 형식으로 조회되도록 `RegionService` / `RegionController`를 수정했습니다. |
| 6️⃣ | Region 서비스/컨트롤러 테스트를 변경 구조에 맞게 수정하고 검증했습니다. |

---

## ✅ 테스트 체크리스트
- [x] RegionService 테스트 수정 및 통과
- [x] RegionController 테스트 수정 및 통과
- [x] soft delete 포함 중복 검사 동작 확인
- [x] 자식 지역 존재 시 계층 변경 제한 로직 확인


---


## 🙋‍♀️ 리뷰어 참고사항
- 지역 목록 조회 기본값은 `size=10`, `sort=createdAt,DESC`입니다.
- `keyword`가 없으면 전체 지역 목록을 페이지 단위로 조회하고, 있으면 지역명 포함 검색 결과를 페이지 단위로 반환합니다.
- `regionCode` 중복 검사는 soft delete 데이터까지 포함해 DB unique 제약 기준과 일치시켰습니다.
- 자식 지역이 존재하는 경우 `parentId` 또는 `depth` 변경은 허용하지 않습니다.
- 확인한 테스트 명령은 아래와 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지역 검색에 페이지 매김 기능 추가
  * 기본값으로 생성 날짜 기준 정렬 적용

* **버그 수정**
  * 삭제된 지역 코드를 포함한 중복 검증 강화
  * 하위 지역이 있을 때 상위 지역 및 깊이 변경 방지 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->