### PR TITLE
refactor: 상품·AI 도메인 코드 품질 개선

### DIFF
--- a/src/main/java/com/sparta/delivery/ai/application/AiDescriptionService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/AiDescriptionService.java
@@ -1,5 +1,6 @@
 package com.sparta.delivery.ai.application;
 
+import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmInputSnapshot;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,9 +26,17 @@ public class AiDescriptionService {
                 aiPromptText
         );
 
-        return llmOrchestrator.generate(actorId, inputSnapshot)
-                .generatedText();
+        String generatedText = llmOrchestrator.generate(actorId, inputSnapshot).generatedText();
+
+        if (generatedText == null || generatedText.isBlank()) {
+            throw new ExternalLlmCallFailedException();
+        }
+
+        return generatedText.length() > 50
+                ? generatedText.substring(0, 50)
+                : generatedText;
     }
+
 
     private String buildPrompt(String productName, Integer price, String aiPromptText) {
         StringBuilder promptBuilder = new StringBuilder();

--- a/src/main/java/com/sparta/delivery/ai/application/LlmCallService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmCallService.java
@@ -38,7 +38,9 @@ public class LlmCallService {
         Pageable pageable = PageRequest.of(
                 Math.max(page, 0),
                 normalizePageSize(size),
-                Sort.by(Sort.Order.desc("createdAt"))
+                Sort.by(Sort.Order.desc("createdAt"),
+                        Sort.Order.desc("callId")
+                )
         );
         if (llmId != null) {
             return llmCallRepository.findByLlmId(llmId, pageable)

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/external/llm/openai/OpenAiClient.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/external/llm/openai/OpenAiClient.java
@@ -9,12 +9,14 @@ import com.sparta.delivery.ai.infrastructure.external.llm.LlmClient;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateRequest;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class OpenAiClient implements LlmClient {
 
@@ -33,6 +35,7 @@ public class OpenAiClient implements LlmClient {
                     .prompt()
                     .options(OpenAiChatOptions.builder()
                             .model(llm.getLlmName())
+                            .maxTokens(40)
                             .build())
                     .system("""
                         당신은 음식 배달 플랫폼의 상품 설명 작성 전문가입니다.
@@ -48,6 +51,8 @@ public class OpenAiClient implements LlmClient {
             try {
                 rawResponse = objectMapper.writeValueAsString(chatResponse);
             } catch (JsonProcessingException e) {
+                log.warn("[OpenAI Client] ChatResponse Serialization 실패: model={}, error={}",
+                        llm.getLlmName(), e.getMessage());
                 rawResponse = null;
             }
 

--- a/src/main/java/com/sparta/delivery/product/application/ProductService.java
+++ b/src/main/java/com/sparta/delivery/product/application/ProductService.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.product.application;
 
 import com.sparta.delivery.ai.application.AiDescriptionService;
+import com.sparta.delivery.store.domain.exception.StoreNotFoundException;
 import com.sparta.delivery.product.domain.entity.DescriptionSource;
 import com.sparta.delivery.product.domain.entity.Product;
 import com.sparta.delivery.product.domain.exception.DuplicateProductNameException;
@@ -105,7 +106,7 @@ public class ProductService {
 
         String normalizedKeyword = normalizeKeyword(keyword);
 
-        Page<Product> products =  getProductPage(storeId, normalizedKeyword, canViewHidden, pageable);
+        Page<Product> products = getProductPage(storeId, normalizedKeyword, canViewHidden, pageable);
 
         return products.map(ProductResponse::from);
     }
@@ -172,9 +173,8 @@ public class ProductService {
 
 
     private Store getStoreOrThrow(UUID storeId) {
-        // TODO: Store 도메인 예외 구현 즉시 해당 예외로 변경
         return storeRepository.findByStoreId(storeId)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(StoreNotFoundException::new);
     }
     private Product getProductOrThrow(UUID productId) {
         // 존재하는 상품인지 확인

--- a/src/main/java/com/sparta/delivery/product/presentation/ProductController.java
+++ b/src/main/java/com/sparta/delivery/product/presentation/ProductController.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.product.presentation;
 
 import com.sparta.delivery.common.config.security.UserPrincipal;
 import com.sparta.delivery.common.response.ApiResponse;
+import com.sparta.delivery.common.response.PageResponse;
 import com.sparta.delivery.product.application.ProductService;
 import com.sparta.delivery.product.presentation.dto.request.ProductCreateRequest;
 import com.sparta.delivery.product.presentation.dto.request.ProductHiddenUpdateRequest;
@@ -66,7 +67,7 @@ public class ProductController {
 
     @Operation(summary = "상품 목록 조회")
     @GetMapping("/stores/{storeId}/products")
-    public ResponseEntity<ApiResponse<Page<ProductResponse>>> getProducts(
+    public ResponseEntity<ApiResponse<PageResponse<ProductResponse>>> getProducts(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable UUID storeId,
             @RequestParam(defaultValue = "0") int page,
@@ -87,7 +88,7 @@ public class ProductController {
                 keyword
         );
 
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.from(response)));
     }
 
 
@@ -115,7 +116,7 @@ public class ProductController {
     public ResponseEntity<ApiResponse<ProductResponse>> changeHidden(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable UUID productId,
-            @RequestBody ProductHiddenUpdateRequest request
+            @RequestBody @Valid ProductHiddenUpdateRequest request
             ) {
         ProductResponse response = productService.changeHidden(
                 principal.getId(),
@@ -133,7 +134,7 @@ public class ProductController {
     public ResponseEntity<ApiResponse<ProductResponse>> changeSoldOut(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable UUID productId,
-            @RequestBody ProductSoldOutUpdateRequest request
+            @RequestBody @Valid ProductSoldOutUpdateRequest request
             ) {
         ProductResponse response = productService.changeSoldOut(
                 principal.getId(),

--- a/src/main/java/com/sparta/delivery/product/presentation/dto/request/ProductHiddenUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/product/presentation/dto/request/ProductHiddenUpdateRequest.java
@@ -1,6 +1,9 @@
 package com.sparta.delivery.product.presentation.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record ProductHiddenUpdateRequest(
-        boolean hidden
+        @NotNull
+        Boolean hidden
 ) {
 }

--- a/src/main/java/com/sparta/delivery/product/presentation/dto/request/ProductSoldOutUpdateRequest.java
+++ b/src/main/java/com/sparta/delivery/product/presentation/dto/request/ProductSoldOutUpdateRequest.java
@@ -1,6 +1,9 @@
 package com.sparta.delivery.product.presentation.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record ProductSoldOutUpdateRequest (
-        boolean soldOut
+        @NotNull
+        Boolean soldOut
 ) {
 }

--- a/src/test/java/com/sparta/delivery/ai/application/AiDescriptionServiceTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/AiDescriptionServiceTest.java
@@ -1,10 +1,13 @@
 package com.sparta.delivery.ai.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+
+import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
 
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateResponse;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmInputSnapshot;
@@ -29,6 +32,64 @@ class AiDescriptionServiceTest {
     @Nested
     @DisplayName("AI description")
     class GenerateDescription {
+
+        @Test
+        @DisplayName("throws ExternalLlmCallFailedException when generated text is null")
+        void generateDescription_fail_whenGeneratedTextIsNull() {
+            // given
+            Long actorId = 1L;
+            LlmGenerateResponse response = new LlmGenerateResponse(
+                    null,
+                    null,
+                    "STOP"
+            );
+            given(llmOrchestrator.generate(eq(actorId), any(LlmInputSnapshot.class))).willReturn(response);
+
+            // when & then
+            assertThatThrownBy(() -> aiDescriptionService.generateDescription(
+                    actorId, "Americano", 4500, null
+            )).isInstanceOf(ExternalLlmCallFailedException.class);
+        }
+
+        @Test
+        @DisplayName("throws ExternalLlmCallFailedException when generated text is blank")
+        void generateDescription_fail_whenGeneratedTextIsBlank() {
+            // given
+            Long actorId = 1L;
+            LlmGenerateResponse response = new LlmGenerateResponse(
+                    "   ",
+                    null,
+                    "STOP"
+            );
+            given(llmOrchestrator.generate(eq(actorId), any(LlmInputSnapshot.class))).willReturn(response);
+
+            // when & then
+            assertThatThrownBy(() -> aiDescriptionService.generateDescription(
+                    actorId, "Americano", 4500, null
+            )).isInstanceOf(ExternalLlmCallFailedException.class);
+        }
+
+        @Test
+        @DisplayName("trims generated text to 50 characters when it exceeds limit")
+        void generateDescription_success_trimmedTo50() {
+            // given
+            Long actorId = 1L;
+            String longText = "가".repeat(60); // 60자
+            LlmGenerateResponse response = new LlmGenerateResponse(
+                    longText,
+                    null,
+                    "STOP"
+            );
+            given(llmOrchestrator.generate(eq(actorId), any(LlmInputSnapshot.class))).willReturn(response);
+
+            // when
+            String result = aiDescriptionService.generateDescription(
+                    actorId, "Americano", 4500, null
+            );
+
+            // then
+            assertThat(result).hasSize(50);
+        }
 
         @Test
         @DisplayName("returns generated text from llm orchestrator")

--- a/src/test/java/com/sparta/delivery/product/presentation/ProductControllerTest.java
+++ b/src/test/java/com/sparta/delivery/product/presentation/ProductControllerTest.java
@@ -345,6 +345,52 @@ class ProductControllerTest {
         }
 
         @Test
+        @DisplayName("returns 400 when hidden field is missing")
+        void changeHidden_fail_whenHiddenFieldMissing() throws Exception {
+            // given
+            UUID productId = UUID.randomUUID();
+            UsernamePasswordAuthenticationToken auth = authenticationToken(UserRole.OWNER);
+
+            // when & then
+            TestSecurityContextHolder.setAuthentication(auth);
+            try {
+                mockMvc.perform(patch("/api/v1/products/{productId}/hidden", productId)
+                                .with(csrf())
+                                .with(authentication(auth))
+                                .contentType("application/json")
+                                .content("{}"))
+                        .andExpect(status().isBadRequest());
+            } finally {
+                TestSecurityContextHolder.clearContext();
+            }
+
+            then(productService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("returns 400 when soldOut field is missing")
+        void changeSoldOut_fail_whenSoldOutFieldMissing() throws Exception {
+            // given
+            UUID productId = UUID.randomUUID();
+            UsernamePasswordAuthenticationToken auth = authenticationToken(UserRole.OWNER);
+
+            // when & then
+            TestSecurityContextHolder.setAuthentication(auth);
+            try {
+                mockMvc.perform(patch("/api/v1/products/{productId}/sold-out", productId)
+                                .with(csrf())
+                                .with(authentication(auth))
+                                .contentType("application/json")
+                                .content("{}"))
+                        .andExpect(status().isBadRequest());
+            } finally {
+                TestSecurityContextHolder.clearContext();
+            }
+
+            then(productService).shouldHaveNoInteractions();
+        }
+
+        @Test
         @DisplayName("deletes a product for OWNER role")
         void deleteProduct_success() throws Exception {
             // given


### PR DESCRIPTION
## 📌 관련 이슈
- Relates to #61 

## ✨ 기능 요약

| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 상품·AI 도메인 코드 품질 개선 |
| 🔍 목적 | 데이터 무결성 보장, 입력 검증 강화, 응답 일관성 확보, 운영 디버깅 개선 |
| 🛠️ 변경사항 | AI 생성 결과 검증·트리밍 / OpenAiClient 로깅 / ProductController 응답 전환 / DTO 검증 강화 / 예외 교체 / 정렬 tie-breaker |

## 📝 상세 내역

| 번호 | 내용 |
|------|------|
| 1️⃣ | `OpenAiClient`에 `maxTokens(40)` 추가 — 출력 토큰 상한 설정으로 비용 캡 적용 |
| 2️⃣ | AI 생성 결과 null/blank 검증 및 50자 트리밍 추가 (`AiDescriptionService`) |
| 3️⃣ | `rawResponse` 직렬화 실패 시 `log.warn()` 추가 (`OpenAiClient`) |
| 4️⃣ | `getStoreOrThrow` `IllegalArgumentException` → `StoreNotFoundException` 교체 — 500 에러 방지 |
| 5️⃣ | `ProductHiddenUpdateRequest` / `ProductSoldOutUpdateRequest` `boolean` → `Boolean` + `@NotNull` |
| 6️⃣ | `changeHidden` / `changeSoldOut` 컨트롤러 `@RequestBody`에 `@Valid` 추가 |
| 7️⃣ | `ProductController.getProducts()` 응답 `Page<>` → `PageResponse` 전환 — `PageImpl` 직렬화 경고 제거 및 타 도메인 응답 구조와 일관성 확보 |
| 8️⃣ | `LlmCallService` 정렬에 `callId` tie-breaker 추가 — 동일 `createdAt` 레코드 간 페이지네이션 결정성 보장 |

---

## ✅ 테스트 체크리스트
- [x] 기능 정상 작동 확인
- [x] 예외/엣지 케이스 확인
- [x] 테스트 코드 작성 완료
  - `AiDescriptionServiceTest` — null/blank 검증, 50자 트리밍 케이스 추가
  - `ProductControllerTest` — hidden/soldOut 필드 누락 시 400 케이스 추가

---

## 🙋‍♀️ 리뷰어 참고사항

### 메인 리뷰 지점
- `AiDescriptionService` — 검증·트리밍 순서 및 로직
- `ProductController` — `PageResponse.from()` 전환
- `ProductHiddenUpdateRequest` / `ProductSoldOutUpdateRequest` — `Boolean` + `@NotNull`

### 추후 반영 예정 (후속 PR)
- `activate()` 비관적 락 + DB partial unique index — single-active 동시성 보장
- `@Async` + 전용 스레드 풀 — OpenAI 호출 비동기 처리로 처리량 향상
- 인덱스 추가 (`p_product.store_id`, `p_llm_calls.llm_id` 등) — 조회 성능 최적화
- 활성 LLM Spring Cache 캐싱 — LLM 호출마다 발생하는 `findByIsActiveTrue()` 쿼리 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 상품 숨김 및 품절 상태 변경 요청의 입력 검증 강화
  * AI 설명 생성 시 최대 길이 제한 및 오류 처리 개선
  * 스토어 조회 실패 시 더 정확한 예외 처리
  * AI API 응답 처리 실패 시 로깅 추가

* **테스트**
  * 상품 업데이트 엔드포인트의 입력 검증 실패 사례 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->