### PR TITLE
refactor: AI-Product 성능 최적화 (캐싱, 비동기, 동시성, 인덱스)

### DIFF
--- a/src/main/java/com/sparta/delivery/ai/application/AiDescriptionService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/AiDescriptionService.java
@@ -2,8 +2,12 @@ package com.sparta.delivery.ai.application;
 
 import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmInputSnapshot;
+import com.sparta.delivery.product.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
@@ -11,7 +15,8 @@ public class AiDescriptionService {
 
     private final LlmOrchestrator llmOrchestrator;
 
-    public String generateDescription(
+    @Async("llmAsyncExecutor")
+    public CompletableFuture<String> generateDescription(
             Long actorId,
             String productName,
             Integer price,
@@ -32,9 +37,11 @@ public class AiDescriptionService {
             throw new ExternalLlmCallFailedException();
         }
 
-        return generatedText.length() > 50
+        String trimmed = generatedText.length() > 50
                 ? generatedText.substring(0, 50)
                 : generatedText;
+
+        return CompletableFuture.completedFuture(trimmed);
     }
 
 

--- a/src/main/java/com/sparta/delivery/ai/application/LlmOrchestrator.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmOrchestrator.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.delivery.ai.domain.entity.Llm;
 import com.sparta.delivery.ai.domain.entity.LlmCall;
-import com.sparta.delivery.ai.domain.exception.ActiveLlmNotFoundException;
 import com.sparta.delivery.ai.domain.exception.LlmInputSnapshotSerializationException;
 import com.sparta.delivery.ai.domain.repository.LlmCallRepository;
-import com.sparta.delivery.ai.domain.repository.LlmRepository;
 import com.sparta.delivery.ai.infrastructure.external.llm.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,23 +13,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
-
 @Service
 @Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class LlmOrchestrator {
 
-    private final LlmRepository llmRepository;
+    private final LlmService llmService;
     private final LlmCallRepository llmCallRepository;
     private final LlmClientRegistry llmClientRegistry;
     private final ObjectMapper objectMapper;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public LlmGenerateResponse generate(Long actorId, LlmInputSnapshot inputSnapshot) {
-        Llm activeLlm = llmRepository.findByIsActiveTrue()
-                .orElseThrow(ActiveLlmNotFoundException::new);
+        Llm activeLlm = llmService.getActiveLlm();
 
         String serializedInputSnapshot = createJsonInputSnapshot(inputSnapshot);
 

--- a/src/main/java/com/sparta/delivery/ai/application/LlmOrchestrator.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmOrchestrator.java
@@ -2,10 +2,10 @@ package com.sparta.delivery.ai.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.delivery.ai.domain.entity.Llm;
 import com.sparta.delivery.ai.domain.entity.LlmCall;
 import com.sparta.delivery.ai.domain.exception.LlmInputSnapshotSerializationException;
 import com.sparta.delivery.ai.domain.repository.LlmCallRepository;
+import com.sparta.delivery.ai.domain.vo.ActiveLlmInfo;
 import com.sparta.delivery.ai.infrastructure.external.llm.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,11 +26,11 @@ public class LlmOrchestrator {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public LlmGenerateResponse generate(Long actorId, LlmInputSnapshot inputSnapshot) {
-        Llm activeLlm = llmService.getActiveLlm();
+        ActiveLlmInfo activeLlm = llmService.getActiveLlm();
 
         String serializedInputSnapshot = createJsonInputSnapshot(inputSnapshot);
 
-        LlmClient client = llmClientRegistry.getClient(activeLlm.getProvider());
+        LlmClient client = llmClientRegistry.getClient(activeLlm.provider());
 
         LlmGenerateResponse response = client.generate(
                 activeLlm,
@@ -38,7 +38,7 @@ public class LlmOrchestrator {
         );
 
         LlmCall llmCall = LlmCall.create(
-                activeLlm.getLlmId(),
+                activeLlm.llmId(),
                 serializedInputSnapshot,
                 response.finishReason(),
                 response.rawResponse(),

--- a/src/main/java/com/sparta/delivery/ai/application/LlmService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmService.java
@@ -3,12 +3,15 @@ package com.sparta.delivery.ai.application;
 import com.sparta.delivery.ai.domain.entity.Llm;
 import com.sparta.delivery.ai.domain.exception.*;
 import com.sparta.delivery.ai.domain.repository.LlmRepository;
+import com.sparta.delivery.ai.domain.vo.ActiveLlmInfo;
 import com.sparta.delivery.ai.presentation.dto.request.LlmCreateRequest;
 import com.sparta.delivery.ai.presentation.dto.request.LlmUpdateRequest;
 import com.sparta.delivery.ai.presentation.dto.response.LlmResponse;
 import com.sparta.delivery.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -27,6 +30,7 @@ import java.util.UUID;
 public class LlmService {
 
     private final LlmRepository llmRepository;
+    private final CacheManager cacheManager;
 
     @Transactional
     public LlmResponse create(Long actorId, UserRole actorRole, LlmCreateRequest request) {
@@ -98,6 +102,16 @@ public class LlmService {
         Llm llm = getLlmOrThrow(llmId);
         validateDuplicateLlmNameOnUpdate(llm, request.llmName());
         llm.updateName(request.llmName());
+
+        if (llm.isActive()) {
+            Cache cache = cacheManager.getCache("activeLlm");
+            if (cache != null) {
+                cache.evict("current");
+            } else {
+                log.warn("activeLlm 캐시를 찾을 수 없습니다.");
+            }
+        }
+
         log.info("LLM 이름 변경 완료 - actorId={}, llmId={}, provider={}, llmName={}",
                 actorId, llm.getLlmId(), llm.getProvider(), llm.getLlmName());
 
@@ -168,8 +182,9 @@ public class LlmService {
     }
 
     @Cacheable(cacheNames = "activeLlm", key = "'current'")
-    public Llm getActiveLlm() {
-        return llmRepository.findByIsActiveTrue()
+    public ActiveLlmInfo getActiveLlm() {
+        Llm llm =  llmRepository.findByIsActiveTrue()
                 .orElseThrow(ActiveLlmNotFoundException::new);
+        return new ActiveLlmInfo(llm.getLlmId(), llm.getLlmName(), llm.getProvider());
     }
 }

--- a/src/main/java/com/sparta/delivery/ai/application/LlmService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmService.java
@@ -1,10 +1,7 @@
 package com.sparta.delivery.ai.application;
 
 import com.sparta.delivery.ai.domain.entity.Llm;
-import com.sparta.delivery.ai.domain.exception.CannotDeleteActiveLlmException;
-import com.sparta.delivery.ai.domain.exception.DuplicateLlmNameException;
-import com.sparta.delivery.ai.domain.exception.AiForbiddenException;
-import com.sparta.delivery.ai.domain.exception.LlmNotFoundException;
+import com.sparta.delivery.ai.domain.exception.*;
 import com.sparta.delivery.ai.domain.repository.LlmRepository;
 import com.sparta.delivery.ai.presentation.dto.request.LlmCreateRequest;
 import com.sparta.delivery.ai.presentation.dto.request.LlmUpdateRequest;
@@ -12,6 +9,8 @@ import com.sparta.delivery.ai.presentation.dto.response.LlmResponse;
 import com.sparta.delivery.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -106,6 +105,7 @@ public class LlmService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = "activeLlm", key = "'current'")
     public LlmResponse activate(Long actorId, UserRole actorRole, UUID llmId) {
         validateLlmPermission(actorRole);
         Llm target = getLlmOrThrow(llmId);
@@ -165,5 +165,11 @@ public class LlmService {
     private void deactivateCurrentActiveLlm() {
         llmRepository.findByIsActiveTrueForUpdate()
                 .ifPresent(Llm::deactivate);
+    }
+
+    @Cacheable(cacheNames = "activeLlm", key = "'current'")
+    public Llm getActiveLlm() {
+        return llmRepository.findByIsActiveTrue()
+                .orElseThrow(ActiveLlmNotFoundException::new);
     }
 }

--- a/src/main/java/com/sparta/delivery/ai/application/LlmService.java
+++ b/src/main/java/com/sparta/delivery/ai/application/LlmService.java
@@ -163,7 +163,7 @@ public class LlmService {
     }
 
     private void deactivateCurrentActiveLlm() {
-        llmRepository.findByIsActiveTrue()
+        llmRepository.findByIsActiveTrueForUpdate()
                 .ifPresent(Llm::deactivate);
     }
 }

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/Llm.java
@@ -14,7 +14,12 @@ import org.hibernate.annotations.SQLRestriction;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_llms")
+@Table(
+        name = "p_llms",
+        indexes = {
+                @Index(name = "idx_llms_is_active", columnList = "is_active")
+        }
+)
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/entity/LlmCall.java
@@ -14,7 +14,13 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_llm_calls")
+@Table(
+        name = "p_llm_calls",
+        indexes = {
+                @Index(name = "idx_llm_calls_llm_id", columnList = "llm_id"),
+                @Index(name = "idx_llm_calls_created_at", columnList = "created_at")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LlmCall {

--- a/src/main/java/com/sparta/delivery/ai/domain/repository/LlmRepository.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/repository/LlmRepository.java
@@ -1,9 +1,11 @@
 package com.sparta.delivery.ai.domain.repository;
 
 import com.sparta.delivery.ai.domain.entity.Llm;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -27,4 +29,8 @@ public interface LlmRepository extends JpaRepository<Llm, UUID> {
             nativeQuery = true
     )
     boolean existsIncludingDeletedByLlmName(@Param("llmName") String llmName);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT l FROM Llm l WHERE l.isActive = true AND l.deletedAt IS NULL")
+    Optional<Llm> findByIsActiveTrueForUpdate();
 }

--- a/src/main/java/com/sparta/delivery/ai/domain/vo/ActiveLlmInfo.java
+++ b/src/main/java/com/sparta/delivery/ai/domain/vo/ActiveLlmInfo.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.ai.domain.vo;
+
+import com.sparta.delivery.ai.domain.entity.LlmProvider;
+
+import java.util.UUID;
+
+public record ActiveLlmInfo(
+        UUID llmId,
+        String llmName,
+        LlmProvider provider
+) {}

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/config/LlmCacheConfig.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/config/LlmCacheConfig.java
@@ -1,0 +1,31 @@
+package com.sparta.delivery.ai.infrastructure.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class LlmCacheConfig {
+
+    @Bean
+    public RedisCacheManager llmCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(24))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/external/llm/LlmClient.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/external/llm/LlmClient.java
@@ -1,10 +1,10 @@
 package com.sparta.delivery.ai.infrastructure.external.llm;
 
-import com.sparta.delivery.ai.domain.entity.Llm;
 import com.sparta.delivery.ai.domain.entity.LlmProvider;
+import com.sparta.delivery.ai.domain.vo.ActiveLlmInfo;
 
 public interface LlmClient {
     boolean supports(LlmProvider provider);
 
-    LlmGenerateResponse generate(Llm llm, LlmGenerateRequest request);
+    LlmGenerateResponse generate(ActiveLlmInfo llm, LlmGenerateRequest request);
 }

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/external/llm/openai/OpenAiClient.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/external/llm/openai/OpenAiClient.java
@@ -2,9 +2,9 @@ package com.sparta.delivery.ai.infrastructure.external.llm.openai;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.delivery.ai.domain.entity.Llm;
 import com.sparta.delivery.ai.domain.entity.LlmProvider;
 import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
+import com.sparta.delivery.ai.domain.vo.ActiveLlmInfo;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmClient;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateRequest;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateResponse;
@@ -29,18 +29,19 @@ public class OpenAiClient implements LlmClient {
     }
 
     @Override
-    public LlmGenerateResponse generate(Llm llm, LlmGenerateRequest request) {
+    public LlmGenerateResponse generate(ActiveLlmInfo llm, LlmGenerateRequest request) {
         try {
             ChatResponse chatResponse = chatClientBuilder.build()
                     .prompt()
                     .options(OpenAiChatOptions.builder()
-                            .model(llm.getLlmName())
-                            .maxTokens(40)
+                            .model(llm.llmName())
+                            .maxCompletionTokens(40)
                             .build())
                     .system("""
                         당신은 음식 배달 플랫폼의 상품 설명 작성 전문가입니다.
                         - 고객이 음식을 주문하고 싶어지도록 매력적으로 작성하세요.
                         - 3문장 이하로 간결하게 작성하세요. 총 길이는 한글 음절수 기준 50자를 넘을 수 없습니다.
+                        - 줄바꿈("\n") 없이 한 줄 안에 상품 설명을 완성하세요.
                         - 과장된 표현은 피하고 자연스러운 문체를 유지하세요.
                         """)
                     .user(request.prompt())
@@ -52,7 +53,7 @@ public class OpenAiClient implements LlmClient {
                 rawResponse = objectMapper.writeValueAsString(chatResponse);
             } catch (JsonProcessingException e) {
                 log.warn("[OpenAI Client] ChatResponse Serialization 실패: model={}, error={}",
-                        llm.getLlmName(), e.getMessage());
+                        llm.llmName(), e.getMessage());
                 rawResponse = null;
             }
 

--- a/src/main/java/com/sparta/delivery/common/config/async/AsyncConfig.java
+++ b/src/main/java/com/sparta/delivery/common/config/async/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.sparta.delivery.common.config.async;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "llmAsyncExecutor")
+    public Executor llmAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(30);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("LLM-Executor-");
+
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/sparta/delivery/product/application/ProductService.java
+++ b/src/main/java/com/sparta/delivery/product/application/ProductService.java
@@ -70,12 +70,9 @@ public class ProductService {
         // hidden 이라면 권한 별 분기 처리
         Store store = getStoreOrThrow(product.getStoreId());
 
-        boolean canViewHidden =
-                actorRole == UserRole.MANAGER
-                || actorRole == UserRole.MASTER
-                || (actorRole == UserRole.OWNER && store.getUserId().equals(actorId));
+        boolean hiddenAccessibility = hiddenAccessibility(actorId, actorRole, store);
 
-        if (!canViewHidden) {
+        if (!hiddenAccessibility) {
             throw new ProductNotFoundException();
         }
 
@@ -93,10 +90,7 @@ public class ProductService {
     ) {
         Store store = getStoreOrThrow(storeId);
 
-        boolean canViewHidden =
-                actorRole == UserRole.MANAGER
-                || actorRole == UserRole.MASTER
-                || (actorRole == UserRole.OWNER && store.getUserId().equals(actorId));
+        boolean hiddenAccessibility = hiddenAccessibility(actorId, actorRole, store);
 
         Pageable pageable = PageRequest.of(
                 Math.max(page, 0),
@@ -106,7 +100,7 @@ public class ProductService {
 
         String normalizedKeyword = normalizeKeyword(keyword);
 
-        Page<Product> products = getProductPage(storeId, normalizedKeyword, canViewHidden, pageable);
+        Page<Product> products = getProductPage(storeId, normalizedKeyword, hiddenAccessibility, pageable);
 
         return products.map(ProductResponse::from);
     }
@@ -205,6 +199,12 @@ public class ProductService {
         if (nameChanged && productRepository.existsByStoreIdAndProductName(product.getStoreId(), productName)) {
             throw new DuplicateProductNameException();
         }
+    }
+
+    private boolean hiddenAccessibility(Long actorId, UserRole actorRole, Store store) {
+        return actorRole == UserRole.MANAGER
+                || actorRole == UserRole.MASTER
+                || (actorRole == UserRole.OWNER && store.getUserId().equals(actorId));
     }
 
     private Product createProduct(

--- a/src/main/java/com/sparta/delivery/product/application/ProductService.java
+++ b/src/main/java/com/sparta/delivery/product/application/ProductService.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.product.application;
 
 import com.sparta.delivery.ai.application.AiDescriptionService;
+import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
 import com.sparta.delivery.store.domain.exception.StoreNotFoundException;
 import com.sparta.delivery.product.domain.entity.DescriptionSource;
 import com.sparta.delivery.product.domain.entity.Product;
@@ -26,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
 @Service
 @Slf4j
@@ -276,12 +278,19 @@ public class ProductService {
 
     private String resolveDescription(Long actorId, ProductCreateRequest request) {
         if (request.shouldGenerateDescription()) {
-            return aiDescriptionService.generateDescription(
-                    actorId,
-                    request.productName(),
-                    request.price(),
-                    request.aiPromptText()
-            );
+            try {
+                return aiDescriptionService.generateDescription(
+                        actorId,
+                        request.productName(),
+                        request.price(),
+                        request.aiPromptText()
+                ).get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new ExternalLlmCallFailedException();
+            } catch (ExecutionException e) {
+                throw new ExternalLlmCallFailedException();
+            }
         }
         return request.description();
     }

--- a/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
+++ b/src/main/java/com/sparta/delivery/product/domain/entity/Product.java
@@ -12,7 +12,13 @@ import org.hibernate.annotations.SQLRestriction;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_product")
+@Table(
+        name = "p_product",
+        indexes = {
+                @Index(name = "idx_product_store_id", columnList = "store_id"),
+                @Index(name = "idx_product_store_id_name", columnList = "store_id, product_name")
+        }
+)
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/test/java/com/sparta/delivery/ai/application/AiDescriptionServiceTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/AiDescriptionServiceTest.java
@@ -8,9 +8,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
-
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateResponse;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmInputSnapshot;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,57 +35,46 @@ class AiDescriptionServiceTest {
 
         @Test
         @DisplayName("throws ExternalLlmCallFailedException when generated text is null")
-        void generateDescription_fail_whenGeneratedTextIsNull() {
+        void generateDescription_fail_whenGeneratedTextIsNull() throws Exception {
             // given
             Long actorId = 1L;
-            LlmGenerateResponse response = new LlmGenerateResponse(
-                    null,
-                    null,
-                    "STOP"
-            );
+            LlmGenerateResponse response = new LlmGenerateResponse(null, null, "STOP");
             given(llmOrchestrator.generate(eq(actorId), any(LlmInputSnapshot.class))).willReturn(response);
 
             // when & then
+            // @Async는 단위 테스트에서 동기 실행되므로 호출 자체에서 예외가 발생한다
             assertThatThrownBy(() -> aiDescriptionService.generateDescription(
                     actorId, "Americano", 4500, null
-            )).isInstanceOf(ExternalLlmCallFailedException.class);
+            ).get()).isInstanceOf(ExternalLlmCallFailedException.class);
         }
 
         @Test
         @DisplayName("throws ExternalLlmCallFailedException when generated text is blank")
-        void generateDescription_fail_whenGeneratedTextIsBlank() {
+        void generateDescription_fail_whenGeneratedTextIsBlank() throws Exception {
             // given
             Long actorId = 1L;
-            LlmGenerateResponse response = new LlmGenerateResponse(
-                    "   ",
-                    null,
-                    "STOP"
-            );
+            LlmGenerateResponse response = new LlmGenerateResponse("   ", null, "STOP");
             given(llmOrchestrator.generate(eq(actorId), any(LlmInputSnapshot.class))).willReturn(response);
 
             // when & then
             assertThatThrownBy(() -> aiDescriptionService.generateDescription(
                     actorId, "Americano", 4500, null
-            )).isInstanceOf(ExternalLlmCallFailedException.class);
+            ).get()).isInstanceOf(ExternalLlmCallFailedException.class);
         }
 
         @Test
         @DisplayName("trims generated text to 50 characters when it exceeds limit")
-        void generateDescription_success_trimmedTo50() {
+        void generateDescription_success_trimmedTo50() throws Exception {
             // given
             Long actorId = 1L;
             String longText = "가".repeat(60); // 60자
-            LlmGenerateResponse response = new LlmGenerateResponse(
-                    longText,
-                    null,
-                    "STOP"
-            );
+            LlmGenerateResponse response = new LlmGenerateResponse(longText, null, "STOP");
             given(llmOrchestrator.generate(eq(actorId), any(LlmInputSnapshot.class))).willReturn(response);
 
             // when
             String result = aiDescriptionService.generateDescription(
                     actorId, "Americano", 4500, null
-            );
+            ).get();
 
             // then
             assertThat(result).hasSize(50);
@@ -93,7 +82,7 @@ class AiDescriptionServiceTest {
 
         @Test
         @DisplayName("returns generated text from llm orchestrator")
-        void generateDescription_success() {
+        void generateDescription_success() throws Exception {
             // given
             Long actorId = 1L;
             String productName = "Americano";
@@ -104,16 +93,12 @@ class AiDescriptionServiceTest {
                     "{\"result\":\"ok\"}",
                     "STOP"
             );
-
             given(llmOrchestrator.generate(eq(actorId), any(LlmInputSnapshot.class))).willReturn(response);
 
             // when
             String generatedDescription = aiDescriptionService.generateDescription(
-                    actorId,
-                    productName,
-                    price,
-                    aiPromptText
-            );
+                    actorId, productName, price, aiPromptText
+            ).get();
 
             // then
             assertThat(generatedDescription).isEqualTo("generated text");

--- a/src/test/java/com/sparta/delivery/ai/application/LlmOrchestratorTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/LlmOrchestratorTest.java
@@ -17,13 +17,11 @@ import com.sparta.delivery.ai.domain.exception.ActiveLlmNotFoundException;
 import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
 import com.sparta.delivery.ai.domain.exception.LlmInputSnapshotSerializationException;
 import com.sparta.delivery.ai.domain.repository.LlmCallRepository;
-import com.sparta.delivery.ai.domain.repository.LlmRepository;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmClient;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmClientRegistry;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateResponse;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmInputSnapshot;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,8 +36,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class LlmOrchestratorTest {
 
+    // LlmOrchestrator는 LlmService.getActiveLlm()을 통해 활성 LLM을 조회한다.
+    // LlmRepository를 직접 mock하지 않는다.
     @Mock
-    private LlmRepository llmRepository;
+    private LlmService llmService;
 
     @Mock
     private LlmCallRepository llmCallRepository;
@@ -76,7 +76,7 @@ class LlmOrchestratorTest {
                     "200"
             );
 
-            given(llmRepository.findByIsActiveTrue()).willReturn(Optional.of(activeLlm));
+            given(llmService.getActiveLlm()).willReturn(activeLlm);
             given(objectMapper.writeValueAsString(any(LlmInputSnapshot.class))).willReturn(inputSnapshot);
             given(llmClientRegistry.getClient(LlmProvider.OPENAI)).willReturn(llmClient);
             given(llmClient.generate(eq(activeLlm), any())).willReturn(llmGenerateResponse);
@@ -109,9 +109,9 @@ class LlmOrchestratorTest {
             Long actorId = 1L;
             LlmInputSnapshot llmInputSnapshot = new LlmInputSnapshot("prompt", "Americano", 4500, null);
 
-            given(llmRepository.findByIsActiveTrue()).willReturn(Optional.empty());
+            given(llmService.getActiveLlm()).willThrow(new ActiveLlmNotFoundException());
 
-            // when // then
+            // when & then
             assertThatThrownBy(() -> llmOrchestrator.generate(actorId, llmInputSnapshot))
                     .isInstanceOf(ActiveLlmNotFoundException.class);
 
@@ -130,12 +130,12 @@ class LlmOrchestratorTest {
             String inputSnapshot = "{\"prompt\":\"prompt\"}";
             Llm activeLlm = createLlm(llmId, "gpt-5.4-mini", LlmProvider.OPENAI, true);
 
-            given(llmRepository.findByIsActiveTrue()).willReturn(Optional.of(activeLlm));
+            given(llmService.getActiveLlm()).willReturn(activeLlm);
             given(objectMapper.writeValueAsString(any(LlmInputSnapshot.class))).willReturn(inputSnapshot);
             given(llmClientRegistry.getClient(LlmProvider.OPENAI)).willReturn(llmClient);
             given(llmClient.generate(eq(activeLlm), any())).willThrow(new ExternalLlmCallFailedException());
 
-            // when // then
+            // when & then
             assertThatThrownBy(() -> llmOrchestrator.generate(actorId, llmInputSnapshot))
                     .isInstanceOf(ExternalLlmCallFailedException.class);
 
@@ -151,11 +151,11 @@ class LlmOrchestratorTest {
             LlmInputSnapshot llmInputSnapshot = new LlmInputSnapshot("prompt", "Americano", 4500, null);
             Llm activeLlm = createLlm(llmId, "gpt-5.4-mini", LlmProvider.OPENAI, true);
 
-            given(llmRepository.findByIsActiveTrue()).willReturn(Optional.of(activeLlm));
+            given(llmService.getActiveLlm()).willReturn(activeLlm);
             given(objectMapper.writeValueAsString(any(LlmInputSnapshot.class)))
                     .willThrow(new JsonProcessingException("serialize fail") { });
 
-            // when // then
+            // when & then
             assertThatThrownBy(() -> llmOrchestrator.generate(actorId, llmInputSnapshot))
                     .isInstanceOf(LlmInputSnapshotSerializationException.class);
 

--- a/src/test/java/com/sparta/delivery/ai/application/LlmOrchestratorTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/LlmOrchestratorTest.java
@@ -17,6 +17,7 @@ import com.sparta.delivery.ai.domain.exception.ActiveLlmNotFoundException;
 import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
 import com.sparta.delivery.ai.domain.exception.LlmInputSnapshotSerializationException;
 import com.sparta.delivery.ai.domain.repository.LlmCallRepository;
+import com.sparta.delivery.ai.domain.vo.ActiveLlmInfo;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmClient;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmClientRegistry;
 import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateResponse;
@@ -69,7 +70,7 @@ class LlmOrchestratorTest {
             String prompt = "prompt";
             LlmInputSnapshot llmInputSnapshot = new LlmInputSnapshot(prompt, "Americano", 4500, "고소한 맛을 강조해줘");
             String inputSnapshot = "{\"prompt\":\"prompt\"}";
-            Llm activeLlm = createLlm(llmId, "gpt-5.4-mini", LlmProvider.OPENAI, true);
+            ActiveLlmInfo activeLlm = new ActiveLlmInfo(llmId, "gpt-5.4-mini", LlmProvider.OPENAI);
             LlmGenerateResponse llmGenerateResponse = new LlmGenerateResponse(
                     "generated text",
                     "{\"result\":\"ok\"}",
@@ -92,7 +93,7 @@ class LlmOrchestratorTest {
             then(llmCallRepository).should().save(llmCallCaptor.capture());
 
             LlmCall savedCall = llmCallCaptor.getValue();
-            assertThat(savedCall.getLlmId()).isEqualTo(llmId);
+            assertThat(savedCall.getLlmId()).isEqualTo(activeLlm.llmId());
             assertThat(savedCall.getProductId()).isNull();
             assertThat(savedCall.getInputSnapshot()).isEqualTo(inputSnapshot);
             assertThat(savedCall.getFinishReason()).isEqualTo("200");
@@ -128,7 +129,7 @@ class LlmOrchestratorTest {
             String prompt = "prompt";
             LlmInputSnapshot llmInputSnapshot = new LlmInputSnapshot(prompt, "Americano", 4500, "고소한 맛을 강조해줘");
             String inputSnapshot = "{\"prompt\":\"prompt\"}";
-            Llm activeLlm = createLlm(llmId, "gpt-5.4-mini", LlmProvider.OPENAI, true);
+            ActiveLlmInfo activeLlm = new ActiveLlmInfo(llmId, "gpt-5.4-mini", LlmProvider.OPENAI);
 
             given(llmService.getActiveLlm()).willReturn(activeLlm);
             given(objectMapper.writeValueAsString(any(LlmInputSnapshot.class))).willReturn(inputSnapshot);
@@ -149,7 +150,7 @@ class LlmOrchestratorTest {
             UUID llmId = UUID.randomUUID();
             Long actorId = 1L;
             LlmInputSnapshot llmInputSnapshot = new LlmInputSnapshot("prompt", "Americano", 4500, null);
-            Llm activeLlm = createLlm(llmId, "gpt-5.4-mini", LlmProvider.OPENAI, true);
+            ActiveLlmInfo activeLlm = new ActiveLlmInfo(llmId, "gpt-5.4-mini", LlmProvider.OPENAI);
 
             given(llmService.getActiveLlm()).willReturn(activeLlm);
             given(objectMapper.writeValueAsString(any(LlmInputSnapshot.class)))
@@ -164,11 +165,5 @@ class LlmOrchestratorTest {
         }
     }
 
-    private Llm createLlm(UUID llmId, String llmName, LlmProvider provider, boolean isActive) {
-        Llm llm = Llm.create(llmName, provider, isActive);
-        ReflectionTestUtils.setField(llm, "llmId", llmId);
-        ReflectionTestUtils.setField(llm, "createdAt", LocalDateTime.now().minusDays(1));
-        ReflectionTestUtils.setField(llm, "updatedAt", LocalDateTime.now());
-        return llm;
-    }
 }
+

--- a/src/test/java/com/sparta/delivery/ai/application/LlmServiceTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/LlmServiceTest.java
@@ -193,7 +193,7 @@ class LlmServiceTest {
             Llm target = createLlm(targetId, "gpt-4.1", LlmProvider.OPENAI, false);
 
             given(llmRepository.findByLlmId(targetId)).willReturn(Optional.of(target));
-            given(llmRepository.findByIsActiveTrue()).willReturn(Optional.of(currentActive));
+            given(llmRepository.findByIsActiveTrueForUpdate()).willReturn(Optional.of(currentActive));
 
             var response = llmService.activate(1L, UserRole.MANAGER, targetId);
 

--- a/src/test/java/com/sparta/delivery/ai/application/LlmServiceTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/LlmServiceTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -39,6 +41,9 @@ class LlmServiceTest {
 
     @Mock
     private LlmRepository llmRepository;
+
+    @Mock
+    private CacheManager cacheManager;
 
     @InjectMocks
     private LlmService llmService;
@@ -165,6 +170,24 @@ class LlmServiceTest {
             var response = llmService.changeLlmName(1L, UserRole.MANAGER, llmId, new LlmUpdateRequest("gpt-4.1"));
 
             assertThat(response.llmName()).isEqualTo("gpt-4.1");
+            // 비활성 LLM 이름 변경 시 캐시 evict 없음
+            then(cacheManager).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("evicts cache when active llm name is changed")
+        void changeLlmName_success_evictsCacheWhenActive() {
+            UUID llmId = UUID.randomUUID();
+            Llm llm = createLlm(llmId, "gpt-4.1-mini", LlmProvider.OPENAI, true); // 활성 LLM
+            Cache mockCache = org.mockito.Mockito.mock(Cache.class);
+            given(llmRepository.findByLlmId(llmId)).willReturn(Optional.of(llm));
+            given(llmRepository.existsIncludingDeletedByLlmName("gpt-4.1")).willReturn(false);
+            given(cacheManager.getCache("activeLlm")).willReturn(mockCache);
+
+            var response = llmService.changeLlmName(1L, UserRole.MANAGER, llmId, new LlmUpdateRequest("gpt-4.1"));
+
+            assertThat(response.llmName()).isEqualTo("gpt-4.1");
+            then(mockCache).should().evict("current");
         }
 
         @Test

--- a/src/test/java/com/sparta/delivery/product/application/ProductServiceTest.java
+++ b/src/test/java/com/sparta/delivery/product/application/ProductServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.never;
 
 import com.sparta.delivery.ai.application.AiDescriptionService;
 import com.sparta.delivery.ai.domain.exception.ExternalLlmCallFailedException;
+import java.util.concurrent.CompletableFuture;
 import com.sparta.delivery.product.domain.entity.DescriptionSource;
 import com.sparta.delivery.product.domain.entity.Product;
 import com.sparta.delivery.product.domain.exception.DuplicateProductNameException;
@@ -146,7 +147,7 @@ class ProductServiceTest {
                     "Americano",
                     4500,
                     "고소한 맛을 강조해줘"
-            )).willReturn("AI generated description");
+            )).willReturn(CompletableFuture.completedFuture("AI generated description"));
             given(productRepository.save(any(Product.class))).willAnswer(invocation -> {
                 Product product = invocation.getArgument(0);
                 ReflectionTestUtils.setField(product, "productId", UUID.randomUUID());
@@ -190,7 +191,7 @@ class ProductServiceTest {
                     "Americano",
                     4500,
                     "고소한 맛을 강조해줘"
-            )).willThrow(new ExternalLlmCallFailedException());
+            )).willReturn(CompletableFuture.failedFuture(new ExternalLlmCallFailedException()));
 
             // when & then
             assertThatThrownBy(() -> productService.create(ownerId, UserRole.OWNER, storeId, request))


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #61

## ✨ 기능 요약

| 항목 | 내용 |
|------|------|
| 🆕 기능명 | AI·Product 도메인 성능 최적화 리팩터 |
| 🔍 목적 | AI 호출 비용 절감, 동시성 안정성 확보, 코드 품질 개선 |
| 🛠️ 변경사항 | 활성 LLM Redis 캐싱, AI 설명 생성 비동기 처리, 비관적 락, 엔티티 인덱스 추가 |

## 📝 상세 내역

| 번호 | 내용 |
|------|------|
| 1️⃣ | **비관적 락** — `activate()` 호출 시 `findByIsActiveTrueForUpdate()`로 락을 걸어 동시에 두 LLM이 활성화되는 race condition 방지 |
| 2️⃣ | **엔티티 인덱스 추가** — `p_product(store_id)`, `p_product(store_id, product_name)`, `p_llms(is_active)`, `p_llm_calls(llm_id)`, `p_llm_calls(created_at)` |
| 3️⃣ | **숨김 상품 권한 처리 메서드화** — `hiddenAccessibility()` 추출로 `getProduct()` / `getProducts()` 중복 제거 |
| 4️⃣ | **활성 LLM Redis 캐싱** — `getActiveLlm()` 에 `@Cacheable` 적용, TTL 24h. `ActiveLlmInfo` VO 도입으로 `LocalDateTime` 직렬화 문제 해결. `changeLlmName()` 은 활성 LLM일 때만 수동 evict |
| 5️⃣ | **AI 설명 생성 비동기 처리** — `AsyncConfig` 신규 추가 (`llmAsyncExecutor`, core=10, max=30), `AiDescriptionService.generateDescription()` `@Async` 적용, `CompletableFuture<String>` 반환 |

---

## ✅ 테스트 체크리스트

- [x] LLM 활성화 순차 호출 → isActive=true 모델 1개만 유지 확인
- [x] 상품 생성 (AI 설명 생성 포함) 정상 동작 확인
- [x] 활성 LLM 이름 변경 후 캐시 evict → 다음 AI 호출 시 새 이름으로 호출 확인
- [x] hidden/soldOut 필드 누락 요청 → 400 응답 확인
- [x] 단위 테스트 전체 통과

---

## 🙋‍♀️ 리뷰어 참고사항

**메인 리뷰 지점**
- LlmService.java
    - `@Cacheable`, `changeLlmName()` 수동 evict 로직
- LlmCacheConfig.java
    - Redis 캐시 설정
- ActiveLlmInfo.java (신규)
    - 캐시 전용 VO, domain-level 의존관계
- AiDescriptionService.java
    - `@Async` 적용, `CompletableFuture` 반환 구조
- AsyncConfig.java
    - `llmAsyncExecutor` 스레드 풀 설정값

**캐싱 설계**
- 캐시 키: `activeLlm::current` (TTL 24h)
- `activate()` → 무조건 evict (`@CacheEvict`)
- `changeLlmName()` → `llm.isActive()` 체크 후 수동 evict (비활성 LLM 변경 시 불필요한 캐시 미스 방지)
- `delete()` → 활성 LLM 삭제 자체를 막으므로 evict 불필요

**OpenAI 모델 지원 범위**
- `max_completion_tokens=40` 제한과 `reasoning_effort` 기본값 충돌 문제로 일부 모델 등록 불가
- 동작 확인: `gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-4.1`, `gpt-4.1-mini`
- 동작 불가 (502): `gpt-5.5`, `gpt-5-mini`, `gpt-5-nano`
- 참고: https://developers.openai.com/api/docs/guides/reasoning

**비동기 처리 주의사항**
- `ProductService`에서 `.get()`으로 블로킹 수신 → Tomcat 스레드 분리 + 예외 격리 목적
- 진짜 fire-and-forget 비동기 전환은 향후 고도화 이슈로 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 기반 상품 설명 생성이 비동기 처리로 개선되어 응답성 향상

* **성능 개선**
  * 활성 LLM 정보 캐싱으로 조회 성능 향상
  * 데이터베이스 인덱스 추가로 쿼리 응답 속도 개선
  * 동시성 제어 강화로 안정성 증대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->