### PR TITLE
refactor: Payment getPayments PageResponse 전환 및 paymentStatus 필터 추가

### DIFF
--- a/src/main/java/com/sparta/delivery/payment/application/service/PaymentService.java
+++ b/src/main/java/com/sparta/delivery/payment/application/service/PaymentService.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import com.sparta.delivery.order.domain.entity.Order;
 import com.sparta.delivery.order.domain.entity.OrderStatus;
 import com.sparta.delivery.order.domain.repository.OrderRepository;
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.payment.domain.entity.Payment;
 import com.sparta.delivery.payment.domain.exception.DuplicatePaymentOrderException;
 import com.sparta.delivery.payment.domain.exception.InvalidOrderIdException;
@@ -92,7 +94,7 @@ public class PaymentService {
         return PaymentResponse.from(payment);
     }
 
-    public List<PaymentResponse> getPayments(
+    public PageResponse<PaymentResponse> getPayments(
             Long actorId,
             UserRole actorRole,
             int page,
@@ -116,7 +118,7 @@ public class PaymentService {
                     .toList();
 
             if (orderIds.isEmpty()) {
-                return List.of();
+                return PageResponse.from(new PageImpl<>(List.of(), pageable, 0));
             }
 
             result = paymentRepository.findAllByOrderIdIn(orderIds, pageable);
@@ -124,9 +126,7 @@ public class PaymentService {
             throw new PaymentForbiddenException();
         }
 
-        return result.getContent().stream()
-                .map(PaymentResponse::from)
-                .toList();
+        return PageResponse.from(result.map(PaymentResponse::from));
     }
 
     @Transactional

--- a/src/main/java/com/sparta/delivery/payment/application/service/PaymentService.java
+++ b/src/main/java/com/sparta/delivery/payment/application/service/PaymentService.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,6 +21,7 @@ import com.sparta.delivery.order.domain.entity.OrderStatus;
 import com.sparta.delivery.order.domain.repository.OrderRepository;
 import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.payment.domain.entity.Payment;
+import com.sparta.delivery.payment.domain.entity.PaymentStatus;
 import com.sparta.delivery.payment.domain.exception.DuplicatePaymentOrderException;
 import com.sparta.delivery.payment.domain.exception.InvalidOrderIdException;
 import com.sparta.delivery.payment.domain.exception.InvalidOrderStatusForPaymentException;
@@ -100,7 +100,8 @@ public class PaymentService {
             int page,
             int size,
             String sortBy,
-            String direction
+            String direction,
+            PaymentStatus paymentStatus
     ) {
         Pageable pageable = PageRequest.of(
                 Math.max(page, 0),
@@ -111,17 +112,9 @@ public class PaymentService {
         Page<Payment> result;
 
         if (actorRole == UserRole.MANAGER || actorRole == UserRole.MASTER) {
-            result = paymentRepository.findAll(pageable);
+            result = findAdminPayments(paymentStatus, pageable);
         } else if (actorRole == UserRole.CUSTOMER) {
-            List<UUID> orderIds = orderRepository.findAllByUserIdOrderByCreatedAtDesc(actorId).stream()
-                    .map(Order::getOrderId)
-                    .toList();
-
-            if (orderIds.isEmpty()) {
-                return PageResponse.from(new PageImpl<>(List.of(), pageable, 0));
-            }
-
-            result = paymentRepository.findAllByOrderIdIn(orderIds, pageable);
+            result = findCustomerPayments(actorId, paymentStatus, pageable);
         } else {
             throw new PaymentForbiddenException();
         }
@@ -174,6 +167,31 @@ public class PaymentService {
 
     private Sort.Direction parseDirection(String direction) {
         return "asc".equalsIgnoreCase(direction) ? Sort.Direction.ASC : Sort.Direction.DESC;
+    }
+
+    private Page<Payment> findAdminPayments(PaymentStatus paymentStatus, Pageable pageable) {
+        if (paymentStatus != null) {
+            return paymentRepository.findAllByPaymentStatus(paymentStatus, pageable);
+        }
+        return paymentRepository.findAll(pageable);
+    }
+
+    private Page<Payment> findCustomerPayments(
+            Long actorId,
+            PaymentStatus paymentStatus,
+            Pageable pageable
+    ) {
+        List<UUID> orderIds = orderRepository.findAllByUserIdOrderByCreatedAtDesc(actorId).stream()
+                .map(Order::getOrderId)
+                .toList();
+
+        if (orderIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        if (paymentStatus != null) {
+            return paymentRepository.findAllByOrderIdInAndPaymentStatus(orderIds, paymentStatus, pageable);
+        }
+        return paymentRepository.findAllByOrderIdIn(orderIds, pageable);
     }
 
 }

--- a/src/main/java/com/sparta/delivery/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/repository/PaymentRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.sparta.delivery.payment.domain.entity.PaymentStatus;
 import com.sparta.delivery.payment.domain.entity.Payment;
 
 public interface PaymentRepository extends JpaRepository<Payment, UUID> {
@@ -23,5 +24,13 @@ public interface PaymentRepository extends JpaRepository<Payment, UUID> {
     @Query(value = "select exists (select 1 from p_payment where order_id = :orderId)", nativeQuery = true)
     boolean existsAnyByOrderIdIncludingDeleted(@Param("orderId") UUID orderId);
 
+    Page<Payment> findAllByPaymentStatus(PaymentStatus paymentStatus, Pageable pageable);
+
     Page<Payment> findAllByOrderIdIn(List<UUID> orderIds, Pageable pageable);
+
+    Page<Payment> findAllByOrderIdInAndPaymentStatus(
+            List<UUID> orderIds,
+            PaymentStatus paymentStatus,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/sparta/delivery/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/com/sparta/delivery/payment/presentation/controller/PaymentController.java
@@ -27,6 +27,7 @@ import com.sparta.delivery.payment.application.service.PaymentService;
 import com.sparta.delivery.payment.presentation.dto.PaymentCreateRequest;
 import com.sparta.delivery.payment.presentation.dto.PaymentResponse;
 import com.sparta.delivery.payment.presentation.dto.PaymentStatusUpdateRequest;
+import com.sparta.delivery.payment.domain.entity.PaymentStatus;
 import com.sparta.delivery.user.domain.entity.UserRole;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,14 +73,23 @@ public class PaymentController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "createdAt") String sortBy,
-            @RequestParam(defaultValue = "desc") String direction
+            @RequestParam(defaultValue = "desc") String direction,
+            @RequestParam(required = false) PaymentStatus paymentStatus
 
     ) {
         int normalizedSize = (size == 10 || size == 30 || size == 50) ? size : 10;
         UserRole actorRole = UserRole.valueOf(principal.getRole());
 
         return ResponseEntity.ok(ApiResponse.success(
-                paymentService.getPayments(principal.getId(), actorRole, page, normalizedSize, sortBy, direction)
+                paymentService.getPayments(
+                        principal.getId(),
+                        actorRole,
+                        page,
+                        normalizedSize,
+                        sortBy,
+                        direction,
+                        paymentStatus
+                )
         ));
     }
 

--- a/src/main/java/com/sparta/delivery/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/com/sparta/delivery/payment/presentation/controller/PaymentController.java
@@ -1,6 +1,5 @@
 package com.sparta.delivery.payment.presentation.controller;
 
-import java.util.List;
 import java.util.UUID;
 
 import jakarta.validation.Valid;
@@ -23,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.sparta.delivery.common.config.security.UserPrincipal;
 import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.payment.application.service.PaymentService;
 import com.sparta.delivery.payment.presentation.dto.PaymentCreateRequest;
 import com.sparta.delivery.payment.presentation.dto.PaymentResponse;
@@ -67,7 +67,7 @@ public class PaymentController {
     @Operation(summary = "결제 전체 조회")
     @GetMapping("/payments")
     @PreAuthorize("hasAnyRole('CUSTOMER', 'MANAGER', 'MASTER')")
-    public ResponseEntity<ApiResponse<List<PaymentResponse>>> getPayments(
+    public ResponseEntity<ApiResponse<PageResponse<PaymentResponse>>> getPayments(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,

--- a/src/test/java/com/sparta/delivery/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/com/sparta/delivery/payment/application/service/PaymentServiceTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.order.domain.entity.Order;
 import com.sparta.delivery.order.domain.entity.OrderItem;
 import com.sparta.delivery.order.domain.repository.OrderRepository;
@@ -285,7 +286,7 @@ class PaymentServiceTest {
             given(paymentRepository.findAll(any(Pageable.class))).willReturn(page);
 
             // when
-            List<PaymentResponse> result = paymentService.getPayments(
+            PageResponse<PaymentResponse> result = paymentService.getPayments(
                     1L,
                     UserRole.MANAGER,
                     0,
@@ -295,19 +296,21 @@ class PaymentServiceTest {
             );
 
             // then
-            assertThat(result).hasSize(2);
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.page()).isEqualTo(0);
+            assertThat(result.size()).isEqualTo(2);
             then(paymentRepository).should().findAll(any(Pageable.class));
         }
 
         @Test
-        @DisplayName("CUSTOMER가 주문이 없으면 빈 리스트를 반환한다")
+        @DisplayName("CUSTOMER가 주문이 없으면 빈 페이지를 반환한다")
         void getPayments_success_customer_noOrders() {
             // given
             Long actorId = 1L;
             given(orderRepository.findAllByUserIdOrderByCreatedAtDesc(actorId)).willReturn(List.of());
 
             // when
-            List<PaymentResponse> result = paymentService.getPayments(
+            PageResponse<PaymentResponse> result = paymentService.getPayments(
                     actorId,
                     UserRole.CUSTOMER,
                     0,
@@ -317,7 +320,9 @@ class PaymentServiceTest {
             );
 
             // then
-            assertThat(result).isEmpty();
+            assertThat(result.content()).isEmpty();
+            assertThat(result.totalElements()).isZero();
+            assertThat(result.size()).isEqualTo(10);
             then(paymentRepository).shouldHaveNoInteractions();
         }
 
@@ -339,7 +344,7 @@ class PaymentServiceTest {
                     .willReturn(new PageImpl<>(List.of(p1, p2)));
 
             // when
-            List<PaymentResponse> result = paymentService.getPayments(
+            PageResponse<PaymentResponse> result = paymentService.getPayments(
                     actorId,
                     UserRole.CUSTOMER,
                     0,
@@ -349,7 +354,8 @@ class PaymentServiceTest {
             );
 
             // then
-            assertThat(result).hasSize(2);
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.totalElements()).isEqualTo(2);
             then(paymentRepository).should().findAllByOrderIdIn(eq(List.of(orderId1, orderId2)), any(Pageable.class));
         }
 

--- a/src/test/java/com/sparta/delivery/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/com/sparta/delivery/payment/application/service/PaymentServiceTest.java
@@ -292,7 +292,8 @@ class PaymentServiceTest {
                     0,
                     10,
                     "createdAt",
-                    "desc"
+                    "desc",
+                    null
             );
 
             // then
@@ -300,6 +301,35 @@ class PaymentServiceTest {
             assertThat(result.page()).isEqualTo(0);
             assertThat(result.size()).isEqualTo(2);
             then(paymentRepository).should().findAll(any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("MANAGER는 paymentStatus 조건으로 결제를 조회할 수 있다")
+        void getPayments_success_manager_withFilters() {
+            // given
+            Payment payment = createPayment(UUID.randomUUID(), UUID.randomUUID(), 10_000);
+            given(paymentRepository.findAllByPaymentStatus(
+                    eq(PaymentStatus.APPROVED),
+                    any(Pageable.class)
+            )).willReturn(new PageImpl<>(List.of(payment)));
+
+            // when
+            PageResponse<PaymentResponse> result = paymentService.getPayments(
+                    1L,
+                    UserRole.MANAGER,
+                    0,
+                    10,
+                    "createdAt",
+                    "desc",
+                    PaymentStatus.APPROVED
+            );
+
+            // then
+            assertThat(result.content()).hasSize(1);
+            then(paymentRepository).should().findAllByPaymentStatus(
+                    eq(PaymentStatus.APPROVED),
+                    any(Pageable.class)
+            );
         }
 
         @Test
@@ -316,7 +346,8 @@ class PaymentServiceTest {
                     0,
                     10,
                     "createdAt",
-                    "desc"
+                    "desc",
+                    null
             );
 
             // then
@@ -350,7 +381,8 @@ class PaymentServiceTest {
                     0,
                     10,
                     "createdAt",
-                    "desc"
+                    "desc",
+                    null
             );
 
             // then
@@ -362,7 +394,15 @@ class PaymentServiceTest {
         @Test
         @DisplayName("허용되지 않는 역할이면 PaymentForbiddenException")
         void getPayments_fail_whenRoleNotAllowed() {
-            assertThatThrownBy(() -> paymentService.getPayments(1L, UserRole.OWNER, 0, 10, "createdAt", "desc"))
+            assertThatThrownBy(() -> paymentService.getPayments(
+                    1L,
+                    UserRole.OWNER,
+                    0,
+                    10,
+                    "createdAt",
+                    "desc",
+                    null
+            ))
                     .isInstanceOf(PaymentForbiddenException.class);
         }
     }

--- a/src/test/java/com/sparta/delivery/payment/presentation/controller/PaymentControllerTest.java
+++ b/src/test/java/com/sparta/delivery/payment/presentation/controller/PaymentControllerTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.delivery.auth.infrastructure.jwt.JwtProvider;
 import com.sparta.delivery.common.config.security.UserPrincipal;
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.payment.application.service.PaymentService;
 import com.sparta.delivery.payment.domain.entity.PaymentFailureReason;
 import com.sparta.delivery.payment.domain.entity.PaymentMethod;
@@ -157,15 +158,16 @@ class PaymentControllerTest {
         void getPayments_success() throws Exception {
             // given
             PaymentResponse response = paymentResponse(UUID.randomUUID(), UUID.randomUUID(), 10_000);
+            PageResponse<PaymentResponse> pageResponse = new PageResponse<>(List.of(response), 0, 10, 1, 1, true);
             given(paymentService.getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc"))
-                    .willReturn(List.of(response));
+                    .willReturn(pageResponse);
 
             // when & then
             mockMvc.perform(get("/api/v1/payments")
                             .with(authentication(authenticationToken(UserRole.MANAGER))))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data[0].totalPrice").value(10_000));
+                    .andExpect(jsonPath("$.data.content[0].totalPrice").value(10_000));
 
             then(paymentService).should().getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc");
         }
@@ -174,8 +176,9 @@ class PaymentControllerTest {
         @DisplayName("size가 10/30/50이 아니면 10으로 보정한다")
         void getPayments_success_sizeNormalized() throws Exception {
             // given
+            PageResponse<PaymentResponse> pageResponse = new PageResponse<>(List.of(), 0, 10, 0, 0, true);
             given(paymentService.getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc"))
-                    .willReturn(List.of());
+                    .willReturn(pageResponse);
 
             // when & then
             mockMvc.perform(get("/api/v1/payments")

--- a/src/test/java/com/sparta/delivery/payment/presentation/controller/PaymentControllerTest.java
+++ b/src/test/java/com/sparta/delivery/payment/presentation/controller/PaymentControllerTest.java
@@ -159,7 +159,7 @@ class PaymentControllerTest {
             // given
             PaymentResponse response = paymentResponse(UUID.randomUUID(), UUID.randomUUID(), 10_000);
             PageResponse<PaymentResponse> pageResponse = new PageResponse<>(List.of(response), 0, 10, 1, 1, true);
-            given(paymentService.getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc"))
+            given(paymentService.getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc", null))
                     .willReturn(pageResponse);
 
             // when & then
@@ -169,7 +169,7 @@ class PaymentControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.content[0].totalPrice").value(10_000));
 
-            then(paymentService).should().getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc");
+            then(paymentService).should().getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc", null);
         }
 
         @Test
@@ -177,7 +177,7 @@ class PaymentControllerTest {
         void getPayments_success_sizeNormalized() throws Exception {
             // given
             PageResponse<PaymentResponse> pageResponse = new PageResponse<>(List.of(), 0, 10, 0, 0, true);
-            given(paymentService.getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc"))
+            given(paymentService.getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc", null))
                     .willReturn(pageResponse);
 
             // when & then
@@ -187,7 +187,39 @@ class PaymentControllerTest {
                             .with(authentication(authenticationToken(UserRole.MANAGER))))
                     .andExpect(status().isOk());
 
-            then(paymentService).should().getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc");
+            then(paymentService).should().getPayments(1L, UserRole.MANAGER, 0, 10, "createdAt", "desc", null);
+        }
+
+        @Test
+        @DisplayName("검색조건 파라미터를 전달한다")
+        void getPayments_success_withSearchFilters() throws Exception {
+            // given
+            PageResponse<PaymentResponse> pageResponse = new PageResponse<>(List.of(), 0, 10, 0, 0, true);
+            given(paymentService.getPayments(
+                    1L,
+                    UserRole.MANAGER,
+                    0,
+                    10,
+                    "createdAt",
+                    "desc",
+                    PaymentStatus.APPROVED
+            )).willReturn(pageResponse);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/payments")
+                            .param("paymentStatus", "APPROVED")
+                            .with(authentication(authenticationToken(UserRole.MANAGER))))
+                    .andExpect(status().isOk());
+
+            then(paymentService).should().getPayments(
+                    1L,
+                    UserRole.MANAGER,
+                    0,
+                    10,
+                    "createdAt",
+                    "desc",
+                    PaymentStatus.APPROVED
+            );
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #74 

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Payment 목록 조회 응답 PageResponse 전환 및 검색조건(paymentStatus) 추가 |
| 🔍 목적 | 기능 체크리스트의 `Search(Page, @RequestParam)` + `검색 조건 + 정렬` 요구사항 충족 |
| 🛠️ 변경사항 | Payment 목록 API 응답/서비스/테스트 구조를 Page 기반으로 정리하고 paymentStatus 필터를 적용 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `PaymentController#getPayments` 응답 타입을 `ApiResponse<PageResponse<PaymentResponse>>`로 변경 |
| 2️⃣ | 목록 조회 쿼리 파라미터에 `paymentStatus`(optional) 추가 |
| 3️⃣ | `PaymentService#getPayments` 반환 타입을 `PageResponse<PaymentResponse>`로 변경하고 권한별 조회 로직에 `paymentStatus` 조건 반영 |
| 4️⃣ | `PaymentRepository`에 `findAllByPaymentStatus`, `findAllByOrderIdInAndPaymentStatus` 메서드 추가 |
| 5️⃣ | `PaymentControllerTest`, `PaymentServiceTest`를 PageResponse 구조/필터 케이스에 맞게 수정 |

---

## ✅ 테스트 체크리스트
- [x] 기능 정상 작동 확인
- [x] 예외/엣지 케이스 확인
- [x] 테스트 코드 작성 완료

---

## 🙋‍♀️ 리뷰어 참고사항
- 목록 조회 응답 스키마가 `data: []`에서 `data.content: []` 형태로 변경되었습니다.
- 검색조건은 `paymentStatus` 1개만 유지해 요구사항 충족 + 복잡도 최소화했습니다.
- `paymentStatus` 값: `PENDING`, `APPROVED`, `FAILED`, `CANCELLED`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 목록 조회에 페이지네이션 기능 추가
  * 결제 상태별 필터링 옵션 추가
  * API 응답에 페이지 정보 포함으로 대용량 데이터 조회 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->