### PR TITLE
fix: Querydsl 생성 경로를 build 디렉터리로 이동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,16 +63,12 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-def generated = 'src/main/generated'
+def generated = layout.buildDirectory.dir('generated/sources/annotationProcessor/java/main')
 
 sourceSets {
-    main.java.srcDirs += [generated]
+    main.java.srcDirs += generated
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.generatedSourceOutputDirectory = file(generated)
-}
-
-clean {
-    delete file(generated)
+    options.generatedSourceOutputDirectory = generated.get().asFile
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #84

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Querydsl 생성 경로 정리 |
| 🔍 목적 | `src/main/generated` 경로 사용으로 인해 Q 클래스가 중복 생성되어 빌드가 실패하는 문제를 해결 |
| 🛠️ 변경사항 | Querydsl generated source 경로를 `build/generated/...`로 변경하고, 기존 `src/main/generated` 하위 Q 클래스 제거 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `build.gradle`에서 Querydsl annotation processor 출력 경로를 `src/main/generated`에서 `build/generated/sources/annotationProcessor/java/main`으로 변경 |
| 2️⃣ | generated source를 빌드 산출물 기준으로 관리하도록 설정 정리 |
| 3️⃣ | `src/main/generated`에 남아 있던 기존 Q 클래스 파일 제거 |

---

## ✅ 테스트 체크리스트
- [x] `./gradlew clean build` 정상 동작 확인
- [x] Querydsl generated source가 `build/generated/...` 아래에 생성되는지 확인
- [x] 기존 `Attempt to recreate a file for type ...` 오류가 발생하지 않는지 확인
- [ ] CI 환경에서 동일하게 빌드되는지 확인

---

## 📸 포스트맨 캡처 사진
- 해당 없음

---

## 🙋‍♀️ 리뷰어 참고사항
- 이번 변경은 비즈니스 로직 수정이 아니라 Querydsl generated source 경로를 빌드 전용 디렉터리로 옮기는 설정 변경입니다.
- 기존에는 `src/main/generated`가 소스 폴더이면서 생성 대상 폴더로도 사용되어 Q 클래스 재생성 충돌이 발생했습니다.
- 로컬에서는 `./gradlew clean build` 기준으로 빌드 성공 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 프로세스 최적화: 생성된 소스 파일의 위치를 Gradle 빌드 디렉토리로 변경하여 빌드 시스템 효율성을 개선했습니다. 이는 내부 빌드 구성 업데이트이며 최종 사용자 기능에는 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->