### PR TITLE
feat: Google Gemini LLM 클라이언트 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     // ===== AI API 호출용 (Gemini) =====
     implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient
     implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.1.4'
+    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai:1.1.4'
     // ===== 모니터링/헬스체크 (배포 시 유용) =====
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // ===== 설정 메타데이터 =====

--- a/src/main/java/com/sparta/delivery/ai/infrastructure/external/llm/gemini/GeminiClient.java
+++ b/src/main/java/com/sparta/delivery/ai/infrastructure/external/llm/gemini/GeminiClient.java
@@ -1,4 +1,4 @@
-package com.sparta.delivery.ai.infrastructure.external.llm.openai;
+package com.sparta.delivery.ai.infrastructure.external.llm.gemini;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,25 +11,25 @@ import com.sparta.delivery.ai.infrastructure.external.llm.LlmGenerateResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatResponse;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class OpenAiClient implements LlmClient {
+public class GeminiClient implements LlmClient {
 
     private final ChatClient chatClient;
     private final ObjectMapper objectMapper;
 
-    public OpenAiClient(OpenAiChatModel chatModel, ObjectMapper objectMapper) {
+    public GeminiClient(GoogleGenAiChatModel chatModel, ObjectMapper objectMapper) {
         this.chatClient = ChatClient.create(chatModel);
         this.objectMapper = objectMapper;
     }
 
     @Override
     public boolean supports(LlmProvider provider) {
-        return provider == LlmProvider.OPENAI;
+        return provider == LlmProvider.GOOGLE;
     }
 
     @Override
@@ -37,9 +37,9 @@ public class OpenAiClient implements LlmClient {
         try {
             ChatResponse chatResponse = chatClient
                     .prompt()
-                    .options(OpenAiChatOptions.builder()
+                    .options(GoogleGenAiChatOptions.builder()
                             .model(llm.llmName())
-                            .maxCompletionTokens(40)
+//                            .maxOutputTokens(40)
                             .build())
                     .system("""
                         당신은 음식 배달 플랫폼의 상품 설명 작성 전문가입니다.
@@ -56,7 +56,7 @@ public class OpenAiClient implements LlmClient {
             try {
                 rawResponse = objectMapper.writeValueAsString(chatResponse);
             } catch (JsonProcessingException e) {
-                log.warn("[OpenAI Client] ChatResponse Serialization 실패: model={}, error={}",
+                log.warn("[Gemini Client] ChatResponse Serialization 실패: model={}, error={}",
                         llm.llmName(), e.getMessage());
                 rawResponse = null;
             }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,10 +20,12 @@ spring:
       chat:
         options:
           temperature: 1.0
-
-    gemini:
-      api-key: ${GEMINI_API_KEY:dummy-key}
-      max-input-length: 500
+    google:
+      genai:
+        api-key: ${GEMINI_API_KEY:dummy-key}
+        chat:
+          options:
+            temperature: 1.0
 
 springdoc:
   swagger-ui:

--- a/src/test/java/com/sparta/delivery/ai/application/LlmOrchestratorTest.java
+++ b/src/test/java/com/sparta/delivery/ai/application/LlmOrchestratorTest.java
@@ -104,6 +104,43 @@ class LlmOrchestratorTest {
         }
 
         @Test
+        @DisplayName("generates text with google gemini active llm")
+        void generate_success_withGeminiLlm() throws Exception {
+            // given
+            UUID llmId = UUID.randomUUID();
+            Long actorId = 1L;
+            String prompt = "prompt";
+            LlmInputSnapshot llmInputSnapshot = new LlmInputSnapshot(prompt, "Americano", 4500, "고소한 맛을 강조해줘");
+            String inputSnapshot = "{\"prompt\":\"prompt\"}";
+            ActiveLlmInfo activeLlm = new ActiveLlmInfo(llmId, "gemini-2.0-flash", LlmProvider.GOOGLE);
+            LlmGenerateResponse llmGenerateResponse = new LlmGenerateResponse(
+                    "generated text",
+                    "{\"result\":\"ok\"}",
+                    "STOP"
+            );
+
+            given(llmService.getActiveLlm()).willReturn(activeLlm);
+            given(objectMapper.writeValueAsString(any(LlmInputSnapshot.class))).willReturn(inputSnapshot);
+            given(llmClientRegistry.getClient(LlmProvider.GOOGLE)).willReturn(llmClient);
+            given(llmClient.generate(eq(activeLlm), any())).willReturn(llmGenerateResponse);
+            given(llmCallRepository.save(any(LlmCall.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            LlmGenerateResponse response = llmOrchestrator.generate(actorId, llmInputSnapshot);
+
+            // then
+            assertThat(response).isEqualTo(llmGenerateResponse);
+
+            ArgumentCaptor<LlmCall> llmCallCaptor = ArgumentCaptor.forClass(LlmCall.class);
+            then(llmCallRepository).should().save(llmCallCaptor.capture());
+
+            LlmCall savedCall = llmCallCaptor.getValue();
+            assertThat(savedCall.getLlmId()).isEqualTo(activeLlm.llmId());
+            assertThat(savedCall.getFinishReason()).isEqualTo("STOP");
+            assertThat(savedCall.getGeneratedText()).isEqualTo("generated text");
+        }
+
+        @Test
         @DisplayName("throws when active llm does not exist")
         void generate_fail_whenActiveLlmNotFound() {
             // given

--- a/src/test/java/com/sparta/delivery/ai/infrastructure/external/llm/LlmClientRegistryTest.java
+++ b/src/test/java/com/sparta/delivery/ai/infrastructure/external/llm/LlmClientRegistryTest.java
@@ -44,6 +44,21 @@ class LlmClientRegistryTest {
         }
 
         @Test
+        @DisplayName("returns google client that supports GOOGLE provider")
+        void getClient_success_google() {
+            // given
+            given(openAiClient.supports(LlmProvider.GOOGLE)).willReturn(false);
+            given(googleClient.supports(LlmProvider.GOOGLE)).willReturn(true);
+            LlmClientRegistry llmClientRegistry = new LlmClientRegistry(List.of(openAiClient, googleClient));
+
+            // when
+            LlmClient client = llmClientRegistry.getClient(LlmProvider.GOOGLE);
+
+            // then
+            assertThat(client).isEqualTo(googleClient);
+        }
+
+        @Test
         @DisplayName("throws when no client supports provider")
         void getClient_fail_whenClientNotFound() {
             // given


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #90

## ✨ 기능 요약

| 항목 | 내용 |
|------|------|
| 🆕 기능명 | Google Gemini LLM 클라이언트 연동 |
| 🔍 목적 | OpenAI 단일 의존에서 멀티 LLM Provider 구조로 확장 |
| 🛠️ 변경사항 | GeminiClient 신규 추가, 양쪽 클라이언트 ChatModel 직접 주입 방식으로 통일 |

## 📝 상세 내역

| 번호 | 내용 |
|------|------|
| 1️⃣ | **GeminiClient 신규 구현** — `GoogleGenAiChatModel` 직접 주입, `GoogleGenAiChatOptions` 적용, `LlmProvider.GOOGLE` 라우팅 |
| 2️⃣ | **OpenAiClient 구조 통일** — `ChatClient.Builder` 빈 충돌 문제로 `OpenAiChatModel` 직접 주입 + `ChatClient.create()` 방식으로 전환 |
| 3️⃣ | **의존성 및 설정 추가** — `spring-ai-starter-model-google-genai:1.1.4` 추가, `application.yml` Gemini Spring AI 설정 추가 |
| 4️⃣ | **테스트 반영** — `LlmClientRegistryTest` GOOGLE provider 케이스, `LlmOrchestratorTest` Gemini 활성 LLM 케이스 추가 |

---

## ✅ 테스트 체크리스트

- [x] Gemini 모델 등록(`2.5-flash`, `2.5-flash-lite`) 후 상품 생성 AI 설명 정상 생성 확인
- [x] OpenAI 모델 기존 동작 유지 확인
- [x] 단위 테스트 전체 통과

---

## 🙋‍♀️ 리뷰어 참고사항

**ChatClient.Builder 빈 충돌 해결**
- OpenAI + Gemini 두 스타터를 동시에 사용하면 `ChatClient.Builder` 빈 충돌
- `@Qualifier`로 해결을 시도했으나 Spring AI가 등록하는 빈 이름이 달라 런타임 에러 발생
- `OpenAiChatModel`, `GoogleGenAiChatModel`을 타입으로 직접 주입받아 `ChatClient.create(chatModel)`로 생성하는 방식으로 전환해 해결

**Gemini maxOutputTokens 미적용**
- 한글 1음절이 OpenAI 대비 더 많은 토큰을 소비해 `maxOutputTokens(40)` 설정 시 한 글자 수준만 출력됨
- 시스템 프롬프트 기반 50자 제한으로 대체

**메인 리뷰 파일**
- `GeminiClient.java`
- `OpenAiClient.java`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Google Gemini AI 모델 통합 지원 추가

* **개선사항**
  * AI 클라이언트 성능 최적화

* **테스트**
  * Google 제공자 지원에 대한 테스트 케이스 추가

* **기타**
  * Spring AI Google GenAI 의존성 추가
  * AI 설정 구조 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->