### PR TITLE
feat: StoreCategory 조회 정책 분리 및 페이지네이션 적용

### DIFF
--- a/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
@@ -1,5 +1,6 @@
 package com.sparta.delivery.store.application;
 
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.store.domain.entity.StoreCategory;
 import com.sparta.delivery.store.domain.exception.DuplicateCategoryNameException;
 import com.sparta.delivery.store.domain.exception.DuplicateCategorySortOrderException;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -62,18 +65,28 @@ public class StoreCategoryService {
         }
     }
 
-    /** 가게 카테고리 목록을 조회한다. */
-    public List<StoreCategoryResponse> getCategories() {
-        return storeCategoryRepository.findAllByOrderBySortOrderAsc().stream()
-                .map(StoreCategoryResponse::from)
-                .toList();
+    /** 활성화된 가게 카테고리 목록을 조회한다. */
+    public PageResponse<StoreCategoryResponse> getCategories(Pageable pageable) {
+        Page<StoreCategoryResponse> page = storeCategoryRepository.findAllByIsActiveTrue(pageable)
+                .map(StoreCategoryResponse::from);
+
+        return PageResponse.from(page);
     }
 
-    /** 활성화된 가게 카테고리 목록을 조회한다. */
-    public List<StoreCategoryResponse> getActiveCategories() {
-        return storeCategoryRepository.findAllByIsActiveTrueOrderBySortOrderAsc().stream()
-                .map(StoreCategoryResponse::from)
-                .toList();
+    /** 비활성화된 가게 카테고리 목록을 조회한다. */
+    public PageResponse<StoreCategoryResponse> getInactiveCategories(Pageable pageable) {
+        Page<StoreCategoryResponse> page = storeCategoryRepository.findAllByIsActiveFalse(pageable)
+                .map(StoreCategoryResponse::from);
+
+        return PageResponse.from(page);
+    }
+
+    /** 전체 가게 카테고리 목록을 조회한다. */
+    public PageResponse<StoreCategoryResponse> getAllCategories(Pageable pageable) {
+        Page<StoreCategoryResponse> page = storeCategoryRepository.findAll(pageable)
+                .map(StoreCategoryResponse::from);
+
+        return PageResponse.from(page);
     }
 
     /** 가게 카테고리를 단건 조회한다. */

--- a/src/main/java/com/sparta/delivery/store/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/delivery/store/domain/repository/StoreCategoryRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.Lock;
@@ -34,7 +35,7 @@ public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UU
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<StoreCategory> findAllByOrderBySortOrderDesc(Pageable pageable);
 
-    List<StoreCategory> findAllByOrderBySortOrderAsc();
+    Page<StoreCategory> findAllByIsActiveFalse(Pageable pageable);
 
-    List<StoreCategory> findAllByIsActiveTrueOrderBySortOrderAsc();
+    Page<StoreCategory> findAllByIsActiveTrue(Pageable pageable);
 }

--- a/src/main/java/com/sparta/delivery/store/presentation/StoreCategoryController.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/StoreCategoryController.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.store.presentation;
 
 import com.sparta.delivery.common.config.security.UserPrincipal;
 import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.store.application.StoreCategoryService;
 import com.sparta.delivery.store.presentation.dto.StoreCategoryCreateRequest;
 import com.sparta.delivery.store.presentation.dto.StoreCategoryResponse;
@@ -12,6 +13,9 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -44,16 +48,33 @@ public class StoreCategoryController {
                 .body(ApiResponse.created(storeCategoryService.createCategory(request)));
     }
 
-    @Operation(summary = "가게 카테고리 목록 조회")
+    @Operation(summary = "활성 가게 카테고리 목록 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<StoreCategoryResponse>>> getCategories() {
-        return ResponseEntity.ok(ApiResponse.success(storeCategoryService.getCategories()));
+    public ResponseEntity<ApiResponse<PageResponse<StoreCategoryResponse>>> getCategories(
+            @PageableDefault(size = 10, sort = "sortOrder", direction = Sort.Direction.ASC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(storeCategoryService.getCategories(pageable)));
     }
 
-    @Operation(summary = "활성 가게 카테고리 목록 조회")
-    @GetMapping("/active")
-    public ResponseEntity<ApiResponse<List<StoreCategoryResponse>>> getActiveCategories() {
-        return ResponseEntity.ok(ApiResponse.success(storeCategoryService.getActiveCategories()));
+    @Operation(summary = "비활성 가게 카테고리 목록 조회")
+    @GetMapping("/inactive")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<PageResponse<StoreCategoryResponse>>> getInactiveCategories(
+            @PageableDefault(size = 10, sort = "sortOrder", direction = Sort.Direction.ASC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(storeCategoryService.getInactiveCategories(pageable)));
+    }
+
+    @Operation(summary = "전체 가게 카테고리 목록 조회")
+    @GetMapping("/all")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<PageResponse<StoreCategoryResponse>>> getAllCategories(
+            @PageableDefault(size = 10, sort = "sortOrder", direction = Sort.Direction.ASC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(storeCategoryService.getAllCategories(pageable)));
     }
 
     @Operation(summary = "가게 카테고리 단건 조회")

--- a/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
@@ -7,12 +7,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.store.domain.entity.StoreCategory;
 import com.sparta.delivery.store.domain.exception.DuplicateCategoryNameException;
 import com.sparta.delivery.store.domain.exception.DuplicateCategorySortOrderException;
 import com.sparta.delivery.store.domain.exception.StoreCategoryNotFoundException;
 import com.sparta.delivery.store.domain.repository.StoreCategoryRepository;
 import com.sparta.delivery.store.presentation.dto.StoreCategoryCreateRequest;
+import com.sparta.delivery.store.presentation.dto.StoreCategoryResponse;
 import com.sparta.delivery.store.presentation.dto.StoreCategoryUpdateRequest;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +26,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -162,32 +166,60 @@ class StoreCategoryServiceTest {
             // given
             StoreCategory chicken = createCategory(UUID.randomUUID(), "치킨", 1, true);
             StoreCategory pizza = createCategory(UUID.randomUUID(), "피자", 2, true);
+            Pageable pageable = PageRequest.of(0, 10);
 
-            given(storeCategoryRepository.findAllByOrderBySortOrderAsc()).willReturn(List.of(chicken, pizza));
+            given(storeCategoryRepository.findAllByIsActiveTrue(pageable))
+                    .willReturn(new PageImpl<>(List.of(chicken, pizza), pageable, 2));
 
             // when
-            var responses = storeCategoryService.getCategories();
+            PageResponse<StoreCategoryResponse> responses = storeCategoryService.getCategories(pageable);
 
             // then
-            assertThat(responses).hasSize(2);
-            assertThat(responses.get(0).categoryName()).isEqualTo("치킨");
-            assertThat(responses.get(1).categoryName()).isEqualTo("피자");
+            assertThat(responses.content()).hasSize(2);
+            assertThat(responses.content().get(0).categoryName()).isEqualTo("치킨");
+            assertThat(responses.content().get(1).categoryName()).isEqualTo("피자");
+            assertThat(responses.page()).isEqualTo(0);
+            assertThat(responses.size()).isEqualTo(10);
         }
 
         @Test
-        @DisplayName("활성 카테고리 목록을 조회한다")
-        void getActiveCategories_success() {
+        @DisplayName("비활성 카테고리 목록을 조회한다")
+        void getInactiveCategories_success() {
             // given
-            StoreCategory chicken = createCategory(UUID.randomUUID(), "치킨", 1, true);
+            StoreCategory chicken = createCategory(UUID.randomUUID(), "치킨", 1, false);
+            Pageable pageable = PageRequest.of(0, 10);
 
-            given(storeCategoryRepository.findAllByIsActiveTrueOrderBySortOrderAsc()).willReturn(List.of(chicken));
+            given(storeCategoryRepository.findAllByIsActiveFalse(pageable))
+                    .willReturn(new PageImpl<>(List.of(chicken), pageable, 1));
 
             // when
-            var responses = storeCategoryService.getActiveCategories();
+            PageResponse<StoreCategoryResponse> responses = storeCategoryService.getInactiveCategories(pageable);
 
             // then
-            assertThat(responses).hasSize(1);
-            assertThat(responses.get(0).categoryName()).isEqualTo("치킨");
+            assertThat(responses.content()).hasSize(1);
+            assertThat(responses.content().get(0).categoryName()).isEqualTo("치킨");
+            assertThat(responses.content().get(0).isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("전체 카테고리 목록을 조회한다")
+        void getAllCategories_success() {
+            // given
+            StoreCategory chicken = createCategory(UUID.randomUUID(), "치킨", 1, true);
+            StoreCategory pizza = createCategory(UUID.randomUUID(), "피자", 2, false);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(storeCategoryRepository.findAll(pageable))
+                    .willReturn(new PageImpl<>(List.of(chicken, pizza), pageable, 2));
+
+            // when
+            PageResponse<StoreCategoryResponse> responses = storeCategoryService.getAllCategories(pageable);
+
+            // then
+            assertThat(responses.content()).hasSize(2);
+            assertThat(responses.content())
+                    .extracting(StoreCategoryResponse::isActive)
+                    .containsExactly(true, false);
         }
     }
 

--- a/src/test/java/com/sparta/delivery/store/presentation/StoreCategoryControllerTest.java
+++ b/src/test/java/com/sparta/delivery/store/presentation/StoreCategoryControllerTest.java
@@ -20,6 +20,7 @@ import com.sparta.delivery.auth.infrastructure.jwt.JwtAuthenticationFilter;
 import com.sparta.delivery.auth.infrastructure.jwt.JwtProvider;
 import com.sparta.delivery.common.config.security.SecurityConfig;
 import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.store.application.StoreCategoryService;
 import com.sparta.delivery.store.presentation.dto.StoreCategoryCreateRequest;
 import com.sparta.delivery.store.presentation.dto.StoreCategoryResponse;
@@ -37,6 +38,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -145,7 +148,7 @@ class StoreCategoryControllerTest {
     class GetCategoryApiTest {
 
         @Test
-        @DisplayName("가게 카테고리 목록을 조회한다")
+        @DisplayName("활성 가게 카테고리 목록을 조회한다")
         void getCategories_success() throws Exception {
             // given
             StoreCategoryResponse response = new StoreCategoryResponse(
@@ -156,23 +159,67 @@ class StoreCategoryControllerTest {
                     true
             );
 
-            given(storeCategoryService.getCategories()).willReturn(List.of(response));
+            given(storeCategoryService.getCategories(PageRequest.of(0, 10, Sort.Direction.ASC, "sortOrder")))
+                    .willReturn(new PageResponse<>(List.of(response), 0, 10, 1, 1, true));
 
             // when & then
             mockMvc.perform(get("/api/v1/store-categories")
                             .with(authentication(customerAuthentication())))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data[0].categoryName").value("치킨"))
-                    .andExpect(jsonPath("$.data[0].sortOrder").value(1));
+                    .andExpect(jsonPath("$.data.content[0].categoryName").value("치킨"))
+                    .andExpect(jsonPath("$.data.content[0].sortOrder").value(1))
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(10));
 
-            then(storeCategoryService).should().getCategories();
+            then(storeCategoryService).should().getCategories(
+                    PageRequest.of(0, 10, Sort.Direction.ASC, "sortOrder")
+            );
         }
 
         @Test
-        @DisplayName("활성 가게 카테고리 목록을 조회한다")
-        void getActiveCategories_success() throws Exception {
+        @DisplayName("MANAGER 권한이면 비활성 가게 카테고리 목록을 조회한다")
+        void getInactiveCategories_success() throws Exception {
             // given
+            StoreCategoryResponse response = new StoreCategoryResponse(
+                    UUID.randomUUID(),
+                    "치킨",
+                    "치킨 카테고리",
+                    1,
+                    false
+            );
+
+            given(storeCategoryService.getInactiveCategories(PageRequest.of(0, 10, Sort.Direction.ASC, "sortOrder")))
+                    .willReturn(new PageResponse<>(List.of(response), 0, 10, 1, 1, true));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/store-categories/inactive")
+                            .with(authentication(managerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content[0].categoryName").value("치킨"))
+                    .andExpect(jsonPath("$.data.content[0].isActive").value(false))
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(10));
+
+            then(storeCategoryService).should().getInactiveCategories(
+                    PageRequest.of(0, 10, Sort.Direction.ASC, "sortOrder")
+            );
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한이면 비활성 가게 카테고리 목록을 조회할 수 없다")
+        void getInactiveCategories_fail_whenCustomer() throws Exception {
+            mockMvc.perform(get("/api/v1/store-categories/inactive")
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isForbidden());
+
+            then(storeCategoryService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("MASTER 권한이면 전체 가게 카테고리 목록을 조회한다")
+        void getAllCategories_success() throws Exception {
             StoreCategoryResponse response = new StoreCategoryResponse(
                     UUID.randomUUID(),
                     "치킨",
@@ -181,16 +228,28 @@ class StoreCategoryControllerTest {
                     true
             );
 
-            given(storeCategoryService.getActiveCategories()).willReturn(List.of(response));
+            given(storeCategoryService.getAllCategories(PageRequest.of(0, 10, Sort.Direction.ASC, "sortOrder")))
+                    .willReturn(new PageResponse<>(List.of(response), 0, 10, 1, 1, true));
 
-            // when & then
-            mockMvc.perform(get("/api/v1/store-categories/active")
-                            .with(authentication(customerAuthentication())))
+            mockMvc.perform(get("/api/v1/store-categories/all")
+                            .with(authentication(masterAuthentication())))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data[0].categoryName").value("치킨"));
+                    .andExpect(jsonPath("$.data.content[0].categoryName").value("치킨"));
 
-            then(storeCategoryService).should().getActiveCategories();
+            then(storeCategoryService).should().getAllCategories(
+                    PageRequest.of(0, 10, Sort.Direction.ASC, "sortOrder")
+            );
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한이면 전체 가게 카테고리 목록을 조회할 수 없다")
+        void getAllCategories_fail_whenCustomer() throws Exception {
+            mockMvc.perform(get("/api/v1/store-categories/all")
+                            .with(authentication(customerAuthentication())))
+                    .andExpect(status().isForbidden());
+
+            then(storeCategoryService).shouldHaveNoInteractions();
         }
 
         @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #76

## ✨ 기능 요약
StoreCategory 조회 정책을 활성/비활성/전체로 분리하고, 목록 조회를 페이지네이션 방식으로 개선했습니다.

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | 기본 `StoreCategory` 조회를 활성 카테고리만 반환하도록 변경했습니다. |
| 2️⃣ | 비활성 카테고리 조회 API(`/inactive`)를 추가하고 `MANAGER`/`MASTER` 권한으로 제한했습니다. |
| 3️⃣ | 전체 카테고리 조회 API(`/all`)를 추가하고 `MANAGER`/`MASTER` 권한으로 제한했습니다. |
| 4️⃣ | StoreCategory 목록 조회를 `Pageable + PageResponse` 기반 페이지네이션 구조로 전환했습니다. |
| 5️⃣ | `StoreCategoryRepository`, `StoreCategoryService`, `StoreCategoryController` 조회 로직을 정책에 맞게 수정했습니다. |
| 6️⃣ | StoreCategory 서비스/컨트롤러 테스트를 변경 구조에 맞게 수정하고 검증했습니다. |

---

## ✅ 테스트 체크리스트
- [x] StoreCategoryService 테스트 수정 및 통과
- [x] StoreCategoryController 테스트 수정 및 통과
- [x] 활성/비활성/전체 조회 정책 분리 동작 확인
- [x] 비활성/전체 조회 권한 제한 확인



---

## 🙋‍♀️ 리뷰어 참고사항
- `GET /api/v1/store-categories`는 활성 카테고리만 반환합니다.
- `GET /api/v1/store-categories/inactive`, `GET /api/v1/store-categories/all`은 `MANAGER`, `MASTER`만 접근할 수 있습니다.
- 목록 조회 기본값은 `size=10`, `sort=sortOrder,ASC`입니다.
- 응답 형식은 공용 `PageResponse<StoreCategoryResponse>`를 사용합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

## 새로운 기능
* 매장 카테고리 목록에 페이지네이션 기능 추가
* 카테고리 조회 엔드포인트 개선: 활성/비활성/전체 카테고리 별 조회 가능
* 권한별 카테고리 관리 엔드포인트 추가 (관리자, 마스터용)

## 리팩토링
* 카테고리 응답 형식을 페이지네이션 구조로 변경
* API 응답 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->