### PR TITLE
feat: 스토어·카테고리·리전 공개 조회 정책 정리

### DIFF
--- a/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
@@ -47,9 +47,17 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/signup")
                         .permitAll()
-                        // 상품 조회
+                        // 공개 조회 엔드포인트
                         .requestMatchers(HttpMethod.GET,
                                 "/api/v1/products/*",
+                                "/api/v1/regions",
+                                "/api/v1/regions/root",
+                                "/api/v1/regions/*",
+                                "/api/v1/regions/*/children",
+                                "/api/v1/store-categories",
+                                "/api/v1/store-categories/*",
+                                "/api/v1/stores",
+                                "/api/v1/stores/*",
                                 "/api/v1/stores/*/products"
                         ).permitAll()
                         // --- 그 외 전부 인증 필요 ---

--- a/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/common/config/security/SecurityConfig.java
@@ -47,6 +47,13 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/signup")
                         .permitAll()
+                        // 관리자 전용 조회 엔드포인트
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/regions/inactive",
+                                "/api/v1/store-categories/inactive",
+                                "/api/v1/store-categories/all",
+                                "/api/v1/stores/inactive"
+                        ).hasAnyRole("MANAGER", "MASTER")
                         // 공개 조회 엔드포인트
                         .requestMatchers(HttpMethod.GET,
                                 "/api/v1/products/*",

--- a/src/main/java/com/sparta/delivery/region/application/RegionService.java
+++ b/src/main/java/com/sparta/delivery/region/application/RegionService.java
@@ -61,6 +61,11 @@ public class RegionService {
     /** 지역 단건 조회 */
     public RegionResponse getRegion(UUID regionId) {
         Region region = getRegionOrThrow(regionId);
+
+        if (!region.getIsActive()) {
+            throw new RegionNotFoundException();
+        }
+
         return RegionResponse.from(region);
     }
 
@@ -68,22 +73,30 @@ public class RegionService {
     public PageResponse<RegionResponse> searchRegions(String keyword, Pageable pageable) {
         String normalizedKeyword = keyword == null ? null : keyword.trim();
         Page<Region> page = (normalizedKeyword == null || normalizedKeyword.isBlank())
-                ? regionRepository.findAll(pageable)
-                : regionRepository.findByRegionNameContaining(normalizedKeyword, pageable);
+                ? regionRepository.findByIsActiveTrue(pageable)
+                : regionRepository.findByRegionNameContainingAndIsActiveTrue(normalizedKeyword, pageable);
 
         return PageResponse.from(page.map(RegionResponse::from));
     }
 
+    /** 비활성 지역 목록 조회 */
+    public PageResponse<RegionResponse> getInactiveRegions(Pageable pageable) {
+        Page<RegionResponse> page = regionRepository.findByIsActiveFalse(pageable)
+                .map(RegionResponse::from);
+
+        return PageResponse.from(page);
+    }
+
     /** 최상위 지역 목록 조회 */
     public List<RegionResponse> getRootRegions() {
-        return regionRepository.findByParentIdIsNull().stream()
+        return regionRepository.findByParentIdIsNullAndIsActiveTrue().stream()
                 .map(RegionResponse::from)
                 .toList();
     }
 
     /** 특정 지역의 하위 지역 목록 조회 */
     public List<RegionResponse> getChildRegions(UUID parentId) {
-        return regionRepository.findByParentId(parentId).stream()
+        return regionRepository.findByParentIdAndIsActiveTrue(parentId).stream()
                 .map(RegionResponse::from)
                 .toList();
     }

--- a/src/main/java/com/sparta/delivery/region/domain/repository/RegionRepository.java
+++ b/src/main/java/com/sparta/delivery/region/domain/repository/RegionRepository.java
@@ -26,7 +26,17 @@ public interface RegionRepository extends JpaRepository<Region, UUID> {
 
     Page<Region> findByRegionNameContaining(String keyword, Pageable pageable);
 
+    Page<Region> findByIsActiveTrue(Pageable pageable);
+
+    Page<Region> findByIsActiveFalse(Pageable pageable);
+
+    Page<Region> findByRegionNameContainingAndIsActiveTrue(String keyword, Pageable pageable);
+
     List<Region> findByParentId(UUID parentId);
 
+    List<Region> findByParentIdAndIsActiveTrue(UUID parentId);
+
     List<Region> findByParentIdIsNull();
+
+    List<Region> findByParentIdIsNullAndIsActiveTrue();
 }

--- a/src/main/java/com/sparta/delivery/region/presentation/RegionController.java
+++ b/src/main/java/com/sparta/delivery/region/presentation/RegionController.java
@@ -67,6 +67,16 @@ public class RegionController {
         return ResponseEntity.ok(ApiResponse.success(regionService.searchRegions(keyword, pageable)));
     }
 
+    @Operation(summary = "비활성 지역 목록 조회")
+    @GetMapping("/inactive")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<PageResponse<RegionResponse>>> getInactiveRegions(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(regionService.getInactiveRegions(pageable)));
+    }
+
     @Operation(summary = "최상위 지역 목록 조회")
     @GetMapping("/root")
     public ResponseEntity<ApiResponse<List<RegionResponse>>> getRootRegions() {

--- a/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreCategoryService.java
@@ -91,7 +91,13 @@ public class StoreCategoryService {
 
     /** 가게 카테고리를 단건 조회한다. */
     public StoreCategoryResponse getCategory(UUID categoryId) {
-        return StoreCategoryResponse.from(getCategoryOrThrow(categoryId));
+        StoreCategory category = getCategoryOrThrow(categoryId);
+
+        if (!category.getIsActive()) {
+            throw new StoreCategoryNotFoundException();
+        }
+
+        return StoreCategoryResponse.from(category);
     }
 
     /** 가게 카테고리 정보를 수정한다. */

--- a/src/main/java/com/sparta/delivery/store/application/StoreService.java
+++ b/src/main/java/com/sparta/delivery/store/application/StoreService.java
@@ -116,10 +116,26 @@ public class StoreService {
     }
 
     /**
+     * 비활성화된 가게 목록을 조회한다.
+     */
+    public PageResponse<StoreResponse> getInactiveStores(Pageable pageable) {
+        Page<StoreResponse> page = storeRepository.findAllByIsActiveFalse(pageable)
+                .map(StoreResponse::from);
+
+        return PageResponse.from(page);
+    }
+
+    /**
      * 가게를 단건 조회한다.
      */
     public StoreResponse getStore(UUID storeId) {
-        return StoreResponse.from(getStoreOrThrow(storeId));
+        Store store = getStoreOrThrow(storeId);
+
+        if (!store.getIsActive()) {
+            throw new StoreNotFoundException();
+        }
+
+        return StoreResponse.from(store);
     }
 
     /**

--- a/src/main/java/com/sparta/delivery/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/delivery/store/domain/repository/StoreRepository.java
@@ -4,6 +4,8 @@ import com.sparta.delivery.store.domain.entity.Store;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, UUID>, StoreRepositoryCustom {
@@ -17,4 +19,6 @@ public interface StoreRepository extends JpaRepository<Store, UUID>, StoreReposi
     List<Store> findByCategoryId(UUID categoryId);
 
     List<Store> findByRegionIdAndCategoryId(UUID regionId, UUID categoryId);
+
+    Page<Store> findAllByIsActiveFalse(Pageable pageable);
 }

--- a/src/main/java/com/sparta/delivery/store/presentation/StoreController.java
+++ b/src/main/java/com/sparta/delivery/store/presentation/StoreController.java
@@ -87,9 +87,23 @@ public class StoreController {
                 createdBefore
         );
 
+        UserRole actorRole = principal != null
+                ? UserRole.valueOf(principal.getRole())
+                : null;
+
         return ResponseEntity.ok(ApiResponse.success(
-                storeService.searchStores(condition, pageable, UserRole.valueOf(principal.getRole()))
+                storeService.searchStores(condition, pageable, actorRole)
         ));
+    }
+
+    @Operation(summary = "비활성 가게 목록 조회")
+    @GetMapping("/inactive")
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<PageResponse<StoreResponse>>> getInactiveStores(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(storeService.getInactiveStores(pageable)));
     }
 
     @Operation(summary = "가게 단건 조회")

--- a/src/test/java/com/sparta/delivery/region/application/RegionServiceTest.java
+++ b/src/test/java/com/sparta/delivery/region/application/RegionServiceTest.java
@@ -272,6 +272,30 @@ class RegionServiceTest {
         }
 
         @Test
+        @DisplayName("비활성 지역은 공개 단건 조회에서 숨긴다")
+        void getRegion_fail_whenInactive() {
+            // given
+            UUID regionId = UUID.randomUUID();
+
+            Region inactiveRegion = Region.create(
+                    "1100000000",
+                    "서울특별시",
+                    null,
+                    1,
+                    false
+            );
+
+            given(regionRepository.findByRegionId(regionId)).willReturn(Optional.of(inactiveRegion));
+
+            // when & then
+            assertThatThrownBy(() -> regionService.getRegion(regionId))
+                    .isInstanceOf(RegionNotFoundException.class)
+                    .hasMessageContaining("지역");
+
+            then(regionRepository).should().findByRegionId(regionId);
+        }
+
+        @Test
         @DisplayName("keyword가 없으면 전체 지역 목록을 조회한다")
         void searchRegions_success_withoutKeyword() {
             // given
@@ -292,7 +316,7 @@ class RegionServiceTest {
             );
 
             Pageable pageable = PageRequest.of(0, 10);
-            given(regionRepository.findAll(pageable))
+            given(regionRepository.findByIsActiveTrue(pageable))
                     .willReturn(new PageImpl<>(List.of(seoul, busan), pageable, 2));
 
             // when
@@ -306,7 +330,7 @@ class RegionServiceTest {
             assertThat(responses.page()).isEqualTo(0);
             assertThat(responses.size()).isEqualTo(10);
 
-            then(regionRepository).should().findAll(pageable);
+            then(regionRepository).should().findByIsActiveTrue(pageable);
         }
 
         @Test
@@ -324,7 +348,7 @@ class RegionServiceTest {
             );
 
             Pageable pageable = PageRequest.of(0, 10);
-            given(regionRepository.findByRegionNameContaining("종로", pageable))
+            given(regionRepository.findByRegionNameContainingAndIsActiveTrue("종로", pageable))
                     .willReturn(new PageImpl<>(List.of(jongno), pageable, 1));
 
             // when
@@ -335,7 +359,7 @@ class RegionServiceTest {
             assertThat(responses.content().get(0).regionName()).isEqualTo("종로구");
             assertThat(responses.content().get(0).parentId()).isEqualTo(parentId);
 
-            then(regionRepository).should().findByRegionNameContaining("종로", pageable);
+            then(regionRepository).should().findByRegionNameContainingAndIsActiveTrue("종로", pageable);
         }
 
         @Test
@@ -351,7 +375,7 @@ class RegionServiceTest {
             );
 
             Pageable pageable = PageRequest.of(0, 10);
-            given(regionRepository.findByRegionNameContaining("종로", pageable))
+            given(regionRepository.findByRegionNameContainingAndIsActiveTrue("종로", pageable))
                     .willReturn(new PageImpl<>(List.of(jongno), pageable, 1));
 
             // when
@@ -361,7 +385,7 @@ class RegionServiceTest {
             assertThat(responses.content()).hasSize(1);
             assertThat(responses.content().get(0).regionName()).isEqualTo("종로구");
 
-            then(regionRepository).should().findByRegionNameContaining("종로", pageable);
+            then(regionRepository).should().findByRegionNameContainingAndIsActiveTrue("종로", pageable);
         }
 
         @Test
@@ -384,7 +408,7 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.findByParentIdIsNull()).willReturn(List.of(seoul, busan));
+            given(regionRepository.findByParentIdIsNullAndIsActiveTrue()).willReturn(List.of(seoul, busan));
 
             // when
             var responses = regionService.getRootRegions();
@@ -395,7 +419,7 @@ class RegionServiceTest {
                     .extracting("regionName")
                     .containsExactly("서울특별시", "부산광역시");
 
-            then(regionRepository).should().findByParentIdIsNull();
+            then(regionRepository).should().findByParentIdIsNullAndIsActiveTrue();
         }
 
         @Test
@@ -412,7 +436,7 @@ class RegionServiceTest {
                     true
             );
 
-            given(regionRepository.findByParentId(parentId)).willReturn(List.of(jongno));
+            given(regionRepository.findByParentIdAndIsActiveTrue(parentId)).willReturn(List.of(jongno));
 
             // when
             var responses = regionService.getChildRegions(parentId);
@@ -422,7 +446,7 @@ class RegionServiceTest {
             assertThat(responses.get(0).regionName()).isEqualTo("종로구");
             assertThat(responses.get(0).parentId()).isEqualTo(parentId);
 
-            then(regionRepository).should().findByParentId(parentId);
+            then(regionRepository).should().findByParentIdAndIsActiveTrue(parentId);
         }
     }
 

--- a/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/delivery/store/application/StoreCategoryServiceTest.java
@@ -161,6 +161,19 @@ class StoreCategoryServiceTest {
         }
 
         @Test
+        @DisplayName("비활성 카테고리는 공개 단건 조회에서 숨긴다")
+        void getCategory_fail_whenInactive() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            StoreCategory inactiveCategory = createCategory(categoryId, "치킨", 1, false);
+            given(storeCategoryRepository.findByCategoryId(categoryId)).willReturn(Optional.of(inactiveCategory));
+
+            // when & then
+            assertThatThrownBy(() -> storeCategoryService.getCategory(categoryId))
+                    .isInstanceOf(StoreCategoryNotFoundException.class);
+        }
+
+        @Test
         @DisplayName("전체 카테고리 목록을 조회한다")
         void getCategories_success() {
             // given

--- a/src/test/java/com/sparta/delivery/store/application/StoreServiceTest.java
+++ b/src/test/java/com/sparta/delivery/store/application/StoreServiceTest.java
@@ -373,6 +373,22 @@ class StoreServiceTest {
             assertThatThrownBy(() -> storeService.getStore(storeId))
                     .isInstanceOf(StoreNotFoundException.class);
         }
+
+        @Test
+        @DisplayName("비활성 가게는 공개 단건 조회에서 숨긴다")
+        void getStore_fail_whenInactive() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            Store inactiveStore = createStoreEntity(UUID.randomUUID(), UUID.randomUUID(), 1L);
+            ReflectionTestUtils.setField(inactiveStore, "storeId", storeId);
+            ReflectionTestUtils.setField(inactiveStore, "isActive", false);
+
+            given(storeRepository.findByStoreId(storeId)).willReturn(Optional.of(inactiveStore));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.getStore(storeId))
+                    .isInstanceOf(StoreNotFoundException.class);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #87

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 스토어·카테고리·리전 공개 조회 정책 정리 |
| 🔍 목적 | 공개 조회 API에서 비활성 데이터 노출을 막고, 관리자 전용 inactive 조회를 분리해 조회 정책을 일관되게 정리 |
| 🛠️ 변경사항 | 공개 조회 GET 경로를 `permitAll()`로 정리하고, 공개 단건/목록 조회에서는 활성 데이터만 노출되도록 수정. 관리자 전용 `inactive` 조회 API 추가 |

## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `SecurityConfig`에서 스토어, 카테고리, 리전 조회 GET 경로를 공개 접근 가능하도록 정리 |
| 2️⃣ | 스토어 목록 조회에서 비로그인 요청 시 `principal` null 처리 추가, 공개 조회에서는 비활성 스토어/카테고리/리전이 노출되지 않도록 서비스 로직 수정 |
| 3️⃣ | 관리자 전용 `GET /api/v1/stores/inactive`, `GET /api/v1/regions/inactive` API 추가 및 관련 repository/service 로직 확장 |

---

## ✅ 테스트 체크리스트
- [x] `./gradlew compileJava` 정상 동작 확인
- [x] 공개 조회 경로 추가 후 컴파일 오류 없는지 확인
- [x] 공개 단건/목록 조회에서 비활성 데이터 숨김 로직 반영 확인


---

## 🙋‍♀️ 리뷰어 참고사항
- 공개 조회 정책은 `활성 데이터만 노출`로 통일했습니다.
- 관리자 전용 운영 조회는 `/inactive` 엔드포인트로 분리했습니다.
- 스토어 목록 조회는 비로그인 요청도 허용하도록 수정했고, 이때는 공개 사용자로 간주해 활성 가게만 조회합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 전용 비활성 지역·비활성 매장 페이징 조회 API 추가

* **보안**
  * 일부 GET API(지역, 매장 카테고리, 매장)의 공개 읽기 범위 확장 — 특정 경로는 인증 없이 접근 가능, 일부 경로는 관리자 권한 필요

* **개선**
  * 단건 조회·검색에서 비활성 항목을 숨기도록 일관성 개선
  * 매장 목록 조회 시 호출자 역할 처리 개선

* **테스트**
  * 비활성 항목 처리 관련 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->