### PR TITLE
refactor: Review 목록 조회 방식 변경

### DIFF
--- a/src/main/java/com/sparta/delivery/review/presentation/ReviewController.java
+++ b/src/main/java/com/sparta/delivery/review/presentation/ReviewController.java
@@ -62,10 +62,10 @@ public class ReviewController {
     }
 
     @Operation(summary = "가게 리뷰 목록 조회")
-    @GetMapping("/stores/{storeId}/reviews")
+    @GetMapping("/reviews")
     @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
     public ResponseEntity<ApiResponse<PageResponse<ReviewResponse>>> getReviews(
-            @PathVariable UUID storeId,
+            @RequestParam UUID storeId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "createdAt") String sortBy,

--- a/src/test/java/com/sparta/delivery/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/sparta/delivery/review/presentation/ReviewControllerTest.java
@@ -191,7 +191,8 @@ class ReviewControllerTest {
             given(reviewService.getReviews(storeId, 0, 10, "createdAt", "desc")).willReturn(pageResponse);
 
             // when & then
-            mockMvc.perform(get("/api/v1/stores/{storeId}/reviews", storeId)
+            mockMvc.perform(get("/api/v1/reviews")
+                            .param("storeId", storeId.toString())
                             .with(authentication(authenticationToken(UserRole.CUSTOMER))))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #79 

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 리뷰 목록 조회 API 파라미터 전달 방식 변경 |
| 🔍 목적 | 요구사항 문구(가게 PK를 쿼리스트링에 담아 호출)와 API 스펙 일치 |
| 🛠️ 변경사항 | `storeId` 전달을 PathVariable에서 RequestParam으로 변경하고 관련 테스트 갱신 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `ReviewController` 목록 조회 엔드포인트를 `GET /api/v1/stores/{storeId}/reviews` → `GET /api/v1/reviews?storeId=...`로 변경 |
| 2️⃣ | `getReviews` 파라미터를 `@PathVariable UUID storeId` → `@RequestParam UUID storeId`로 변경 |
| 3️⃣ | `ReviewControllerTest` 목록 조회 테스트를 쿼리스트링 호출 방식으로 수정 |토링 또는 제거된 불필요 코드 |

---

## ✅ 테스트 체크리스트
- [x] 기능 정상 작동 확인
- [x] 예외/엣지 케이스 확인
- [ ] UI/UX 흐름 확인 (해당 없음)
- [x] 테스트 코드 작성 완료

--

## 🙋‍♀️ 리뷰어 참고사항
- 리뷰 목록 조회 URL 스펙이 변경되어 기존 경로 기반 호출 클라이언트는 쿼리스트링 방식으로 수정이 필요합니다.
- 서비스/도메인 로직 변경 없이 컨트롤러 계약 및 테스트만 조정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **리팩토링**
  * 리뷰 조회 API 엔드포인트 경로 변경 및 매장 ID 파라미터 전달 방식 업데이트 (경로 변수에서 쿼리 파라미터로 변경).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->