### PR TITLE
refactor: Payment totalPrice 검증 예외 분리 및 에러코드 정합성 개선

### DIFF
--- a/src/main/java/com/sparta/delivery/payment/application/service/PaymentService.java
+++ b/src/main/java/com/sparta/delivery/payment/application/service/PaymentService.java
@@ -16,17 +16,17 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.order.domain.entity.Order;
 import com.sparta.delivery.order.domain.entity.OrderStatus;
 import com.sparta.delivery.order.domain.repository.OrderRepository;
-import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.payment.domain.entity.Payment;
 import com.sparta.delivery.payment.domain.entity.PaymentStatus;
 import com.sparta.delivery.payment.domain.exception.DuplicatePaymentOrderException;
 import com.sparta.delivery.payment.domain.exception.InvalidOrderIdException;
 import com.sparta.delivery.payment.domain.exception.InvalidOrderStatusForPaymentException;
-import com.sparta.delivery.payment.domain.exception.InvalidTotalPriceException;
 import com.sparta.delivery.payment.domain.exception.InvalidPaymentStatusTransitionException;
+import com.sparta.delivery.payment.domain.exception.OrderTotalPriceMismatchException;
 import com.sparta.delivery.payment.domain.exception.PaymentForbiddenException;
 import com.sparta.delivery.payment.domain.exception.PaymentNotFoundException;
 import com.sparta.delivery.payment.domain.repository.PaymentRepository;
@@ -57,7 +57,7 @@ public class PaymentService {
         requireOrderStatusAllowedForPayment(order.getStatus());
 
         if (!order.getTotalPrice().equals(request.totalPrice())) {
-            throw new InvalidTotalPriceException();
+            throw new OrderTotalPriceMismatchException();
         }
 
         if (paymentRepository.existsAnyByOrderIdIncludingDeleted(order.getOrderId())) {

--- a/src/main/java/com/sparta/delivery/payment/domain/exception/OrderTotalPriceMismatchException.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/exception/OrderTotalPriceMismatchException.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.payment.domain.exception;
+
+import com.sparta.delivery.common.exception.BaseException;
+
+public class OrderTotalPriceMismatchException extends BaseException {
+
+    public OrderTotalPriceMismatchException() { super(PaymentErrorCode.ORDER_TOTAL_PRICE_MISMATCH); }
+
+}

--- a/src/main/java/com/sparta/delivery/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/exception/PaymentErrorCode.java
@@ -21,7 +21,7 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT-005", "결제 정보를 찾을 수 없습니다."),
     PAYMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "PAYMENT-006", "결제에 접근할 수 없습니다."),
     DUPLICATE_PAYMENT_ORDER(HttpStatus.CONFLICT, "PAYMENT-007", "이미 해당 주문에 대한 결제가 존재합니다."),
-    ORDER_TOTAL_PRICE_MISMATCH(HttpStatus.CONFLICT, "PAYMENT-009", "주문 합계와 일치하지 않습니다.");
+    ORDER_TOTAL_PRICE_MISMATCH(HttpStatus.CONFLICT, "PAYMENT-010", "주문 합계와 일치하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sparta/delivery/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/sparta/delivery/payment/domain/exception/PaymentErrorCode.java
@@ -20,7 +20,8 @@ public enum PaymentErrorCode implements ErrorCode {
 
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT-005", "결제 정보를 찾을 수 없습니다."),
     PAYMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "PAYMENT-006", "결제에 접근할 수 없습니다."),
-    DUPLICATE_PAYMENT_ORDER(HttpStatus.CONFLICT, "PAYMENT-007", "이미 해당 주문에 대한 결제가 존재합니다.");
+    DUPLICATE_PAYMENT_ORDER(HttpStatus.CONFLICT, "PAYMENT-007", "이미 해당 주문에 대한 결제가 존재합니다."),
+    ORDER_TOTAL_PRICE_MISMATCH(HttpStatus.CONFLICT, "PAYMENT-009", "주문 합계와 일치하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/com/sparta/delivery/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/com/sparta/delivery/payment/application/service/PaymentServiceTest.java
@@ -22,7 +22,7 @@ import com.sparta.delivery.payment.domain.entity.PaymentMethod;
 import com.sparta.delivery.payment.domain.exception.DuplicatePaymentOrderException;
 import com.sparta.delivery.payment.domain.exception.InvalidOrderIdException;
 import com.sparta.delivery.payment.domain.exception.InvalidOrderStatusForPaymentException;
-import com.sparta.delivery.payment.domain.exception.InvalidTotalPriceException;
+import com.sparta.delivery.payment.domain.exception.OrderTotalPriceMismatchException;
 import com.sparta.delivery.payment.domain.exception.PaymentForbiddenException;
 import com.sparta.delivery.payment.domain.exception.PaymentNotFoundException;
 import com.sparta.delivery.payment.domain.repository.PaymentRepository;
@@ -144,7 +144,7 @@ class PaymentServiceTest {
         }
 
         @Test
-        @DisplayName("요청 금액이 주문 총액과 다르면 InvalidTotalPriceException")
+        @DisplayName("요청 금액이 주문 총액과 다르면 OrderTotalPriceMismatchException")
         void create_fail_whenTotalPriceMismatch() {
             // given
             Long actorId = 1L;
@@ -156,7 +156,7 @@ class PaymentServiceTest {
 
             // when & then
             assertThatThrownBy(() -> paymentService.create(actorId, request))
-                    .isInstanceOf(InvalidTotalPriceException.class);
+                    .isInstanceOf(OrderTotalPriceMismatchException.class);
 
             then(paymentRepository).shouldHaveNoInteractions();
         }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #81 

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 결제 금액 검증 예외 분리 |
| 🔍 목적 | 서로 다른 실패 원인(0 이하 금액 vs 주문 합계 불일치)을 명확히 구분 |
| 🛠️ 변경사항 | `OrderTotalPriceMismatchException` 추가, `PaymentService` 예외 교체, `PaymentErrorCode` 신규 코드 추가, 테스트 기대값 수정 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `PaymentService.create`에서 주문 합계 불일치 시 `OrderTotalPriceMismatchException` 발생하도록 변경 |
| 2️⃣ | `PaymentErrorCode`에 `ORDER_TOTAL_PRICE_MISMATCH(PAYMENT-010)` 추가로 코드 중복 해소 |
| 3️⃣ | `PaymentServiceTest`의 mismatch 케이스를 신규 예외 타입 기준으로 수정 |

---

## 🙋‍♀️ 리뷰어 참고사항
- `InvalidTotalPriceException`은 여전히 `Payment.create`의 `null/0 이하` 검증에 사용됩니다.
- 주문 합계 불일치만 별도 예외로 분리되어 클라이언트가 실패 원인을 명확히 구분할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 주문 합계 불일치 시 더욱 정확한 오류 응답을 제공하도록 결제 검증 로직을 개선했습니다. 시스템이 이제 주문 금액 오류를 더 명확하게 식별하고 보고합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->